### PR TITLE
Organize projects on Dashboard and test reporting updates.

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
@@ -10,14 +10,12 @@
 * Contributors:
 *     IBM Corporation - initial implementation
 *******************************************************************************/
-package io.openliberty.tools.eclipse.utils;
+package io.openliberty.tools.eclipse;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -26,37 +24,29 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 
-import io.openliberty.tools.eclipse.Project;
 import io.openliberty.tools.eclipse.logging.Trace;
 
 /**
- * Resource workspace utilities.
+ * Represents the Liberty tools dashboard.
  */
-public class Workspace {
+public class Dashboard {
 
     /**
-     * Retrieves the IProject object associated with the input name.
-     *
-     * @param name The name of the project.
-     *
-     * @return The IProject object associated with the input name.
+     * Maven projects displayed on the dashboard.
      */
-    public static IProject getOpenProjectByName(String name) {
+    public ConcurrentHashMap<String, Project> mavenProjects;
 
-        try {
-            IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+    /**
+     * Gradle projects displayed on the dashboard.
+     */
+    public ConcurrentHashMap<String, Project> gradleProjects;
 
-            IProject[] projects = workspaceRoot.getProjects();
-            for (int i = 0; i < projects.length; i++) {
-                IProject project = projects[i];
-                if (project.isOpen() && (project.getName().equals(name))) {
-                    return project;
-                }
-            }
-        } catch (Exception ce) {
-
-        }
-        return null;
+    /**
+     * Constructor.
+     */
+    public Dashboard() {
+        mavenProjects = new ConcurrentHashMap<String, Project>();
+        gradleProjects = new ConcurrentHashMap<String, Project>();
     }
 
     /**
@@ -64,17 +54,17 @@ public class Workspace {
      *
      * @return A map projects from the workspace that are each themselves NOT nested/contained in another workspace project
      */
-    public static Map<String, Project> getTopLevelWorkspaceProjects() {
+    private Map<String, Project> getTopLevelWorkspaceProjects() {
         IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
         IProject[] iProjects = workspaceRoot.getProjects();
-        HashMap<String, Project> projects = new HashMap<String, Project>();
-        
+        ConcurrentHashMap<String, Project> projects = new ConcurrentHashMap<String, Project>();
+
         for (IProject iProject : iProjects) {
             projects.put(iProject.getLocation().toOSString(), new Project(iProject));
         }
 
         try {
-        	for (IProject iProject : iProjects) {
+            for (IProject iProject : iProjects) {
                 boolean multimodSet = false;
 
                 for (IResource res : iProject.members()) {
@@ -112,31 +102,67 @@ public class Workspace {
     }
 
     /**
-     * Returns the list of projects that are configured to run on Liberty.
-     *
-     * @return The list of projects that are configured to run on Liberty.
+     * Returns the project associated with the input name or null if none is found.
+     * 
+     * @param name The name of the project.
+     * 
+     * @return The project associated with the input name or null if none is found.
+     */
+    public Project getProject(String name) {
+        Project p = mavenProjects.get(name);
+        if (p == null) {
+            p = gradleProjects.get(name);
+        }
+        return p;
+    }
+
+    /**
+     * Retrieves and caches the set of installed projects that are to appear on the dashboard.
      *
      * @throws Exception
      */
-    public static List<String> getDashboardProjects(boolean refresh) throws Exception {
+    public void retrieveSupportedProjects() throws Exception {
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UTILS, refresh);
+            Trace.getTracer().traceEntry(Trace.TRACE_UTILS);
         }
-        
-        ArrayList<String> finalList = new ArrayList<String>();
 
         Map<String, Project> projectList = getTopLevelWorkspaceProjects();
-
+        ConcurrentHashMap<String, Project> finalMavenContent = new ConcurrentHashMap<String, Project>();
+        ConcurrentHashMap<String, Project> finalGradleContent = new ConcurrentHashMap<String, Project>();
         for (Project p : projectList.values()) {
             if (p.isSupported()) {
-                finalList.add(p.getProject().getName());
-            } 
+                if (p.isMaven()) {
+                    finalMavenContent.put(p.getIProject().getName(), p);
+                } else if (p.isGradle()) {
+                    finalGradleContent.put(p.getIProject().getName(), p);
+                }
+            }
         }
+
+        mavenProjects = finalMavenContent;
+        gradleProjects = finalGradleContent;
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceExit(Trace.TRACE_UTILS, finalList);
+            Trace.getTracer().traceExit(Trace.TRACE_UTILS, new Object[] { mavenProjects, gradleProjects });
         }
-
-        return finalList;
     }
+
+    /**
+     * Returns a list of names associated with the Maven projects on the dashboard.
+     * 
+     * @return A list of names associated with the Maven projects on the dashboard.
+     */
+    public List<String> getMavenProjectNames() {
+        return new ArrayList<String>(mavenProjects.keySet());
+    }
+
+    /**
+     * Returns a list of names associated with the Gradle projects on the dashboard.
+     * 
+     * @return A list of names associated with the Gradle projects on the dashboard.
+     */
+    public List<String> getGradleProjectNames() {
+        return new ArrayList<String>(gradleProjects.keySet());
+    }
+
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
@@ -131,10 +131,16 @@ public class Dashboard {
         ConcurrentHashMap<String, Project> finalGradleContent = new ConcurrentHashMap<String, Project>();
         for (Project p : projectList.values()) {
             if (p.isSupported()) {
-                if (p.isMaven()) {
-                    finalMavenContent.put(p.getIProject().getName(), p);
-                } else if (p.isGradle()) {
-                    finalGradleContent.put(p.getIProject().getName(), p);
+                String projectName = p.getIProject().getName();
+                if (p.getBuildType() == Project.BuildType.MAVEN) {
+                    finalMavenContent.put(projectName, p);
+                } else if (p.getBuildType() == Project.BuildType.GRADLE) {
+                    finalGradleContent.put(projectName, p);
+                } else {
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UTILS,
+                                "Project " + projectName + " could not be identified as being a Maven or Gradle project.");
+                    }
                 }
             }
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -159,9 +159,9 @@ public class DevModeOperations {
 
             // Prepare the Liberty plugin dev mode command.
             String cmd = "";
-            if (project.isMaven()) {
+            if (project.getBuildType() == Project.BuildType.MAVEN) {
                 cmd = getMavenCommand(projectPath, "io.openliberty.tools:liberty-maven-plugin:dev -f " + projectPath);
-            } else if (project.isGradle()) {
+            } else if (project.getBuildType() == Project.BuildType.GRADLE) {
                 cmd = getGradleCommand(projectPath, "libertyDev -p=" + projectPath);
             } else {
                 throw new Exception("Project" + projectName + "is not a Gradle or Maven project.");
@@ -260,9 +260,9 @@ public class DevModeOperations {
 
             // Prepare the Liberty plugin dev mode command.
             String cmd = "";
-            if (project.isMaven()) {
+            if (project.getBuildType() == Project.BuildType.MAVEN) {
                 cmd = getMavenCommand(projectPath, "io.openliberty.tools:liberty-maven-plugin:dev " + userParms + " -f " + projectPath);
-            } else if (project.isGradle()) {
+            } else if (project.getBuildType() == Project.BuildType.GRADLE) {
                 cmd = getGradleCommand(projectPath, "libertyDev " + userParms + " -p=" + projectPath);
             } else {
                 throw new Exception("Project" + projectName + "is not a Gradle or Maven project.");
@@ -353,9 +353,9 @@ public class DevModeOperations {
 
             // Prepare the Liberty plugin container dev mode command.
             String cmd = "";
-            if (project.isMaven()) {
+            if (project.getBuildType() == Project.BuildType.MAVEN) {
                 cmd = getMavenCommand(projectPath, "io.openliberty.tools:liberty-maven-plugin:devc -f " + projectPath);
-            } else if (project.isGradle()) {
+            } else if (project.getBuildType() == Project.BuildType.GRADLE) {
                 cmd = getGradleCommand(projectPath, "libertyDevc -p=" + projectPath);
             } else {
                 throw new Exception("Project" + projectName + "is not a Gradle or Maven project.");
@@ -1027,10 +1027,10 @@ public class DevModeOperations {
      */
     public List<String> getDashboardProjects() throws Exception {
         dashboard.retrieveSupportedProjects();
-        List<String> gradleProjs = dashboard.getGradleProjectNames();
-        Collections.sort(gradleProjs);
         List<String> mvnProjs = dashboard.getMavenProjectNames();
         Collections.sort(mvnProjs);
+        List<String> gradleProjs = dashboard.getGradleProjectNames();
+        Collections.sort(gradleProjs);
 
         ArrayList<String> sortedProjects = new ArrayList<String>();
         sortedProjects.addAll(mvnProjs);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Project.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Project.java
@@ -26,14 +26,14 @@ import org.eclipse.core.runtime.Path;
 import io.openliberty.tools.eclipse.logging.Trace;
 
 /**
- * Project.
+ * Represents a project in the Liberty tools dashboard.
  */
 public class Project {
 
     /**
      * The Eclipse project reference.
      */
-    IProject project;
+    IProject iProject;
 
     /**
      * Multi-module project indicator. It is based on the existence of one or more projects inside a project.
@@ -46,7 +46,7 @@ public class Project {
      * @param project The Eclipse project reference.
      */
     public Project(IProject project) {
-        this.project = project;
+        this.iProject = project;
     }
 
     /**
@@ -70,8 +70,8 @@ public class Project {
      * 
      * @return The associated Eclipse project reference.
      */
-    public IProject getProject() {
-        return project;
+    public IProject getIProject() {
+        return iProject;
     }
 
     /**
@@ -82,19 +82,8 @@ public class Project {
      * @return The absolute path of this project or null if the path could not be obtained.
      */
     public String getPath() {
-        return getPath(project);
-    }
-
-    /**
-     * Retrieves the absolute path of the input project.
-     *
-     * @param selectedProject The project object
-     *
-     * @return The absolute path of the input project or null if the path could not be obtained.
-     */
-    public static String getPath(IProject project) {
-        if (project != null) {
-            IPath path = project.getLocation();
+        if (iProject != null) {
+            IPath path = iProject.getLocation();
             if (path != null) {
                 return path.toOSString();
             }
@@ -109,29 +98,18 @@ public class Project {
      * @return True if this project is a Maven built project. False, otherwise.
      */
     public boolean isMaven() {
-        return isMaven(project);
-    }
-
-    /**
-     * Returns true if the input project is a Maven built project. False otherwise.
-     *
-     * @param project The project to check.
-     *
-     * @return True if the input project is a Maven built project. False, otherwise.
-     */
-    public static boolean isMaven(IProject project) {
         boolean isMaven = false;
 
         try {
-            isMaven = project.getDescription().hasNature("org.eclipse.m2e.core.maven2Nature");
+            isMaven = iProject.getDescription().hasNature("org.eclipse.m2e.core.maven2Nature");
 
             if (!isMaven) {
-                isMaven = project.getFile("pom.xml").exists();
+                isMaven = iProject.getFile("pom.xml").exists();
             }
         } catch (Exception e) {
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UTILS,
-                        "An error occurred while checking if project " + project + "is a Maven project", e);
+                        "An error occurred while checking if project " + iProject.getName() + "is a Maven project", e);
             }
         }
 
@@ -144,28 +122,17 @@ public class Project {
      * @return True if this project is a Gradle built project. False otherwise.
      */
     public boolean isGradle() {
-        return isGradle(project);
-    }
-
-    /**
-     * Returns true if the input project is a Gradle built project. False, otherwise.
-     *
-     * @param project The project to check.
-     *
-     * @return True if the input project is a Gradle built project. False otherwise.
-     */
-    public static boolean isGradle(IProject project) {
         boolean isGradle = false;
 
         try {
-            isGradle = project.getDescription().hasNature("org.eclipse.buildship.core.gradleprojectnature");
+            isGradle = iProject.getDescription().hasNature("org.eclipse.buildship.core.gradleprojectnature");
             if (!isGradle) {
-                isGradle = project.getFile("build.gradle").exists();
+                isGradle = iProject.getFile("build.gradle").exists();
             }
         } catch (Exception e) {
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UTILS,
-                        "An error occurred while checking if project " + project + "is a Gradle project", e);
+                        "An error occurred while checking if project " + iProject.getName() + "is a Gradle project", e);
             }
         }
 
@@ -174,10 +141,10 @@ public class Project {
 
     /**
      * Returns true if the input project is configured to run in Liberty and it uses a supported build mechanism. False,
-     * otherwise. If it is determined that the project is a supported type, the outcome is persisted by associating the
-     * project with a Liberty type/nature.
+     * otherwise. If it is determined that the project is a supported type, the outcome is persisted by associating the project
+     * with a Liberty type/nature.
      *
-     * @param project The project to check.
+     * @param iProject The project to check.
      *
      * @return True if the input project is configured to run in Liberty's dev mode. False, otherwise.
      *
@@ -191,7 +158,7 @@ public class Project {
         // are improved to handle customized projects, Liberty natures should be cleaned up automatically.
 
         // Check if the input project is already marked as being a supported liberty project.
-        if (project.getDescription().hasNature(LibertyNature.NATURE_ID)) {
+        if (iProject.getDescription().hasNature(LibertyNature.NATURE_ID)) {
             return true;
         }
 
@@ -201,32 +168,31 @@ public class Project {
         // Check if the project has a server.xml config file in a specific location.
         // Gradle built multi-module projects are excluded. Dev mode currently does not support
         // that type of project.
-
         if (isMultiModule() && !isGradle()) {
-          for (IResource resource : project.members()) {
-            if (resource.getType() == IResource.FOLDER) {
-                IFolder folder = ((IFolder) resource);
-                Path path = new Path("src/main/liberty/config/server.xml");
-                if (path != null) {
-                    IFile serverxml = folder.getFile(path);
-                    if (serverxml.exists()) {
-                        supported = true;
-                        break;
+            for (IResource resource : iProject.members()) {
+                if (resource.getType() == IResource.FOLDER) {
+                    IFolder folder = ((IFolder) resource);
+                    Path path = new Path("src/main/liberty/config/server.xml");
+                    if (path != null) {
+                        IFile serverxml = folder.getFile(path);
+                        if (serverxml.exists()) {
+                            supported = true;
+                            break;
+                        }
                     }
                 }
             }
-          }
         } else {
-          IFile serverxml = project.getFile(new Path("src/main/liberty/config/server.xml"));
-          if (serverxml.exists()) {
-            supported = true;
-          }
-        }        
+            IFile serverxml = iProject.getFile(new Path("src/main/liberty/config/server.xml"));
+            if (serverxml.exists()) {
+                supported = true;
+            }
+        }
 
         // If it is determined that the input project can run on Liberty, persist the outcome (if not
         // done so already) by adding a Liberty type/nature marker to the project's metadata.
         if (supported) {
-            addLibertyNature(project);
+            addLibertyNature(iProject);
         }
 
         return supported;
@@ -287,10 +253,10 @@ public class Project {
             Trace.getTracer().traceExit(Trace.TRACE_UTILS, new Object[] { project, newNatures });
         }
     }
-    
+
     @Override
     public String toString() {
-        return "IProject = " + project.toString();
+        return "IProject: " + iProject.toString() + ". Muti-module: " + multiModule;
     }
-    
+
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/DashboardEntryLabelProvider.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/DashboardEntryLabelProvider.java
@@ -1,0 +1,96 @@
+package io.openliberty.tools.eclipse.ui;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.ITableLabelProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.swt.graphics.Image;
+
+import io.openliberty.tools.eclipse.DevModeOperations;
+import io.openliberty.tools.eclipse.Project;
+import io.openliberty.tools.eclipse.logging.Trace;
+
+/**
+ * Table label provider for entries in the table containing the dashboard content.
+ */
+public class DashboardEntryLabelProvider extends LabelProvider implements ITableLabelProvider {
+
+    /**
+     * Image representing a Maven project.
+     */
+    private Image mavenImg;
+
+    /**
+     * Image representing a Gradle project.
+     */
+    private Image gradleImg;
+
+    /**
+     * DevModeOperations reference.
+     */
+    private DevModeOperations devModeOps;
+
+    /**
+     * Constructor.
+     * 
+     * @param devModeOps DevModeOperations instance.
+     */
+    public DashboardEntryLabelProvider(DevModeOperations devModeOps) {
+        this.devModeOps = devModeOps;
+
+        try {
+            ImageDescriptor mavenImgDesc = ImageDescriptor.createFromURL(new URL("platform:/plugin/org.eclipse.m2e.core.ui/icons/m2.png"));
+            mavenImg = mavenImgDesc.createImage();
+            ImageDescriptor buildshipImageDesc = ImageDescriptor
+                    .createFromURL(new URL("platform:/plugin/org.eclipse.buildship.ui/icons/full/ovr16/gradle_logo@2x.png"));
+            gradleImg = buildshipImageDesc.createImage();
+        } catch (MalformedURLException e) {
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_UI, "Unable to create URL for specified image path." + e);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Image getColumnImage(Object element, int columnIndex) {
+        // Currently, the table under which the dashboard content is organized consists of a single
+        // column and a single row. The content is the string containing the name of the project.
+        String projectName = null;
+        Image img = null;
+        if (element != null && element instanceof String) {
+            projectName = (String) element;
+            Project project = devModeOps.getDashboardProject(projectName);
+
+            if (project != null) {
+                if (project.isGradle()) {
+                    img = gradleImg;
+                } else {
+                    img = mavenImg;
+                }
+            }
+        }
+
+        return img;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getColumnText(Object element, int columnIndex) {
+        // Currently the table consists of a single column and a single row, and the
+        // content is a string containing the name of the project.
+        // Therefore, the columnIndex is not used.
+        String columnText = null;
+        if (element != null && element instanceof String) {
+            columnText = element.toString();
+        }
+
+        return columnText;
+    }
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/DashboardEntryLabelProvider.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/DashboardEntryLabelProvider.java
@@ -67,7 +67,7 @@ public class DashboardEntryLabelProvider extends LabelProvider implements ITable
             Project project = devModeOps.getDashboardProject(projectName);
 
             if (project != null) {
-                if (project.isGradle()) {
+                if (project.getBuildType() == Project.BuildType.GRADLE) {
                     img = gradleImg;
                 } else {
                     img = mavenImg;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/DashboardView.java
@@ -23,8 +23,8 @@ import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.commands.ActionHandler;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ArrayContentProvider;
-import org.eclipse.jface.viewers.LabelProvider;
-import org.eclipse.jface.viewers.ListViewer;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.ui.contexts.IContextService;
@@ -35,7 +35,6 @@ import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.Project;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.utils.Dialog;
-import io.openliberty.tools.eclipse.utils.Workspace;
 
 /**
  * View of Liberty application projects and dev mode actions to be processed on the selected projects.
@@ -74,22 +73,26 @@ public class DashboardView extends ViewPart {
     private Action refreshAction;
 
     /**
-     * Class instances.
+     * Table viewer instance.
      */
-    private ListViewer viewer;
-    public static DevModeOperations devMode = new DevModeOperations();
+    private TableViewer viewer;
+
+    /**
+     * DevModeOperations reference.
+     */
+    public static DevModeOperations devModeOps = new DevModeOperations();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void createPartControl(Composite parent) {
-        viewer = new ListViewer(parent);
-        viewer.setContentProvider(new ArrayContentProvider());
-        viewer.setLabelProvider(new LabelProvider());
+        viewer = new TableViewer(parent, SWT.SINGLE | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
+        viewer.setContentProvider(ArrayContentProvider.getInstance());
+        viewer.setLabelProvider(new DashboardEntryLabelProvider(devModeOps));
 
         try {
-            viewer.setInput(Workspace.getDashboardProjects(false));
+            viewer.setInput(devModeOps.getDashboardProjects());
         } catch (Exception e) {
             String msg = "An error was detected while retrieving Liberty projects.";
             if (Trace.isEnabled()) {
@@ -147,7 +150,9 @@ public class DashboardView extends ViewPart {
      * @param mgr The menu manager.
      */
     private void addActionsToContextMenu(IMenuManager mgr) {
-        IProject project = devMode.getSelectedDashboardProject();
+        IProject iProject = devModeOps.getSelectedDashboardProject();
+        String projectName = iProject.getName();
+        Project project = devModeOps.getDashboardProject(projectName);
 
         if (project != null) {
             mgr.add(startAction);
@@ -156,13 +161,13 @@ public class DashboardView extends ViewPart {
             mgr.add(stopAction);
             mgr.add(runTestAction);
 
-            if (Project.isMaven(project)) {
+            if (project.isMaven()) {
                 mgr.add(viewMavenITestReportsAction);
                 mgr.add(viewMavenUTestReportsAction);
-            } else if (Project.isGradle(project)) {
+            } else if (project.isGradle()) {
                 mgr.add(viewGradleTestReportsAction);
             } else {
-                Dialog.displayErrorMessage("Project" + project.getName() + "is not a Gradle or Maven project.");
+                Dialog.displayErrorMessage("Project" + projectName + "is not a Gradle or Maven project.");
                 return;
             }
         }
@@ -193,7 +198,7 @@ public class DashboardView extends ViewPart {
         startAction = new Action(APP_MENU_ACTION_START) {
             @Override
             public void run() {
-                devMode.start();
+                devModeOps.start();
             }
         };
         startAction.setImageDescriptor(ActionImg);
@@ -206,7 +211,7 @@ public class DashboardView extends ViewPart {
         startWithParmAction = new Action(APP_MENU_ACTION_START_PARMS) {
             @Override
             public void run() {
-                devMode.startWithParms();
+                devModeOps.startWithParms();
             }
         };
         startWithParmAction.setImageDescriptor(ActionImg);
@@ -218,7 +223,7 @@ public class DashboardView extends ViewPart {
         startInContainerAction = new Action(APP_MENU_ACTION_START_IN_CONTAINER) {
             @Override
             public void run() {
-                devMode.startInContainer();
+                devModeOps.startInContainer();
             }
         };
         startInContainerAction.setImageDescriptor(ActionImg);
@@ -230,7 +235,7 @@ public class DashboardView extends ViewPart {
         stopAction = new Action(APP_MENU_ACTION_STOP) {
             @Override
             public void run() {
-                devMode.stop();
+                devModeOps.stop();
             }
         };
         stopAction.setImageDescriptor(ActionImg);
@@ -242,7 +247,7 @@ public class DashboardView extends ViewPart {
         runTestAction = new Action(APP_MENU_ACTION_RUN_TESTS) {
             @Override
             public void run() {
-                devMode.runTests();
+                devModeOps.runTests();
             }
         };
         runTestAction.setImageDescriptor(ActionImg);
@@ -254,7 +259,7 @@ public class DashboardView extends ViewPart {
         viewMavenITestReportsAction = new Action(APP_MENU_ACTION_VIEW_MVN_IT_REPORT) {
             @Override
             public void run() {
-                devMode.openMavenIntegrationTestReport();
+                devModeOps.openMavenIntegrationTestReport();
             }
         };
         viewMavenITestReportsAction.setImageDescriptor(ActionImg);
@@ -266,7 +271,7 @@ public class DashboardView extends ViewPart {
         viewMavenUTestReportsAction = new Action(APP_MENU_ACTION_VIEW_MVN_UT_REPORT) {
             @Override
             public void run() {
-                devMode.openMavenUnitTestReport();
+                devModeOps.openMavenUnitTestReport();
             }
         };
         viewMavenUTestReportsAction.setImageDescriptor(ActionImg);
@@ -278,7 +283,7 @@ public class DashboardView extends ViewPart {
         viewGradleTestReportsAction = new Action(APP_MENU_ACTION_VIEW_GRADLE_TEST_REPORT) {
             @Override
             public void run() {
-                devMode.openGradleTestReport();
+                devModeOps.openGradleTestReport();
             }
         };
         viewGradleTestReportsAction.setImageDescriptor(ActionImg);
@@ -291,7 +296,7 @@ public class DashboardView extends ViewPart {
             @Override
             public void run() {
                 try {
-                    viewer.setInput(Workspace.getDashboardProjects(true));
+                    viewer.setInput(devModeOps.getDashboardProjects());
                 } catch (Exception e) {
                     Dialog.displayErrorMessageWithDetails("An error was detected while retrieving Liberty projects.", e);
                     return;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/DashboardView.java
@@ -161,10 +161,10 @@ public class DashboardView extends ViewPart {
             mgr.add(stopAction);
             mgr.add(runTestAction);
 
-            if (project.isMaven()) {
+            if (project.getBuildType() == Project.BuildType.MAVEN) {
                 mgr.add(viewMavenITestReportsAction);
                 mgr.add(viewMavenUTestReportsAction);
-            } else if (project.isGradle()) {
+            } else if (project.getBuildType() == Project.BuildType.GRADLE) {
                 mgr.add(viewGradleTestReportsAction);
             } else {
                 Dialog.displayErrorMessage("Project" + projectName + "is not a Gradle or Maven project.");

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -16,6 +16,7 @@
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/releases/2022-06/"/>
             <unit id="org.apache.xml.resolver" version="1.2.0.v201005080400"/>
+            <unit id="org.eclipse.buildship.ui" version="3.1.6.v20220511-1359"/>
             <unit id="org.eclipse.jdt.feature.group" version="3.18.1200.v20220607-0700"/>
             <unit id="org.eclipse.lsp4e" version="0.13.12.202206011407"/>
             <unit id="org.eclipse.lsp4e.jdt" version="0.10.2.202205031750"/>

--- a/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTPluginOperations.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTPluginOperations.java
@@ -15,6 +15,7 @@ package io.openliberty.tools.eclipse.test.it.utils;
 import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.allOf;
 import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.widgetOfType;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -26,11 +27,11 @@ import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.utils.SWTUtils;
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotList;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotRootMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarPushButton;
@@ -98,15 +99,20 @@ public class SWTPluginOperations {
      *
      * @return A list of entries on the Open Liberty dashboard.
      */
-    public static String[] getDashboardContent(SWTWorkbenchBot bot, SWTBotView dashboard) {
+    public static List<String> getDashboardContent(SWTWorkbenchBot bot, SWTBotView dashboard) {
         if (dashboard == null) {
             SWTPluginOperations.openDashboardUsingMenu(bot);
         } else {
             dashboard.show();
         }
 
-        SWTBotList dashboardContent = bot.list();
-        return dashboardContent.getItems();
+        SWTBotTable dashboardTable = bot.table();
+        ArrayList<String> contentList = new ArrayList<String>();
+        for (int i = 0; i < dashboardTable.rowCount(); i++) {
+            contentList.add(dashboardTable.getTableItem(i).getText());
+        }
+
+        return contentList;
     }
 
     /**
@@ -126,9 +132,9 @@ public class SWTPluginOperations {
         }
 
         SWTPluginOperations.openDashboardUsingMenu(bot);
-        SWTBotList dashboardContent = bot.list();
-        dashboardContent.select(item);
-        SWTBotRootMenu appCtxMenu = dashboardContent.contextMenu();
+        SWTBotTable dashboardTable = bot.table();
+        dashboardTable.select(item);
+        SWTBotRootMenu appCtxMenu = dashboardTable.contextMenu();
         return appCtxMenu.menuItems();
     }
 
@@ -153,7 +159,6 @@ public class SWTPluginOperations {
         SWTBotRootMenu appCtxMenu = getAppContextMenu(bot, dashboard, item);
         SWTBotMenu startAction = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_START);
         startAction.click();
-
     }
 
     /**
@@ -213,7 +218,7 @@ public class SWTPluginOperations {
         SWTBotMenu itReport = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_VIEW_MVN_IT_REPORT);
         itReport.click();
 
-        bot.waitUntil(SWTTestCondition.isEditorActive(bot, DevModeOperations.BROWSER_MVN_IT_RESULT_NAME), 5000);
+        bot.waitUntil(SWTTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_IT_REPORT_NAME_SUFFIX), 5000);
     }
 
     /**
@@ -228,7 +233,7 @@ public class SWTPluginOperations {
         SWTBotMenu utReport = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT);
         utReport.click();
 
-        bot.waitUntil(SWTTestCondition.isEditorActive(bot, DevModeOperations.BROWSER_MVN_IT_RESULT_NAME), 5000);
+        bot.waitUntil(SWTTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_UT_REPORT_NAME_SUFFIX), 5000);
     }
 
     /**
@@ -243,7 +248,7 @@ public class SWTPluginOperations {
         SWTBotMenu testReport = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_VIEW_GRADLE_TEST_REPORT);
         testReport.click();
 
-        bot.waitUntil(SWTTestCondition.isEditorActive(bot, DevModeOperations.BROWSER_MVN_IT_RESULT_NAME), 5000);
+        bot.waitUntil(SWTTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_GRADLE_TEST_REPORT_NAME_SUFFIX), 5000);
     }
 
     /**
@@ -362,9 +367,9 @@ public class SWTPluginOperations {
             dashboard.setFocus();
         }
 
-        SWTBotList dashboardContent = bot.list();
-        dashboardContent.select(item);
-        return dashboardContent.contextMenu();
+        SWTBotTable dashboardTable = bot.table();
+        dashboardTable.select(item);
+        return dashboardTable.contextMenu();
     }
 
     /**


### PR DESCRIPTION
This a post-early-release PR that does the following:
- Updates the test report tab titles to contain the project name. This aligns with the other Liberty dev tools.
- Limits dashboard project selection to only one project at a time.
- Sorts the projects in the dashboard in two groups (maven/gradle) and alphabetically orders the projects within those two groups. The projects are separated visually using icons provided by m2e and buildship plugins. One TODO from this is to investigate if approval of some sort is needed to use these images (#136 ).

Fixes #49 