### PR TITLE
Fix repo build - sign and update artifacts for installation

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -22,8 +22,11 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
 RUN mkdir eclipse-ltp \
     && cd eclipse-ltp \
     && git clone https://github.com/OpenLiberty/liberty-tools-eclipse.git
-
+ 
 WORKDIR /eclipse-ltp/liberty-tools-eclipse
 
 # build the repo and generate release artifacts.
 RUN mvn clean install -DskipTests
+
+# command to run to make container available
+CMD ["sleep", "9000"]

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,7 +3,7 @@
 set -Eexo pipefail
 
 DOCKER_WORK_DIR="eclipse-ltp"
-DOCKER_REL_REPO_DIR_LOC="/liberty-tools-eclipse/releng/io.openliberty.tools.update/io.openliberty.tools.update/target/repository"
+DOCKER_REL_REPO_DIR_LOC="/liberty-tools-eclipse/releng/io.openliberty.tools.update/target/repository"
 DOCKER_REL_ZIP_LOC="/liberty-tools-eclipse/releng/io.openliberty.tools.update/target/io.openliberty.tools.update.eclipse-repository-0.1.0.zip"
 DOCKER_DOMAIN="release"
 DOCKER_IMG_NAME="liberty-tools-eclipse:0.1.0"

--- a/ci/build3.sh
+++ b/ci/build3.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -Eexo pipefail
+
+DOCKER_WORK_DIR="eclipse-ltp"
+DOCKER_REL_REPO_DIR_LOC="/liberty-tools-eclipse/releng/io.openliberty.tools.update/target/repository"
+DOCKER_REL_ZIP_LOC="/liberty-tools-eclipse/releng/io.openliberty.tools.update/target/io.openliberty.tools.update.eclipse-repository-0.1.0.zip"
+DOCKER_DOMAIN="release"
+DOCKER_IMG_NAME="liberty-tools-eclipse:0.1.0"
+DOCKER_IMG="${DOCKER_DOMAIN}/${DOCKER_IMG_NAME}"
+
+RELEASE_OUTPUT_DIR="release-artifacts"
+
+# Create the output directory to contain the release repository.
+if [ ! -d  "$RELEASE_OUTPUT_DIR" ]; then
+  mkdir "$RELEASE_OUTPUT_DIR"
+fi
+
+# Build the image.
+#docker build --progress plain -t "$DOCKER_IMG" .
+
+# Create a container.
+container_id=$(docker create "$DOCKER_IMG")
+
+# Copy the newly signed release artifacts for re-packaging.
+docker cp "$RELEASE_OUTPUT_DIR/repository/features/io.openliberty.tools.eclipse.feature_0.1.0.jar" "${container_id}:/${DOCKER_WORK_DIR}/${DOCKER_REL_REPO_DIR_LOC}/features"
+docker cp "$RELEASE_OUTPUT_DIR/repository/plugins/io.openliberty.tools.eclipse.lsp4e_0.1.0.jar" "${container_id}:/${DOCKER_WORK_DIR}/${DOCKER_REL_REPO_DIR_LOC}/plugins"
+docker cp "$RELEASE_OUTPUT_DIR/repository/plugins/io.openliberty.tools.eclipse.ui_0.1.0.jar" "${container_id}:/${DOCKER_WORK_DIR}/${DOCKER_REL_REPO_DIR_LOC}/plugins"
+
+# start the container
+docker start $container_id
+
+#run the re-package mvn command
+docker exec $container_id /bin/bash -c "mvn -pl releng tycho-p2-repository:fix-artifacts-metadata -Drepository.home=/eclipse-ltp/liberty-tools-eclipse/releng/io.openliberty.tools.update"
+
+# Copy the re-packaged release artifacts.xml locally
+docker cp "${container_id}:/${DOCKER_WORK_DIR}/${DOCKER_REL_REPO_DIR_LOC}/artifacts.xml.xz" "$RELEASE_OUTPUT_DIR/repository"
+
+# stop the container - this will remove it as well
+docker stop $container_id
+

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
 		<!--maven.deploy.skip>true</maven.deploy.skip-->
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <repository.home>${project.basedir}</repository.home>
+            
 	</properties>
 	
 	<repositories>
@@ -213,7 +215,7 @@
                 <artifactId>tycho-p2-repository-plugin</artifactId>
                 <version>${tycho.version}</version>
                 <configuration>
-                    <repositoryLocation>io.openliberty.tools.update/target/repository</repositoryLocation>
+                    <repositoryLocation>${repository.home}/target/repository</repositoryLocation>
                 </configuration>
             </plugin>
 			<plugin>


### PR DESCRIPTION
ci build occurs in 3 phases for now:
* phase 1: run build.sh to build image and copy out the install repo artifacts.
* phase 2: using the artifacts, sign the 3 jar files
1. features/io.openliberty.tools.eclipse.feature_0.1.0.jar
2. plugins/io.openliberty.tools.eclipse.lsp4e_0.1.0.jar
3. plugins/io.openliberty.tools.eclipse.ui_0.1.0.jar
overlay the original versions of those jars with the newly signed jars
* phase 3: run build3.sh - will copy the 3 signed jars into the container, run the mvn -pl command to update the artifacts.xml.xz file with the signing info and then copies that xml file out of the container and into the local repository file structure