### PR TITLE
Run configuration and core rework/updates

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
@@ -6,9 +6,10 @@ Bundle-Vendor: IBM
 Bundle-SymbolicName: io.openliberty.tools.eclipse.ui;singleton:=true
 Bundle-Version: 0.4.0.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.LibertyDevPlugin
-Export-Package: io.openliberty.tools.eclipse,
- io.openliberty.tools.eclipse.ui.dashboard,
- io.openliberty.tools.eclipse.ui.launch
+Export-Package: io.openliberty.tools.eclipse;x-friends:="io.openliberty.tools.eclipse.tests",
+ io.openliberty.tools.eclipse.ui.dashboard;x-friends:="io.openliberty.tools.eclipse.tests",
+ io.openliberty.tools.eclipse.ui.launch;x-friends:="io.openliberty.tools.eclipse.tests",
+ io.openliberty.tools.eclipse.ui.launch.shortcuts;x-friends:="io.openliberty.tools.eclipse.tests"
 Require-Bundle: org.eclipse.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: io.openliberty.tools.eclipse.ui

--- a/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
+++ b/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
@@ -43,8 +43,8 @@
             categoryId="io.openliberty.tools.eclipse.command.category">
       </command>
       <command
-            id="io.openliberty.tools.eclipse.project.startWithParms.command"
-            name="Liberty Start with Parameters"
+            id="io.openliberty.tools.eclipse.project.startConfigDialog.command"
+            name="Liberty Start with Configuration"
             categoryId="io.openliberty.tools.eclipse.command.category">
       </command>
       <command
@@ -80,45 +80,51 @@
 
       <!-- Run Configuration -->
       <command
-            id="io.openliberty.tools.eclipse.launch.config.start.shortcut.run"
-            name="Liberty start"
-            description="Launches Liberty dev mode"
+            id="io.openliberty.tools.eclipse.launch.start.shortcut.run"
+            name="Liberty Start"
+            description="Launches the associated project on Liberty using dev mode"
             categoryId="org.eclipse.debug.ui.category.run">
       </command>
       <command
-            id="io.openliberty.tools.eclipse.launch.config.start.container.shortcut.run"
-            name="Liberty start in container"
-            description="Launches Liberty dev mode in a container"
+            id="io.openliberty.tools.eclipse.launch.start.config.shortcut.run"
+            name="Liberty Start with Configuration Dialog"
+            description="Launches the configuration dialog to run the associated project on Liberty using dev mode"
             categoryId="org.eclipse.debug.ui.category.run">
       </command>
       <command
-            id="io.openliberty.tools.eclipse.launch.config.stop.shortcut.run"
-            name="Liberty stop"
-            description="Launches action to stop Liberty dev mode"
+            id="io.openliberty.tools.eclipse.launch.start.container.shortcut.run"
+            name="Liberty Start in Container"
+            description="Launches the associated project in a container on Liberty using dev mode"
             categoryId="org.eclipse.debug.ui.category.run">
       </command>
       <command
-            id="io.openliberty.tools.eclipse.launch.config.run.tests.shortcut.run"
-            name="Liberty run tests"
-            description="Launches dev mode start"
+            id="io.openliberty.tools.eclipse.launch.stop.shortcut.run"
+            name="Liberty Stop"
+            description="Launches a request to stop the associated project"
             categoryId="org.eclipse.debug.ui.category.run">
       </command>
       <command
-            id="io.openliberty.tools.eclipse.launch.config.maven.itest.report.shortcut.run"
-            name="Liberty viewe integration test reports"
-            description="Launches the action that displays Maven integration test reports"
+            id="io.openliberty.tools.eclipse.launch.run.tests.shortcut.run"
+            name="Liberty Run Tests"
+            description="Launches a request to run the tests provided by the associated project"
             categoryId="org.eclipse.debug.ui.category.run">
       </command>
       <command
-            id="io.openliberty.tools.eclipse.launch.config.maven.utest.report.shortcut.run"
-            name="Liberty Start shortcut"
-            description="Launches the action that displays Maven unit test reports"
+            id="io.openliberty.tools.eclipse.launch.maven.itest.report.shortcut.run"
+            name="Liberty View Integration Test Report"
+            description="Launches a request to display the integration test reports for the associated project"
             categoryId="org.eclipse.debug.ui.category.run">
       </command>
       <command
-            id="io.openliberty.tools.eclipse.launch.config.gradle.test.report.shortcut.run"
-            name="Liberty Start shortcut"
-            description="Launches the action that displays Gradle test reports"
+            id="io.openliberty.tools.eclipse.launch.maven.utest.report.shortcut.run"
+            name="Liberty View Unit Test Report"
+            description="Launches a request to display the unit test reports for the associated project"
+            categoryId="org.eclipse.debug.ui.category.run">
+      </command>
+      <command
+            id="io.openliberty.tools.eclipse.launch.gradle.test.report.shortcut.run"
+            name="Liberty View Gradle Test Report"
+            description="Launches a request to display the test reports for the associated project"
             categoryId="org.eclipse.debug.ui.category.run">
       </command>
    </extension>
@@ -138,7 +144,7 @@
             sequence="M2+M3+L S">
       </key>
       <key
-            commandId="io.openliberty.tools.eclipse.project.startWithParms.command"
+            commandId="io.openliberty.tools.eclipse.project.startConfigDialog.command"
             contextId="io.openliberty.tools.eclipse.context"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+M3+L P">
@@ -182,43 +188,49 @@
 
       <!-- Run Configuration shortcuts -->
       <key
-            commandId="io.openliberty.tools.eclipse.launch.config.start.shortcut.run"
+            commandId="io.openliberty.tools.eclipse.launch.start.shortcut.run"
             contextId="org.eclipse.ui.contexts.window"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+M3+L S">
       </key>
       <key
-            commandId="io.openliberty.tools.eclipse.launch.config.start.container.shortcut.run"
+            commandId="io.openliberty.tools.eclipse.launch.start.config.shortcut.run"
+            contextId="org.eclipse.ui.contexts.window"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M2+M3+L P">
+      </key>
+      <key
+            commandId="io.openliberty.tools.eclipse.launch.start.container.shortcut.run"
             contextId="org.eclipse.ui.contexts.window"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+M3+L C">
       </key>
       <key
-            commandId="io.openliberty.tools.eclipse.launch.config.stop.shortcut.run"
+            commandId="io.openliberty.tools.eclipse.launch.stop.shortcut.run"
             contextId="org.eclipse.ui.contexts.window"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+M3+L Q">
       </key>
       <key
-            commandId="io.openliberty.tools.eclipse.launch.config.run.tests.shortcut.run"
+            commandId="io.openliberty.tools.eclipse.launch.run.tests.shortcut.run"
             contextId="org.eclipse.ui.contexts.window"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+M3+L T">
       </key>
       <key
-            commandId="io.openliberty.tools.eclipse.launch.config.maven.itest.report.shortcut.run"
+            commandId="io.openliberty.tools.eclipse.launch.maven.itest.report.shortcut.run"
             contextId="org.eclipse.ui.contexts.window"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+M3+L I">
       </key>
       <key
-            commandId="io.openliberty.tools.eclipse.launch.config.maven.utest.report.shortcut.run"
+            commandId="io.openliberty.tools.eclipse.launch.maven.utest.report.shortcut.run"
             contextId="org.eclipse.ui.contexts.window"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+M3+L U">
       </key>
       <key
-            commandId="io.openliberty.tools.eclipse.launch.config.gradle.test.report.shortcut.run"
+            commandId="io.openliberty.tools.eclipse.launch.gradle.test.report.shortcut.run"
             contextId="org.eclipse.ui.contexts.window"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+M3+L R">
@@ -252,48 +264,67 @@
   <!-- Launch configuration -->
   <extension point="org.eclipse.debug.core.launchConfigurationTypes">
       <launchConfigurationType
-          name="Liberty Tools"
+          name="Liberty"
           delegate="io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher"
           modes="run, debug"
-          id="io.openliberty.tools.eclipse.launch.config.type">
+          id="io.openliberty.tools.eclipse.launch.type">
       </launchConfigurationType>
   </extension>
   <extension point="org.eclipse.debug.ui.launchConfigurationTypeImages">
       <launchConfigurationTypeImage
-          id="io.openliberty.tools.eclipse.launch.config.type.image"
-          configTypeID="io.openliberty.tools.eclipse.launch.config.type"
+          id="io.openliberty.tools.eclipse.launch.type.image"
+          configTypeID="io.openliberty.tools.eclipse.launch.type"
           icon="icons/openLibertyLogo.png">
       </launchConfigurationTypeImage>
   </extension>
   <extension point="org.eclipse.debug.ui.launchConfigurationTabGroups">
       <launchConfigurationTabGroup
           class="io.openliberty.tools.eclipse.ui.launch.LaunchConfigTabGroup"
-          id="io.openliberty.tools.eclipse.launch.config.tab.group"
-          type="io.openliberty.tools.eclipse.launch.config.type">
+          id="io.openliberty.tools.eclipse.launch.tab.group"
+          type="io.openliberty.tools.eclipse.launch.type">
       </launchConfigurationTabGroup>
   </extension>
   <extension point="org.eclipse.debug.ui.launchShortcuts">
       <shortcut
           class="io.openliberty.tools.eclipse.ui.launch.shortcuts.StartAction"
           icon="icons/openLibertyLogo.png"
-          id="io.openliberty.tools.eclipse.launch.config.start.shortcut"
+          id="io.openliberty.tools.eclipse.launch.start.shortcut"
           label="Liberty Start"
           modes="run, debug"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group1"
           description="Launches the associated project on Liberty using dev mode">
           <contextualLaunch>
               <enablement>
-                  <with
-                      variable="selection">
-                      <count
-                          value="1">
-                      </count>
-	                  <iterate>
+                  <with variable="selection">
+                      <count value="1"/>
+                      <iterate>
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
                           </and>
-	                  </iterate>
+                      </iterate>
+                  </with>
+              </enablement>
+          </contextualLaunch>
+      </shortcut>
+      <shortcut
+          class="io.openliberty.tools.eclipse.ui.launch.shortcuts.StartConfigurationDialogAction"
+          icon="icons/openLibertyLogo.png"
+          id="io.openliberty.tools.eclipse.launch.start.config.shortcut"
+          label="Liberty Start..."
+          modes="run, debug"
+          path="io.openliberty.tools.eclipse.launch.shortcuts.group1"
+          description="Launches the configuration dialog to run the associated project on Liberty using dev mode">
+          <contextualLaunch>
+              <enablement>
+                  <with variable="selection">
+                      <count value="1"/>
+                      <iterate>
+                          <and>
+                              <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                          </and>
+                      </iterate>
                   </with>
               </enablement>
           </contextualLaunch>
@@ -301,24 +332,21 @@
       <shortcut
           class="io.openliberty.tools.eclipse.ui.launch.shortcuts.StartInContainerAction"
           icon="icons/openLibertyLogo.png"
-          id="io.openliberty.tools.eclipse.launch.config.start.container.shortcut"
+          id="io.openliberty.tools.eclipse.launch.start.container.shortcut"
           label="Liberty Start in Container"
           modes="run, debug"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group1"
           description="Launches the associated project in a container on Liberty using dev mode">
           <contextualLaunch>
               <enablement>
-                  <with
-                      variable="selection">
-                      <count
-                          value="1">
-                      </count>
-	                  <iterate>
+                  <with variable="selection">
+                      <count value="1"/>
+                      <iterate>
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
                           </and>
-	                  </iterate>
+                      </iterate>
                   </with>
               </enablement>
           </contextualLaunch>
@@ -326,24 +354,21 @@
       <shortcut
           class="io.openliberty.tools.eclipse.ui.launch.shortcuts.StopAction"
           icon="icons/openLibertyLogo.png"
-          id="io.openliberty.tools.eclipse.launch.config.stop.shortcut"
+          id="io.openliberty.tools.eclipse.launch.stop.shortcut"
           label="Liberty Stop"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group1"
           modes="run, debug"
           description="Launches a request to stop the associated project">
           <contextualLaunch>
               <enablement>
-                  <with
-                      variable="selection">
-                      <count
-                          value="1">
-                      </count>
-	                  <iterate>
+                  <with variable="selection">
+                      <count value="1"/>
+                      <iterate>
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
                           </and>
-	                  </iterate>
+                      </iterate>
                   </with>
               </enablement>
           </contextualLaunch>
@@ -351,24 +376,21 @@
       <shortcut
           class="io.openliberty.tools.eclipse.ui.launch.shortcuts.RunTestsAction"
           icon="icons/openLibertyLogo.png"
-          id="io.openliberty.tools.eclipse.launch.config.run.tests.shortcut"
+          id="io.openliberty.tools.eclipse.launch.run.tests.shortcut"
           label="Liberty Run Tests"
           modes="run, debug"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group2"
           description="Launches a request to run the tests provided by the associated project">
           <contextualLaunch>
               <enablement>
-                  <with
-                      variable="selection">
-                      <count
-                          value="1">
-                      </count>
-	                  <iterate>
+                  <with variable="selection">
+                      <count value="1"/>
+                      <iterate>
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
                           </and>
-	                  </iterate>
+                      </iterate>
                   </with>
               </enablement>
           </contextualLaunch>
@@ -376,25 +398,22 @@
       <shortcut
           class="io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenMavenITestReportAction"
           icon="icons/openLibertyLogo.png"
-          id="io.openliberty.tools.eclipse.launch.config.maven.itest.report.shortcut"
+          id="io.openliberty.tools.eclipse.launch.maven.itest.report.shortcut"
           label="Liberty View Integration Test Report"
           modes="run,debug"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group2"
           description="Launches a request to display the integration test reports for the associated project">
           <contextualLaunch>
               <enablement>
-                  <with
-                      variable="selection">
-                      <count
-                          value="1">
-                      </count>
-	                  <iterate>
+                  <with variable="selection">
+                      <count value="1"/>
+                      <iterate>
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="org.eclipse.m2e.core.maven2Nature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="org.eclipse.m2e.core.maven2Nature"/>
                           </and>
-	                  </iterate>
+                      </iterate>
                   </with>
               </enablement>
           </contextualLaunch>
@@ -402,25 +421,22 @@
       <shortcut
           class="io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenMavenUTestReportAction"
           icon="icons/openLibertyLogo.png"
-          id="io.openliberty.tools.eclipse.launch.config.maven.utest.report.shortcut"
+          id="io.openliberty.tools.eclipse.launch.maven.utest.report.shortcut"
           label="Liberty View Unit Test Report"
           modes="run,debug"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group2"
           description="Launches a request to display the unit test reports for the associated project">
           <contextualLaunch>
               <enablement>
-                  <with
-                      variable="selection">
-                      <count
-                          value="1">
-                      </count>
-	                  <iterate>
+                  <with variable="selection">
+                      <count value="1"/>
+                      <iterate>
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="org.eclipse.m2e.core.maven2Nature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="org.eclipse.m2e.core.maven2Nature"/>
                           </and>
-	                  </iterate>
+                      </iterate>
                   </with>
               </enablement>
           </contextualLaunch>
@@ -428,25 +444,22 @@
       <shortcut
           class="io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenGradleTestReportAction"
           icon="icons/openLibertyLogo.png"
-          id="io.openliberty.tools.eclipse.launch.config.gradle.test.report.shortcut"
+          id="io.openliberty.tools.eclipse.launch.gradle.test.report.shortcut"
           label="Liberty View Test Report"
           modes="run,debug"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group2"
           description="Launches a request to display the test reports for the associated project">
           <contextualLaunch>
               <enablement>
-                  <with
-                      variable="selection">
-                      <count
-                          value="1">
-                      </count>
-	                  <iterate>
+                  <with variable="selection">
+                      <count value="1"/>
+                      <iterate>
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
-		                      <test property="org.eclipse.debug.ui.projectNature" value="org.eclipse.buildship.core.gradleprojectnature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test property="org.eclipse.debug.ui.projectNature" value="org.eclipse.buildship.core.gradleprojectnature"/>
                           </and>
-	                  </iterate>
+                      </iterate>
                   </with>
               </enablement>
           </contextualLaunch>

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
@@ -34,6 +34,14 @@ import org.eclipse.ui.part.ViewPart;
 import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.Project;
 import io.openliberty.tools.eclipse.logging.Trace;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenGradleTestReportAction;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenMavenITestReportAction;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenMavenUTestReportAction;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.RunTestsAction;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.StartAction;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.StartInContainerAction;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.StartConfigurationDialogAction;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.StopAction;
 import io.openliberty.tools.eclipse.utils.Dialog;
 
 /**
@@ -50,7 +58,7 @@ public class DashboardView extends ViewPart {
      * Menu Constants.
      */
     public static final String APP_MENU_ACTION_START = "Start";
-    public static final String APP_MENU_ACTION_START_PARMS = "Start...";
+    public static final String APP_MENU_ACTION_START_CONFIG = "Start...";
     public static final String APP_MENU_ACTION_START_IN_CONTAINER = "Start in container";
     public static final String APP_MENU_ACTION_STOP = "Stop";
     public static final String APP_MENU_ACTION_RUN_TESTS = "Run tests";
@@ -63,7 +71,7 @@ public class DashboardView extends ViewPart {
      * view actions.
      */
     private Action startAction;
-    private Action startWithParmAction;
+    private Action startConfigDialogAction;
     private Action startInContainerAction;
     private Action stopAction;
     private Action runTestAction;
@@ -163,7 +171,7 @@ public class DashboardView extends ViewPart {
 
         if (project != null) {
             mgr.add(startAction);
-            mgr.add(startWithParmAction);
+            mgr.add(startConfigDialogAction);
             mgr.add(startInContainerAction);
             mgr.add(stopAction);
             mgr.add(runTestAction);
@@ -205,9 +213,19 @@ public class DashboardView extends ViewPart {
         startAction = new Action(APP_MENU_ACTION_START) {
             @Override
             public void run() {
-                devModeOps.start();
+                IProject iproject = devModeOps.getSelectedDashboardProject();
+                try {
+                    StartAction.run(iproject, null, "run");
+                } catch (Exception e) {
+                    String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_START + " action.";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                    Dialog.displayErrorMessageWithDetails(msg, e);
+                }
             }
         };
+
         startAction.setImageDescriptor(ActionImg);
         startAction.setActionDefinitionId("io.openliberty.tools.eclipse.project.start.command");
         IHandlerService handlerService = getSite().getService(IHandlerService.class);
@@ -215,22 +233,32 @@ public class DashboardView extends ViewPart {
         handlerService.activateHandler(startAction.getActionDefinitionId(), startHandler);
 
         // Menu: Start with parameters.
-        startWithParmAction = new Action(APP_MENU_ACTION_START_PARMS) {
+        startConfigDialogAction = new Action(APP_MENU_ACTION_START_CONFIG) {
             @Override
             public void run() {
-                devModeOps.startWithParms();
+                StartConfigurationDialogAction.openLaunchConfigurationsDialog();
             }
         };
-        startWithParmAction.setImageDescriptor(ActionImg);
-        startWithParmAction.setActionDefinitionId("io.openliberty.tools.eclipse.project.startWithParms.command");
-        ActionHandler startWithParmsHandler = new ActionHandler(startWithParmAction);
-        handlerService.activateHandler(startWithParmAction.getActionDefinitionId(), startWithParmsHandler);
+        startConfigDialogAction.setImageDescriptor(ActionImg);
+        startConfigDialogAction.setActionDefinitionId("io.openliberty.tools.eclipse.project.startConfigDialog.command");
+        ActionHandler startConfigDialogHandler = new ActionHandler(startConfigDialogAction);
+        handlerService.activateHandler(startConfigDialogAction.getActionDefinitionId(), startConfigDialogHandler);
 
         // Menu: Start in container.
         startInContainerAction = new Action(APP_MENU_ACTION_START_IN_CONTAINER) {
             @Override
             public void run() {
-                devModeOps.startInContainer();
+                IProject iproject = devModeOps.getSelectedDashboardProject();
+                try {
+                    StartInContainerAction.run(iproject, null, "run");
+                } catch (Exception e) {
+                    String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_START_IN_CONTAINER
+                            + " action.";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                    Dialog.displayErrorMessageWithDetails(msg, e);
+                }
             }
         };
         startInContainerAction.setImageDescriptor(ActionImg);
@@ -242,7 +270,16 @@ public class DashboardView extends ViewPart {
         stopAction = new Action(APP_MENU_ACTION_STOP) {
             @Override
             public void run() {
-                devModeOps.stop();
+                IProject iproject = devModeOps.getSelectedDashboardProject();
+                try {
+                    StopAction.run(iproject);
+                } catch (Exception e) {
+                    String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_STOP + " action.";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                    Dialog.displayErrorMessageWithDetails(msg, e);
+                }
             }
         };
         stopAction.setImageDescriptor(ActionImg);
@@ -254,7 +291,16 @@ public class DashboardView extends ViewPart {
         runTestAction = new Action(APP_MENU_ACTION_RUN_TESTS) {
             @Override
             public void run() {
-                devModeOps.runTests();
+                IProject iproject = devModeOps.getSelectedDashboardProject();
+                try {
+                    RunTestsAction.run(iproject);
+                } catch (Exception e) {
+                    String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_RUN_TESTS + " action.";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                    Dialog.displayErrorMessageWithDetails(msg, e);
+                }
             }
         };
         runTestAction.setImageDescriptor(ActionImg);
@@ -266,7 +312,17 @@ public class DashboardView extends ViewPart {
         viewMavenITestReportsAction = new Action(APP_MENU_ACTION_VIEW_MVN_IT_REPORT) {
             @Override
             public void run() {
-                devModeOps.openMavenIntegrationTestReport();
+                IProject iproject = devModeOps.getSelectedDashboardProject();
+                try {
+                    OpenMavenITestReportAction.run(iproject);
+                } catch (Exception e) {
+                    String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_VIEW_MVN_IT_REPORT
+                            + " action.";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                    Dialog.displayErrorMessageWithDetails(msg, e);
+                }
             }
         };
         viewMavenITestReportsAction.setImageDescriptor(ActionImg);
@@ -278,7 +334,17 @@ public class DashboardView extends ViewPart {
         viewMavenUTestReportsAction = new Action(APP_MENU_ACTION_VIEW_MVN_UT_REPORT) {
             @Override
             public void run() {
-                devModeOps.openMavenUnitTestReport();
+                IProject iproject = devModeOps.getSelectedDashboardProject();
+                try {
+                    OpenMavenUTestReportAction.run(iproject);
+                } catch (Exception e) {
+                    String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT
+                            + " action.";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                    Dialog.displayErrorMessageWithDetails(msg, e);
+                }
             }
         };
         viewMavenUTestReportsAction.setImageDescriptor(ActionImg);
@@ -290,7 +356,17 @@ public class DashboardView extends ViewPart {
         viewGradleTestReportsAction = new Action(APP_MENU_ACTION_VIEW_GRADLE_TEST_REPORT) {
             @Override
             public void run() {
-                devModeOps.openGradleTestReport();
+                IProject iproject = devModeOps.getSelectedDashboardProject();
+                try {
+                    OpenGradleTestReportAction.run(iproject);
+                } catch (Exception e) {
+                    String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_VIEW_GRADLE_TEST_REPORT
+                            + " action.";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                    Dialog.displayErrorMessageWithDetails(msg, e);
+                }
             }
         };
         viewGradleTestReportsAction.setImageDescriptor(ActionImg);
@@ -306,7 +382,6 @@ public class DashboardView extends ViewPart {
                     viewer.setInput(devModeOps.getSupportedProjects());
                 } catch (Exception e) {
                     Dialog.displayErrorMessageWithDetails("An error was detected while retrieving Liberty projects.", e);
-                    return;
                 }
             }
         };

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenGradleTestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenGradleTestReportAction.java
@@ -24,40 +24,27 @@ import io.openliberty.tools.eclipse.utils.Dialog;
 import io.openliberty.tools.eclipse.utils.Utils;
 
 /**
- * Liberty Tools view Gradle test report action shortcut.
+ * Liberty view Gradle test report action shortcut.
  */
 public class OpenGradleTestReportAction implements ILaunchShortcut {
-
-    /**
-     * DevModeOperations instance.
-     */
-    private DevModeOperations devModeOps = DevModeOperations.getInstance();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void launch(ISelection selection, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromSelection(selection);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromSelection(selection);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_GRADLE_VIEW_TEST_REPORT
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \""
+                    + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_GRADLE_VIEW_TEST_REPORT + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
-
-        devModeOps.openGradleTestReport(iProject);
     }
 
     /**
@@ -65,25 +52,37 @@ public class OpenGradleTestReportAction implements ILaunchShortcut {
      */
     @Override
     public void launch(IEditorPart part, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromPart(part);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromPart(part);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_GRADLE_VIEW_TEST_REPORT
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \""
+                    + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_GRADLE_VIEW_TEST_REPORT + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
+    }
 
+    /**
+     * Processes the view test report shortcut action.
+     * 
+     * @param iProject The project to process.
+     * 
+     * @throws Exception
+     */
+    public static void run(IProject iProject) throws Exception {
+        if (iProject == null) {
+            throw new Exception("Invalid project. Be sure to select a project first.");
+        }
+
+        // Validate that the project is supported.
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
+        devModeOps.verifyProjectSupport(iProject);
+
+        // Process the actions.
         devModeOps.openGradleTestReport(iProject);
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenITestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenITestReportAction.java
@@ -24,40 +24,27 @@ import io.openliberty.tools.eclipse.utils.Dialog;
 import io.openliberty.tools.eclipse.utils.Utils;
 
 /**
- * Liberty Tools view Maven integration test report action shortcut.
+ * Liberty view Maven integration test report action shortcut.
  */
 public class OpenMavenITestReportAction implements ILaunchShortcut {
-
-    /**
-     * DevModeOperations instance.
-     */
-    private DevModeOperations devModeOps = DevModeOperations.getInstance();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void launch(ISelection selection, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromSelection(selection);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromSelection(selection);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \""
+                    + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
-
-        devModeOps.openMavenIntegrationTestReport(iProject);
     }
 
     /**
@@ -65,25 +52,37 @@ public class OpenMavenITestReportAction implements ILaunchShortcut {
      */
     @Override
     public void launch(IEditorPart part, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromPart(part);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromPart(part);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \""
+                    + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
+    }
 
+    /**
+     * Processes the view integration test report shortcut action.
+     * 
+     * @param iProject The project to process.
+     * 
+     * @throws Exception
+     */
+    public static void run(IProject iProject) throws Exception {
+        if (iProject == null) {
+            throw new Exception("Invalid project. Be sure to select a project first.");
+        }
+
+        // Validate that the project is supported.
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
+        devModeOps.verifyProjectSupport(iProject);
+
+        // Process the actions.
         devModeOps.openMavenIntegrationTestReport(iProject);
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenUTestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenUTestReportAction.java
@@ -24,40 +24,27 @@ import io.openliberty.tools.eclipse.utils.Dialog;
 import io.openliberty.tools.eclipse.utils.Utils;
 
 /**
- * Liberty Tools view Maven unit test report action shortcut.
+ * Liberty view Maven unit test report action shortcut.
  */
 public class OpenMavenUTestReportAction implements ILaunchShortcut {
-
-    /**
-     * DevModeOperations instance.
-     */
-    private DevModeOperations devModeOps = DevModeOperations.getInstance();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void launch(ISelection selection, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromSelection(selection);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromSelection(selection);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \""
+                    + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
-
-        devModeOps.openMavenUnitTestReport(iProject);
     }
 
     /**
@@ -65,25 +52,37 @@ public class OpenMavenUTestReportAction implements ILaunchShortcut {
      */
     @Override
     public void launch(IEditorPart part, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromPart(part);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromPart(part);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \""
+                    + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
+    }
 
+    /**
+     * Processes the view unit test report shortcut action.
+     * 
+     * @param iProject The project to process.
+     * 
+     * @throws Exception
+     */
+    public static void run(IProject iProject) throws Exception {
+        if (iProject == null) {
+            throw new Exception("Invalid project. Be sure to select a project first.");
+        }
+
+        // Validate that the project is supported.
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
+        devModeOps.verifyProjectSupport(iProject);
+
+        // Process the actions.
         devModeOps.openMavenUnitTestReport(iProject);
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/RunTestsAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/RunTestsAction.java
@@ -24,40 +24,27 @@ import io.openliberty.tools.eclipse.utils.Dialog;
 import io.openliberty.tools.eclipse.utils.Utils;
 
 /**
- * Liberty Tools run tests action shortcut.
+ * Liberty run tests action shortcut.
  */
 public class RunTestsAction implements ILaunchShortcut {
-
-    /**
-     * DevModeOperations instance.
-     */
-    private DevModeOperations devModeOps = DevModeOperations.getInstance();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void launch(ISelection selection, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromSelection(selection);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromSelection(selection);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_RUN_TESTS
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_RUN_TESTS
+                    + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
-
-        devModeOps.runTests(iProject);
     }
 
     /**
@@ -65,25 +52,37 @@ public class RunTestsAction implements ILaunchShortcut {
      */
     @Override
     public void launch(IEditorPart part, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromPart(part);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromPart(part);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_RUN_TESTS
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_RUN_TESTS
+                    + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
+    }
 
+    /**
+     * Processes the run tests shortcut action.
+     * 
+     * @param iProject The project to process.
+     * 
+     * @throws Exception
+     */
+    public static void run(IProject iProject) throws Exception {
+        if (iProject == null) {
+            throw new Exception("Invalid project. Be sure to select a project first.");
+        }
+
+        // Validate that the project is supported.
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
+        devModeOps.verifyProjectSupport(iProject);
+
+        // Process the actions.
         devModeOps.runTests(iProject);
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -13,23 +13,18 @@
 package io.openliberty.tools.eclipse.ui.launch.shortcuts;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
-import org.eclipse.debug.ui.DebugUITools;
-import org.eclipse.debug.ui.IDebugModelPresentation;
 import org.eclipse.debug.ui.ILaunchShortcut;
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.window.Window;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.dialogs.ElementListSelectionDialog;
 
 import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.logging.Trace;
@@ -39,62 +34,25 @@ import io.openliberty.tools.eclipse.utils.Dialog;
 import io.openliberty.tools.eclipse.utils.Utils;
 
 /**
- * Liberty Tools start action shortcut.
+ * Liberty start action shortcut.
  */
 public class StartAction implements ILaunchShortcut {
-
-    /** Configuration selection Dialog title. */
-    private static final String SELECTION_DIALOG_TITLE = "Liberty Tools Configuration Selection";
-
-    /** Run mode configuration selection Dialog message. */
-    private static final String SELECTION_DIALOG_RUN_MSG = "Select a run configuration";
-
-    /** Debug mode configuration selection Dialog message. */
-    private static final String SELECTION_DIALOG_DEBUG_MSG = "Select a debug configuration";
-
-    /** DevModeOperations instance. */
-    private DevModeOperations devModeOps = DevModeOperations.getInstance();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void launch(ISelection selection, String mode) {
-        IProject iProject = null;
-        String startParms = null;
-
         try {
-            ILaunchConfiguration configuration = getLaunchConfiguration(mode);
-            // If the configuration is null, there is nothing else to do. A null configuration can be caused by:
-            // 1. An error. In this case an error dialog was already displayed.
-            // 2. The user pressed the cancel button when asked to choose a configuration from a list configurations
-            // associated with the selected project.
-            if (configuration == null) {
-                return;
-            }
-
-            iProject = Utils.getProjectFromSelection(selection);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
-
-            startParms = configuration.getAttribute(MainTab.START_PARM, "");
+            IProject iProject = Utils.getProjectFromSelection(selection);
+            run(iProject, null, mode);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START
+                    + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
-            return;
-        }
-
-        if (startParms == null || startParms.isEmpty()) {
-            devModeOps.start(iProject);
-        } else {
-            devModeOps.startWithParms(iProject, startParms);
         }
     }
 
@@ -103,112 +61,191 @@ public class StartAction implements ILaunchShortcut {
      */
     @Override
     public void launch(IEditorPart part, String mode) {
-        IProject iProject = null;
-        String startParms = null;
-
         try {
-            ILaunchConfiguration configuration = getLaunchConfiguration(mode);
-            iProject = Utils.getProjectFromPart(part);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
-
-            startParms = configuration.getAttribute(MainTab.START_PARM, "");
+            IProject selectedProject = Utils.getProjectFromPart(part);
+            run(selectedProject, null, mode);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START
+                    + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
-            return;
+        }
+    }
+
+    /**
+     * Processes the start shortcut action.
+     * 
+     * @param iProject The project to process.
+     * @param mode The operation mode type. Run or debug.
+     * 
+     * @throws Exception
+     */
+    public static void run(IProject iProject, ILaunchConfiguration iConfiguration, String mode) throws Exception {
+        if (iProject == null) {
+            throw new Exception("Invalid project. Be sure to select a project first.");
         }
 
-        if (startParms == null || startParms.isEmpty()) {
-            devModeOps.start(iProject);
+        // Validate that the project is supported.
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
+        devModeOps.verifyProjectSupport(iProject);
+
+        // If the configuration was not provided by the caller, determine what configuration to use.
+        ILaunchConfiguration configuration = (iConfiguration != null) ? iConfiguration : getLaunchConfiguration(iProject, mode, false);
+
+        // Save the time when this configuration was processed.
+        saveConfigProcessingTime(configuration);
+
+        // Retrieve configuration data.
+        boolean runInContainer = configuration.getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
+        String startParms = configuration.getAttribute(MainTab.PROJECT_START_PARM, (String) null);
+
+        // Process the action.
+        if (runInContainer) {
+            devModeOps.startInContainer(iProject, startParms);
         } else {
-            devModeOps.startWithParms(iProject, startParms);
+            devModeOps.start(iProject, startParms);
         }
     }
 
     /**
      * Returns the configuration to be used by the project associated with the action being processed.
      * 
-     * @param mode The mode.
+     * @param iProject The project for which the configuration will be returned. It must not be null.
+     * @param mode The launch mode.
+     * @param container The indicator of whether or not the caller is running in a container. If true, It allows multiple
+     *        configurations associated to a single project to be filtered based on whether or not the configuration was previously
+     *        used to run the project in a container.
      * 
      * @return The configuration to be used by the project associated with the action being processed.
+     * 
+     * @throws Exception
      */
-    private ILaunchConfiguration getLaunchConfiguration(String mode) {
+    protected static ILaunchConfiguration getLaunchConfiguration(IProject iProject, String mode, boolean container) throws Exception {
         ILaunchConfiguration configuration = null;
         ILaunchManager iLaunchMgr = DebugPlugin.getDefault().getLaunchManager();
         ILaunchConfigurationType iLaunchConfigType = iLaunchMgr
                 .getLaunchConfigurationType(LaunchConfigurationDelegateLauncher.LAUNCH_CONFIG_TYPE_ID);
-        IProject currentProject = Utils.getActiveProject();
 
-        try {
-            // Find the set of configurations that were used by the currently active project last.
-            ILaunchConfiguration[] existingConfigs = iLaunchMgr.getLaunchConfigurations(iLaunchConfigType);
-            ArrayList<ILaunchConfiguration> matchingConfigList = new ArrayList<>();
-            for (ILaunchConfiguration existingConfig : existingConfigs) {
-                String configProjName = existingConfig.getAttribute(MainTab.PROJECT_NAME, "");
-                if (configProjName == null || currentProject == null) {
-                    continue;
-                }
+        // Find the set of configurations that were used by the currently active project last.
+        ILaunchConfiguration[] existingConfigs = iLaunchMgr.getLaunchConfigurations(iLaunchConfigType);
 
-                if (currentProject.getName().equals(configProjName)) {
-                    matchingConfigList.add(existingConfig);
-                }
-            }
+        List<ILaunchConfiguration> matchingConfigList = filterLaunchConfigurations(existingConfigs, iProject.getName(), container);
 
-            switch (matchingConfigList.size()) {
-            case 0:
-                // Create a new configuration.
-                String newName = iLaunchMgr.generateLaunchConfigurationName(currentProject.getName());
-                ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
-                workingCopy.setAttribute(MainTab.PROJECT_NAME, currentProject.getName());
-                workingCopy.setAttribute(MainTab.START_PARM, "");
-                configuration = workingCopy.doSave();
-                break;
+        switch (matchingConfigList.size()) {
+        case 0:
+            // Create a new configuration.
+            String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
+            ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
+            workingCopy.setAttribute(MainTab.PROJECT_NAME, iProject.getName());
+            workingCopy.setAttribute(MainTab.PROJECT_START_PARM, "");
+            workingCopy.setAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
+            configuration = workingCopy.doSave();
+            break;
 
-            case 1:
-                // Return the found configuration.
-                configuration = matchingConfigList.get(0);
-                break;
-            default:
-                // Allow the user to select one of the matching configurations to use.
-                final IDebugModelPresentation debugLabelProvider = DebugUITools.newDebugModelPresentation();
-                Shell activeShell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-                ElementListSelectionDialog selectionDialog = new ElementListSelectionDialog(activeShell, debugLabelProvider);
-                selectionDialog.setTitle(SELECTION_DIALOG_TITLE);
-
-                if (ILaunchManager.RUN_MODE.equals(mode)) {
-                    selectionDialog.setMessage(SELECTION_DIALOG_RUN_MSG);
-                } else {
-                    selectionDialog.setMessage(SELECTION_DIALOG_DEBUG_MSG);
-                }
-
-                selectionDialog.setMultipleSelection(false);
-                selectionDialog.setElements(matchingConfigList.toArray());
-                int rc = selectionDialog.open();
-                debugLabelProvider.dispose();
-
-                if (rc == Window.OK) {
-                    configuration = (ILaunchConfiguration) selectionDialog.getFirstResult();
-                }
-
-                break;
-            }
-        } catch (CoreException ce) {
-            // Trace and ignore.
-            String msg = "An error was detected while attempting to retrieve the run configuration for project: "
-                    + currentProject.getName();
-            if (Trace.isEnabled()) {
-                Trace.getTracer().trace(Trace.TRACE_UI, msg, ce);
-            }
+        case 1:
+            // Return the found configuration.
+            configuration = matchingConfigList.get(0);
+            break;
+        default:
+            // Return the configuration that was run last.
+            configuration = getLastRunConfiguration(matchingConfigList);
+            break;
         }
 
         return configuration;
+    }
+
+    /**
+     * Returns a filtered list of launch configurations.
+     * 
+     * @param rawConfigList The raw list of Liberty associated launch configurations to be filtered.
+     * @param projectName The project name to be used as filter.
+     * @param container The processing type to be used as filter.
+     * 
+     * @return A filtered list of launch configurations.
+     * 
+     * @throws Exception
+     */
+    public static List<ILaunchConfiguration> filterLaunchConfigurations(ILaunchConfiguration[] rawConfigList, String projectName,
+            boolean container) throws Exception {
+        ArrayList<ILaunchConfiguration> matchingConfigList = new ArrayList<>();
+        for (ILaunchConfiguration existingConfig : rawConfigList) {
+            String configProjName = existingConfig.getAttribute(MainTab.PROJECT_NAME, "");
+            if (configProjName.isEmpty()) {
+                continue;
+            }
+
+            if (projectName.equals(configProjName)) {
+                boolean configRanInContainer = existingConfig.getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
+                if (container) {
+                    if (configRanInContainer) {
+                        matchingConfigList.add(existingConfig);
+                    }
+                } else {
+                    if (!configRanInContainer) {
+                        matchingConfigList.add(existingConfig);
+                    }
+                }
+            }
+        }
+
+        return matchingConfigList;
+
+    }
+
+    /**
+     * Returns the last run configuration found in the input list of launch configurations.
+     * 
+     * @param launchConfigList The list of launch configurations.
+     * 
+     * @return The last run configuration found in the input list of launch configurations.
+     */
+    public static ILaunchConfiguration getLastRunConfiguration(List<ILaunchConfiguration> launchConfigList) {
+        launchConfigList.sort(new Comparator<ILaunchConfiguration>() {
+
+            /**
+             * Organizes the items in the descending order. If there are more than one entries with equal value that are considered greater
+             * than the others, the one in the first position after the sort is returned in no particular order.
+             */
+            @Override
+            public int compare(ILaunchConfiguration lc1, ILaunchConfiguration lc2) {
+                int rc = 0;
+                try {
+                    long time1 = Long.valueOf(lc1.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
+                    long time2 = Long.valueOf(lc2.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
+                    rc = (time2 > time1) ? 1 : -1;
+                } catch (Exception e) {
+                    String msg = "An error occurred while trying to determine which configuration ran last. Configuration list: "
+                            + launchConfigList;
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                }
+
+                return rc;
+            }
+        });
+
+        return launchConfigList.get(0);
+    }
+
+    /**
+     * Persists the configuration processing time in the configuration itself.
+     * 
+     * @param configuration The configuration being processed.
+     */
+    protected static void saveConfigProcessingTime(ILaunchConfiguration configuration) {
+        try {
+            ILaunchConfigurationWorkingCopy configWorkingCopy = configuration.getWorkingCopy();
+            configWorkingCopy.setAttribute(MainTab.PROJECT_RUN_TIME, String.valueOf(System.currentTimeMillis()));
+            configWorkingCopy.doSave();
+        } catch (Exception e) {
+            // Log it and move on.
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_UI, "Unable to set time for configuration " + configuration.getName(), e);
+            }
+        }
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartConfigurationDialogAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartConfigurationDialogAction.java
@@ -1,0 +1,69 @@
+package io.openliberty.tools.eclipse.ui.launch.shortcuts;
+
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.debug.ui.ILaunchShortcut;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.PlatformUI;
+
+import io.openliberty.tools.eclipse.logging.Trace;
+import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
+import io.openliberty.tools.eclipse.utils.Dialog;
+
+/**
+ * Liberty start configuration dialog action shortcut.
+ */
+public class StartConfigurationDialogAction implements ILaunchShortcut {
+
+    public static final String LAUNCH_GROUP_RUN_ID = "org.eclipse.debug.ui.launchGroup.run";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void launch(ISelection selection, String mode) {
+        try {
+            openLaunchConfigurationsDialog();
+        } catch (Exception e) {
+            String msg = "An error was detected while processing the \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONFIG
+                    + "\" launch shortcut.";
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+            }
+            Dialog.displayErrorMessageWithDetails(msg, e);
+            return;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void launch(IEditorPart part, String mode) {
+        try {
+            openLaunchConfigurationsDialog();
+        } catch (Exception e) {
+            String msg = "An error was detected while processing the \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONFIG
+                    + "\" launch shortcut.";
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+            }
+            Dialog.displayErrorMessageWithDetails(msg, e);
+            return;
+        }
+    }
+
+    /**
+     * Open the launch configurations dialog.
+     */
+    public static void openLaunchConfigurationsDialog() {
+        ILaunchConfiguration latest = DebugUITools.getLastLaunch(LAUNCH_GROUP_RUN_ID);
+        IStructuredSelection selection = (latest != null) ? new StructuredSelection(latest) : new StructuredSelection();
+        Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+        DebugUITools.openLaunchConfigurationDialogOnGroup(shell, selection, LAUNCH_GROUP_RUN_ID);
+    }
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StopAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StopAction.java
@@ -24,40 +24,27 @@ import io.openliberty.tools.eclipse.utils.Dialog;
 import io.openliberty.tools.eclipse.utils.Utils;
 
 /**
- * Liberty Tools stop action shortcut.
+ * Liberty stop action shortcut.
  */
 public class StopAction implements ILaunchShortcut {
-
-    /**
-     * DevModeOperations instance.
-     */
-    private DevModeOperations devModeOps = DevModeOperations.getInstance();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void launch(ISelection selection, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromSelection(selection);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromSelection(selection);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_STOP
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_STOP
+                    + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
-
-        devModeOps.stop(iProject);
     }
 
     /**
@@ -65,25 +52,37 @@ public class StopAction implements ILaunchShortcut {
      */
     @Override
     public void launch(IEditorPart part, String mode) {
-        IProject iProject = null;
-
         try {
-            iProject = Utils.getProjectFromPart(part);
-            if (iProject == null) {
-                throw new Exception("Unable to find the selected project.");
-            }
-
-            devModeOps.verifyProjectSupport(iProject);
+            IProject iProject = Utils.getProjectFromPart(part);
+            run(iProject);
         } catch (Exception e) {
-            String msg = "An error was detected during \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_STOP
-                    + "\" launch shortcut processing.";
+            String msg = "An error was detected while processing the \"" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_STOP
+                    + "\" launch shortcut.";
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
             }
             Dialog.displayErrorMessageWithDetails(msg, e);
             return;
         }
+    }
 
+    /**
+     * Processes the stop shortcut action.
+     * 
+     * @param iProject The project to process.
+     * 
+     * @throws Exception
+     */
+    public static void run(IProject iProject) throws Exception {
+        if (iProject == null) {
+            throw new Exception("Invalid project. Be sure to select a project first.");
+        }
+
+        // Validate that the project is supported.
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
+        devModeOps.verifyProjectSupport(iProject);
+
+        // Process the actions.
         devModeOps.stop(iProject);
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/Dialog.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/Dialog.java
@@ -29,7 +29,7 @@ import io.openliberty.tools.eclipse.LibertyDevPlugin;
 
 public class Dialog {
 
-    public static String dTitle = "Liberty Dev Mode";
+    public static String dTitle = "Liberty Tools";
 
     /**
      * Displays an error message dialog with details.
@@ -69,21 +69,22 @@ public class Dialog {
         MessageDialog dialog = new MessageDialog(shell, dTitle, null, message, MessageDialog.WARNING, new String[] { "OK" }, 0);
         dialog.open();
     }
-    
+
     /**
      * Converts a throwable to a string.
      *
      * @param t The throwable.
+     * 
      * @return A throwable to a string
      */
     public static String throwableToString(Throwable t) {
         if (t != null) {
-    	    StringWriter sw = new StringWriter();
-    	    PrintWriter pw = new PrintWriter(sw);
-    	    t.printStackTrace(pw);
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            t.printStackTrace(pw);
             return sw.toString();
         }
 
-    	return "";	
+        return "";
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/Utils.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/Utils.java
@@ -86,7 +86,10 @@ public class Utils {
         if (part != null && part instanceof IEditorPart) {
             IEditorPart editorPart = (IEditorPart) part;
             IEditorInput input = editorPart.getEditorInput();
-            iProject = ((IResource) input.getAdapter(IResource.class)).getProject();
+            IResource resource = (IResource) input.getAdapter(IResource.class);
+            if (resource != null) {
+                iProject = resource.getProject();
+            }
         }
 
         return iProject;
@@ -120,8 +123,8 @@ public class Utils {
     /**
      * Returns the project instance associated with the currently selected view or editor.
      *
-     * @return The project instance associated with the currently selected view or editor. If the project is not found, null
-     *     is returned.
+     * @return The project instance associated with the currently selected view or editor. If the project is not found, null is
+     *         returned.
      */
     public static IProject getActiveProject() {
         IProject iProject = null;

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -11,11 +11,12 @@
   
   Contributors:
       IBM Corporation - initial implementation
---><target includeMode="feature" name="target-platform.target" sequenceNumber="15">
+-->
+<target includeMode="feature" name="target-platform.target" sequenceNumber="15">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/releases/2022-09/"/>
-            
+
             <unit id="org.apache.xml.resolver" version="1.2.0.v20220715-1206"/>
             <unit id="org.eclipse.buildship.ui" version="3.1.6.v20220511-1359"/>
             <unit id="org.eclipse.jdt.feature.group" version="3.18.1300.v20220831-1800"/>
@@ -31,7 +32,7 @@
             <unit id="org.junit" version="4.13.2.v20211018-1956"/>
             <unit id="junit-jupiter-api" version="5.9.0"/>
             <unit id="junit-jupiter-engine" version="5.9.0"/>
-            
+
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository"/>
@@ -66,7 +67,7 @@
             <unit id="org.eclipse.tm.terminal.feature.source.feature.group" version="10.6.2.202205081303"/>
             <unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="10.6.2.202205081303"/>
             <unit id="org.eclipse.tm.terminal.view.feature.source.feature.group" version="10.6.2.202205081303"/>
-        </location>	
+        </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="http://download.eclipse.org/lsp4mp/releases/0.5.0/repository/"/>
             <unit id="org.eclipse.lsp4mp.jdt.core" version="0.5.0.20220725-1528"/>
@@ -75,5 +76,39 @@
             <repository location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository/"/>
             <unit id="org.eclipse.jdt.ls.core" version="1.5.0.202110191539"/>
         </location>
+	    <location includeDependencyDepth="none" includeDependencyScopes="compile" missingManifest="generate" type="Maven">
+		    <dependencies>
+			    <dependency>
+				    <groupId>net.bytebuddy</groupId>
+				    <artifactId>byte-buddy-agent</artifactId>
+				    <version>1.12.17</version>
+				    <type>jar</type>
+			    </dependency>
+			    <dependency>
+				    <groupId>net.bytebuddy</groupId>
+				    <artifactId>byte-buddy</artifactId>
+				    <version>1.12.17</version>
+				    <type>jar</type>
+			    </dependency>
+			    <dependency>
+				    <groupId>org.mockito</groupId>
+				    <artifactId>mockito-core</artifactId>
+				    <version>4.8.0</version>
+				    <type>jar</type>
+			    </dependency>
+			    <dependency>
+				    <groupId>org.mockito</groupId>
+				    <artifactId>mockito-junit-jupiter</artifactId>
+				    <version>4.8.0</version>
+				    <type>jar</type>
+			    </dependency>
+			    <dependency>
+				    <groupId>org.objenesis</groupId>
+				    <artifactId>objenesis</artifactId>
+				    <version>3.3</version>
+				    <type>jar</type>
+			    </dependency>
+		    </dependencies>
+	    </location>
     </locations>
 </target>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Copyright: Copyright (c) 2022 IBM Corporation and others.
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
-Bundle-SymbolicName: tests
+Bundle-SymbolicName: io.openliberty.tools.eclipse.tests
 Bundle-Version: 0.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: junit-jupiter-api;bundle-version="[5.8.0,6.0.0)",
@@ -11,10 +11,13 @@ Require-Bundle: junit-jupiter-api;bundle-version="[5.8.0,6.0.0)",
 Import-Package: io.openliberty.tools.eclipse,
  io.openliberty.tools.eclipse.ui.dashboard,
  io.openliberty.tools.eclipse.ui.launch,
+ io.openliberty.tools.eclipse.ui.launch.shortcuts,
  org.eclipse.buildship.core,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.core.runtime.preferences,
+ org.eclipse.debug.core,
+ org.eclipse.debug.ui,
  org.eclipse.m2e.core,
  org.eclipse.m2e.core.embedder,
  org.eclipse.m2e.core.project,
@@ -27,4 +30,7 @@ Import-Package: io.openliberty.tools.eclipse,
  org.eclipse.swtbot.swt.finder.utils,
  org.eclipse.swtbot.swt.finder.waits,
  org.eclipse.swtbot.swt.finder.widgets,
+ org.mockito,
+ org.mockito.junit.jupiter,
+ org.mockito.stubbing,
  org.osgi.service.prefs

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -20,7 +20,7 @@
         <version>0.4.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>tests</artifactId>
+    <artifactId>io.openliberty.tools.eclipse.tests</artifactId>
     <packaging>eclipse-test-plugin</packaging>
 
     <build>

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDashboardTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDashboardTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.openliberty.tools.eclipse.test.it.utils.SWTPluginOperations;
+import io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations;
 
 /**
  * Tests Open Liberty Eclipse plugin functions.
@@ -34,14 +34,14 @@ public class LibertyPluginSWTBotDashboardTest {
      * Dashboard instance.
      */
     static SWTBotView dashboard;
-    
+
     /**
      * Setup.
      */
     @BeforeAll
     public static void setup() {
         bot = new SWTWorkbenchBot();
-        SWTPluginOperations.closeWelcomePage(bot);
+        SWTBotPluginOperations.closeWelcomePage(bot);
     }
 
     /**
@@ -60,6 +60,6 @@ public class LibertyPluginSWTBotDashboardTest {
     @Test
     public void testOpenDashboardWithToolbarIcon() {
         // Open the dashboard view.
-        SWTPluginOperations.openDashboardUsingToolbar(bot);
+        SWTBotPluginOperations.openDashboardUsingToolbar(bot);
     }
 }

--- a/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -31,7 +31,6 @@ import org.eclipse.swtbot.swt.finder.utils.SWTUtils;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotRootMenu;
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
@@ -54,7 +53,7 @@ import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLaunche
 /**
  * Provides a set of SWTBot wrapper functions.
  */
-public class SWTPluginOperations {
+public class SWTBotPluginOperations {
 
     /**
      * Constants.
@@ -64,6 +63,7 @@ public class SWTPluginOperations {
     public static final String TOOLBAR_OPEN_DASHBOARD_TIP = "Open Liberty Dashboard View";
     public static final String DASHBOARD_TOOLBAR_REFRESH_TIP = "refresh";
     public static final String DASHBOARD_VIEW_TITLE = "Liberty Dashboard";
+    public static final String LAUNCH_CONFIG_LIBERTY_MENU_NAME = "Liberty";
 
     /**
      * Close the welcome page if active.
@@ -106,7 +106,7 @@ public class SWTPluginOperations {
      */
     public static List<String> getDashboardContent(SWTWorkbenchBot bot, SWTBotView dashboard) {
         if (dashboard == null) {
-            SWTPluginOperations.openDashboardUsingToolbar(bot);
+        	SWTBotPluginOperations.openDashboardUsingToolbar(bot);
         } else {
             dashboard.show();
         }
@@ -131,7 +131,7 @@ public class SWTPluginOperations {
      */
     public static List<String> getDashboardItemMenuActions(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         if (dashboard == null) {
-            SWTPluginOperations.openDashboardUsingToolbar(bot);
+            SWTBotPluginOperations.openDashboardUsingToolbar(bot);
         } else {
             dashboard.show();
         }
@@ -153,106 +153,100 @@ public class SWTPluginOperations {
     }
 
     /**
-     * Launches the start menu action associated with the input application item.
+     * Launches the dashboard's start action associated with the input application item.
      *
      * @param bot The SWTWorkbenchBot instance.
      * @param dashboard An instance representing the Open Liberty dashboard view.
      * @param item The application name to select.
      */
-    public static void launchAppMenuStartAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
+    public static void launchStartWithDashboardAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         SWTBotRootMenu appCtxMenu = getAppContextMenu(bot, dashboard, item);
         SWTBotMenu startAction = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_START);
         startAction.click();
     }
 
     /**
-     * Launches the start with parameters menu action associated with the input application item.
+     * Launches the dashoboard's start with configuration dialog associated with the input application item.
      *
      * @param bot The SWTWorkbenchBot instance.
      * @param dashboard An instance representing the Open Liberty dashboard view.
      * @param item The application name to select.
      */
-    public static void launchAppMenuStartWithParmsAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item, String parms) {
+    public static void launchStartConfigDialogWithDashboardAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         SWTBotRootMenu appCtxMenu = getAppContextMenu(bot, dashboard, item);
-        SWTBotMenu startAction = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_START_PARMS);
+        SWTBotMenu startAction = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_START_CONFIG);
         startAction.click();
-        SWTBotShell inputParmDialog = bot.activeShell();
-        bot.waitUntil(SWTTestCondition.isDialogActive(inputParmDialog), 5000);
-
-        SWTBotText textDialog = bot.textWithLabel(DevModeOperations.DEVMODE_START_PARMS_DIALOG_MSG);
-        textDialog = textDialog.setText(parms);
-        bot.button("OK").click();
     }
 
     /**
-     * Launches the run test menu action associated with the input application item.
+     * Launches the dashboard's run test action associated with the input application item.
      *
      * @param bot The SWTWorkbenchBot instance.
      * @param dashboard An instance representing the Open Liberty dashboard view.
      * @param item The application name to select.
      */
-    public static void launchAppMenuRunTestsAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
+    public static void launchRunTestsWithDashboardAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         SWTBotRootMenu appCtxMenu = getAppContextMenu(bot, dashboard, item);
         SWTBotMenu runTestsAction = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_RUN_TESTS);
         runTestsAction.click();
     }
 
     /**
-     * Launches the stop menu action associated with the input application item.
+     * Launches the dashboard's stop action associated with the input application item.
      *
      * @param bot The SWTWorkbenchBot instance.
      * @param dashboard An instance representing the Open Liberty dashboard view.
      * @param item The application name to select.
      */
-    public static void launchAppMenuStopAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
+    public static void launchStopWithDashboardAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         SWTBotRootMenu appCtxMenu = getAppContextMenu(bot, dashboard, item);
         SWTBotMenu stopAction = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_STOP);
         stopAction.click();
     }
 
     /**
-     * Launches the menu action to view the integration test report associated with the input Maven application item.
+     * Launches dashboard's view (Maven) integration test report action associated with the input application item.
      *
      * @param bot The SWTWorkbenchBot instance.
      * @param dashboard An instance representing the Open Liberty dashboard view.
      * @param item The Maven application name to select.
      */
-    public static void launchAppMenuViewMavenITReportAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
+    public static void launchViewITReportWithDashboardAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         SWTBotRootMenu appCtxMenu = getAppContextMenu(bot, dashboard, item);
         SWTBotMenu itReport = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_VIEW_MVN_IT_REPORT);
         itReport.click();
 
-        bot.waitUntil(SWTTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_IT_REPORT_NAME_SUFFIX), 5000);
+        bot.waitUntil(SWTBotTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_IT_REPORT_NAME_SUFFIX), 5000);
     }
 
     /**
-     * Launches the menu action to view the unit test report associated with the input Maven application item.
+     * Launches the dashboard's view (Maven) unit test report action associated with the input application item.
      *
      * @param bot The SWTWorkbenchBot instance.
      * @param dashboard An instance representing the Open Liberty dashboard view.
      * @param item The Maven application name to select.
      */
-    public static void launchAppMenuViewMavenUTReportAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
+    public static void launchViewUTReportWithDashboardAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         SWTBotRootMenu appCtxMenu = getAppContextMenu(bot, dashboard, item);
         SWTBotMenu utReport = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT);
         utReport.click();
 
-        bot.waitUntil(SWTTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_UT_REPORT_NAME_SUFFIX), 5000);
+        bot.waitUntil(SWTBotTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_UT_REPORT_NAME_SUFFIX), 5000);
     }
 
     /**
-     * Launches the menu action to view the test report associated with the input Gradle application item.
+     * Launches the dashboard's view (Gradle) the test report action associated with the input application item.
      *
      * @param bot The SWTWorkbenchBot instance.
      * @param dashboard An instance representing the Open Liberty dashboard view.
      * @param item The Gradle application name to select.
      */
-    public static void launchAppMenuViewGradleTestReportAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
+    public static void launchViewTestReportWithDashboardAction(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         SWTBotRootMenu appCtxMenu = getAppContextMenu(bot, dashboard, item);
         SWTBotMenu testReport = appCtxMenu.contextMenu(DashboardView.APP_MENU_ACTION_VIEW_GRADLE_TEST_REPORT);
         testReport.click();
 
-        bot.waitUntil(SWTTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_GRADLE_TEST_REPORT_NAME_SUFFIX), 5000);
+        bot.waitUntil(SWTBotTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_GRADLE_TEST_REPORT_NAME_SUFFIX), 5000);
     }
 
     /**
@@ -279,7 +273,7 @@ public class SWTPluginOperations {
     }
 
     /**
-     * Returns the object representing the Run As menu.
+     * Returns the object representing the explorer->project->right-click->Run As menu.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
@@ -298,7 +292,7 @@ public class SWTPluginOperations {
     }
 
     /**
-     * Returns the object representing the Debug As menu.
+     * Returns the object representing the explorer->project->right-click->Debug As menu.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
@@ -317,7 +311,7 @@ public class SWTPluginOperations {
     }
 
     /**
-     * Returns the object representing the Run/Debug As->Run/Debug Configuration... menu entry.
+     * Returns the object representing the Run/Debug As->Run/Debug Configuration...->Liberty menu entry.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
@@ -325,11 +319,10 @@ public class SWTPluginOperations {
      * 
      * @return The object representing the Run/Debug As->Run/Debug Configuration... menu entry.
      */
-    public static SWTBotTreeItem getLibertyToolsConfigMenuEntry(SWTWorkbenchBot bot, String item, String mode) {
+    public static void launchRunConfigurationsDialog(SWTWorkbenchBot bot, String item, String mode) {
         Assertions.assertTrue(("run".equals(mode) || "debug".equals(mode)),
                 () -> "Invalid configration mode: " + mode + ". Accepted values: run, debug.");
 
-        SWTBotTreeItem libertyToolsEntry = null;
         SWTBotMenu modeAsMenu = ("run".equals(mode)) ? getAppRunAsMenu(bot, item) : getAppDebugAsMenu(bot, item);
         String configMenuText = ("run".equals(mode)) ? "Run Configurations..." : "Debug Configurations...";
 
@@ -337,14 +330,25 @@ public class SWTPluginOperations {
         runConfigMenu.setFocus();
         runConfigMenu.click();
 
-        libertyToolsEntry = bot.tree().getTreeItem("Liberty Tools");
+        SWTBotTestCondition.isTreeWidgetActive(bot, LAUNCH_CONFIG_LIBERTY_MENU_NAME);
+    }
+
+    /**
+     * Returns the object that represents the Run/Debug As->Run/Debug Configuration...->Liberty menu entry.
+     * 
+     * @param bot The SWTWorkbenchBot instance..
+     * 
+     * @return The object that represents the Run/Debug As->Run/Debug Configuration...->Liberty menu entry.
+     */
+    public static SWTBotTreeItem getLibertyToolsConfigMenuItem(SWTWorkbenchBot bot) {
+        SWTBotTreeItem libertyToolsEntry = bot.tree().getTreeItem(LAUNCH_CONFIG_LIBERTY_MENU_NAME);
         libertyToolsEntry.setFocus();
 
         return libertyToolsEntry;
     }
 
     /**
-     * Deletes Liberty Tools configuration entries based on the supplied mode.
+     * Deletes Liberty configuration entries based on the supplied mode.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
@@ -354,7 +358,8 @@ public class SWTPluginOperations {
         Assertions.assertTrue(("run".equals(mode) || "debug".equals(mode)),
                 () -> "Invalid configration mode: " + mode + ". Accepted values: run, debug.");
 
-        SWTBotTreeItem libertyToolsEntry = getLibertyToolsConfigMenuEntry(bot, item, mode);
+        SWTBotPluginOperations.launchRunConfigurationsDialog(bot, item, mode);
+        SWTBotTreeItem libertyToolsEntry = getLibertyToolsConfigMenuItem(bot);
         libertyToolsEntry.setFocus();
         List<String> configs = libertyToolsEntry.getNodes();
 
@@ -370,63 +375,94 @@ public class SWTPluginOperations {
         SWTBotButton closeButton = bot.button("Close");
         closeButton.setFocus();
         closeButton.click();
-
     }
 
     /**
-     * Launches dev mode start using a new Liberty tools configuration (Run/Debug As -> Run/Debug Configurations -> Liberty Tools ->
-     * New config -> Run).
+     * Launches dev mode start using a new Liberty configuration: project -> Run/Debug As -> Run/Debug Configurations -> Liberty ->
+     * New configuration (default) -> Run.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
      * @param mode The operating mode. It can be either \"run\" or \"debug\".
      */
-    public static void launchAppConfigStart(SWTWorkbenchBot bot, String item, String mode) {
+    public static void launchStartWithDefaultConfig(SWTWorkbenchBot bot, String item, String mode) {
         Assertions.assertTrue(("run".equals(mode) || "debug".equals(mode)),
                 () -> "Invalid configration mode: " + mode + ". Accepted values: run, debug.");
 
-        SWTBotTreeItem libertyToolsEntry = getLibertyToolsConfigMenuEntry(bot, item, mode);
+        SWTBotPluginOperations.launchRunConfigurationsDialog(bot, item, mode);
+        SWTBotTreeItem libertyToolsEntry = getLibertyToolsConfigMenuItem(bot);
         libertyToolsEntry.doubleClick();
 
-        SWTBotButton runButton = bot.button(("run".equals(mode)) ? "Run" : "Debug");
-        runButton.setFocus();
-        runButton.click();
+        runLibertyConfiguration(bot, mode);
     }
 
     /**
-     * Launches dev mode with parms using a new Liberty tools configuration (Run/Debug As -> Run/Debug Configurations -> Liberty Tools
-     * -> New config -> update parms -> Run). Note that the changes are not saved.
+     * Launches dev mode with parms using a new Liberty configuration: project -> Run/Debug As -> Run/Debug Configurations -> Liberty
+     * -> New configuration (default) -> update parms -> Run. Note that the changes are not saved.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
      * @param mode The operating mode. It can be either \"run\" or \"debug\".
      * @param parms The parameter(s) to pass to the dev mode start action.
      */
-    public static void launchAppConfigStartWithParms(SWTWorkbenchBot bot, String item, String mode, String parms) {
+    public static void launchStartWithCustomConfig(SWTWorkbenchBot bot, String item, String mode, String parms) {
         Assertions.assertTrue(("run".equals(mode) || "debug".equals(mode)),
                 () -> "Invalid configration mode: " + mode + ". Accepted values: run, debug.");
 
-        SWTBotTreeItem libertyToolsEntry = getLibertyToolsConfigMenuEntry(bot, item, mode);
-        libertyToolsEntry.doubleClick();
+        SWTBotPluginOperations.launchRunConfigurationsDialog(bot, item, mode);
+        createNewLibertyConfiguration(bot);
 
-        SWTBotText parmTextBox = bot.textWithLabel("Start parameter:");
+        setLibertyConfigParms(bot, parms);
+
+        runLibertyConfiguration(bot, mode);
+    }
+
+    /**
+     * Creates a new Liberty configuration: <Run/Debug configurations dialog> -> Liberty -> New configuration. The Run/Debug
+     * configurations dialog containing the Liberty entry must be the active view when this method is called.
+     * 
+     * @param bot The SWTWorkbenchBot instance.
+     */
+    public static void createNewLibertyConfiguration(SWTWorkbenchBot bot) {
+        SWTBotTreeItem libertyToolsEntry = getLibertyToolsConfigMenuItem(bot);
+        libertyToolsEntry.doubleClick();
+    }
+
+    /**
+     * Updates the Start parameters entry on the Main tab of the Liberty configuration. The Liberty Main tab on the Run Configurations
+     * dialog must be the active view when this method is called.
+     * 
+     * @param bot The SWTWorkbenchBot instance.
+     * @param parms The parameter(s) to pass to the dev mode start action.
+     */
+    public static void setLibertyConfigParms(SWTWorkbenchBot bot, String parms) {
+        SWTBotText parmTextBox = bot.textWithLabel("Start parameters:");
         parmTextBox.setFocus();
         parmTextBox.setText(parms);
-        bot.waitUntil(SWTTestCondition.isTextPresent(parmTextBox, parms), 5000);
+        bot.waitUntil(SWTBotTestCondition.isTextPresent(parmTextBox, parms), 5000);
+    }
 
+    /**
+     * Clicks the Run/Debug button on the Main tab of the Liberty configuration. The Liberty Main tab on the Run Configurations dialog
+     * must be the active view when this method is called.
+     * 
+     * @param bot The SWTWorkbenchBot instance.
+     * @param mode The operating mode. It can be either \"run\" or \"debug\".
+     */
+    public static void runLibertyConfiguration(SWTWorkbenchBot bot, String mode) {
         SWTBotButton runButton = bot.button(("run".equals(mode)) ? "Run" : "Debug");
         runButton.setFocus();
         runButton.click();
     }
 
     /**
-     * Launches dev mode using the run as configuration start shortcut.
+     * Launches the start action using the run/debug as configuration shortcut.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
      * @param mode The operating mode. It can be either \"run\" or \"debug\".
      */
-    public static void launchAppConfigShortcutStart(SWTWorkbenchBot bot, String item, String mode) {
+    public static void launchStartWithRunDebugAsShortcut(SWTWorkbenchBot bot, String item, String mode) {
         Assertions.assertTrue(("run".equals(mode) || "debug".equals(mode)),
                 () -> "Invalid configration mode: " + mode + ". Accepted values: run, debug.");
 
@@ -439,13 +475,13 @@ public class SWTPluginOperations {
     }
 
     /**
-     * Stops dev mode using the run as configuration stop shortcut
+     * Launches the stop action using the run/debug as configuration shortcut.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
      * @param mode The operating mode. It can be either \"run\" or \"debug\".
      */
-    public static void launchAppConfigShortcutStop(SWTWorkbenchBot bot, String item, String mode) {
+    public static void launchStopWithRunDebugAsShortcut(SWTWorkbenchBot bot, String item, String mode) {
         Assertions.assertTrue(("run".equals(mode) || "debug".equals(mode)),
                 () -> "Invalid configration mode: " + mode + ". Accepted values: run, debug.");
 
@@ -458,13 +494,13 @@ public class SWTPluginOperations {
     }
 
     /**
-     * Launches the run tests action using the run as configuration run tests shortcut.
+     * Launches the run tests action using the run/debug as configuration shortcut.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
      * @param mode The operating mode. It can be either \"run\" or \"debug\".
      */
-    public static void launchAppRunAsShortcutRunTests(SWTWorkbenchBot bot, String item, String mode) {
+    public static void launchRunTestspWithRunDebugAsShortcut(SWTWorkbenchBot bot, String item, String mode) {
         Assertions.assertTrue(("run".equals(mode) || "debug".equals(mode)),
                 () -> "Invalid configration mode: " + mode + ". Accepted values: run, debug.");
 
@@ -476,54 +512,54 @@ public class SWTPluginOperations {
     }
 
     /**
-     * Launches the action that displays the maven IT test report using the run as configuration view IT test report shortcut.
+     * Launches the view (Maven) integration test report action using the run/debug as configuration shortcut.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
      */
-    public static void launchAppRunAsShortcutViewMavenITReport(SWTWorkbenchBot bot, String item) {
-        SWTBotMenu runAsMenu = SWTPluginOperations.getAppRunAsMenu(bot, item);
+    public static void launchViewITReportWithRunDebugAsShortcut(SWTWorkbenchBot bot, String item) {
+        SWTBotMenu runAsMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, item);
         SWTBotMenu stopShortcut = runAsMenu.menu(
                 WidgetMatcherFactory.withRegex(".*" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT + ".*"), false,
                 0);
         stopShortcut.setFocus();
         stopShortcut.click();
 
-        bot.waitUntil(SWTTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_IT_REPORT_NAME_SUFFIX), 5000);
+        bot.waitUntil(SWTBotTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_IT_REPORT_NAME_SUFFIX), 5000);
     }
 
     /**
-     * Launches the action that displays the maven UT test report using the run as configuration view UT test report shortcut.
+     * Launches the view (Maven) unit test report action using the run/debug as configuration shortcut.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
      */
-    public static void launchAppRunAsShortcutViewMavenUTReport(SWTWorkbenchBot bot, String item) {
-        SWTBotMenu runAsMenu = SWTPluginOperations.getAppRunAsMenu(bot, item);
+    public static void launchViewUTReportWithRunDebugAsShortcut(SWTWorkbenchBot bot, String item) {
+        SWTBotMenu runAsMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, item);
         SWTBotMenu stopShortcut = runAsMenu.menu(
                 WidgetMatcherFactory.withRegex(".*" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT + ".*"), false,
                 0);
         stopShortcut.setFocus();
         stopShortcut.click();
 
-        bot.waitUntil(SWTTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_UT_REPORT_NAME_SUFFIX), 5000);
+        bot.waitUntil(SWTBotTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_MVN_UT_REPORT_NAME_SUFFIX), 5000);
     }
 
     /**
-     * Launches the action that displays the gradle test report using the run as configuration view test report shortcut.
+     * Launches the view (Gradle) test report action using the run/debug as configuration shortcut.
      * 
      * @param bot The SWTWorkbenchBot instance.
      * @param item The application name.
      */
-    public static void launchAppRunAsShortcutViewGradleTestReport(SWTWorkbenchBot bot, String item) {
-        SWTBotMenu runAsMenu = SWTPluginOperations.getAppRunAsMenu(bot, item);
+    public static void launchViewTestReportWithRunDebugAsShortcut(SWTWorkbenchBot bot, String item) {
+        SWTBotMenu runAsMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, item);
         SWTBotMenu stopShortcut = runAsMenu.menu(
                 WidgetMatcherFactory.withRegex(".*" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_GRADLE_VIEW_TEST_REPORT + ".*"),
                 false, 0);
         stopShortcut.setFocus();
         stopShortcut.click();
 
-        bot.waitUntil(SWTTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_GRADLE_TEST_REPORT_NAME_SUFFIX), 5000);
+        bot.waitUntil(SWTBotTestCondition.isEditorActive(bot, item + " " + DevModeOperations.BROWSER_GRADLE_TEST_REPORT_NAME_SUFFIX), 5000);
     }
 
     /**
@@ -636,7 +672,7 @@ public class SWTPluginOperations {
      */
     public static SWTBotRootMenu getAppContextMenu(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         if (dashboard == null) {
-            SWTPluginOperations.openDashboardUsingToolbar(bot);
+        	SWTBotPluginOperations.openDashboardUsingToolbar(bot);
         } else {
             dashboard.show();
             dashboard.setFocus();
@@ -659,7 +695,7 @@ public class SWTPluginOperations {
         toolbarButton.click();
         SWTBotView dashboard = bot.viewByTitle(DASHBOARD_VIEW_TITLE);
         dashboard.show();
-        bot.waitUntil(SWTTestCondition.isViewActive(dashboard, DASHBOARD_VIEW_TITLE), 5000);
+        bot.waitUntil(SWTBotTestCondition.isViewActive(dashboard, DASHBOARD_VIEW_TITLE), 5000);
         return dashboard;
     }
 

--- a/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTBotTestCondition.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTBotTestCondition.java
@@ -19,11 +19,12 @@ import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.waits.ICondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 
 /**
  * Provides a predefined set conditions to wait for.
  */
-public class SWTTestCondition {
+public class SWTBotTestCondition {
 
     /**
      * Returns true if the view is active. False, otherwise.
@@ -72,6 +73,30 @@ public class SWTTestCondition {
     }
 
     /**
+     * Returns true if the input tree structure is active and contains a particular item. False, otherwise.
+     * 
+     * @param tree The tree widget
+     * @param item The name of the desired item in the tree structure.
+     * 
+     * @return True If the input tree structure is active and contains a particular item. False, otherwise.
+     */
+    public static ICondition isTreeWidgetActive(SWTWorkbenchBot bot, String item) {
+        return new CustomCondition() {
+
+            @Override
+            public boolean test() throws Exception {
+                SWTBotTree tree = bot.tree();
+                return (tree != null) && (tree.isActive() && tree.getTreeItem(item) != null);
+            }
+
+            @Override
+            public String getFailureMessage() {
+                return "Tree is not active.";
+            }
+        };
+    }
+
+    /**
      * Returns true if the dialog is active. False, otherwise.
      * 
      * @param dialog The dialog to check.
@@ -106,7 +131,7 @@ public class SWTTestCondition {
 
             @Override
             public boolean test() throws Exception {
-                SWTBotEditor editor = SWTPluginOperations.searchForEditor(wbbot, fileName);
+                SWTBotEditor editor = SWTBotPluginOperations.searchForEditor(wbbot, fileName);
 
                 if (editor == null) {
                     return false;

--- a/tests/src/io/openliberty/tools/eclipse/test/ut/LibertyPluginUnitTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/ut/LibertyPluginUnitTest.java
@@ -1,0 +1,192 @@
+package io.openliberty.tools.eclipse.test.ut;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import io.openliberty.tools.eclipse.ui.launch.MainTab;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.StartAction;
+
+public class LibertyPluginUnitTest {
+
+    /**
+     * Runs before each test.
+     */
+    @BeforeEach
+    public void beforeEach(TestInfo info) {
+        System.out.println("INFO: Test " + info.getDisplayName() + " entry: " + java.time.LocalDateTime.now());
+    }
+
+    /**
+     * Runs after each test.
+     */
+    @AfterEach
+    public void afterEach(TestInfo info) {
+        System.out.println("INFO: Test " + info.getDisplayName() + " exit: " + java.time.LocalDateTime.now());
+    }
+
+    /**
+     * Tests that run configurations are filtered correctly based on the project, run environment.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConfigFiltering() throws Exception {
+        List<ILaunchConfiguration> rawCfgList = getDefaultConfigurationList();
+
+        // Test 1. Normal run.
+        List<ILaunchConfiguration> filteredListDev = StartAction
+                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", false);
+        Assertions.assertTrue(filteredListDev.size() == 3,
+                "The resulting list should have contained 3 entries. List size: " + filteredListDev.size());
+        Assertions.assertTrue(filteredListDev.get(0).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, true) == false,
+                "The run in container value associated with config entry[0] was not false.");
+        Assertions.assertTrue(filteredListDev.get(1).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, true) == false,
+                "The run in container value associated with config entry[1] was not false.");
+        Assertions.assertTrue(filteredListDev.get(2).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, true) == false,
+                "The run in container value associated with config entry[2] was not false.");
+
+        // test 2. Container run.
+        List<ILaunchConfiguration> filteredListDevc = StartAction
+                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", true);
+        Assertions.assertTrue(filteredListDevc.size() == 3,
+                "The resulting list should have contained 3 entries. Found: " + filteredListDevc.size() + ". List: " + filteredListDevc);
+        Assertions.assertTrue(filteredListDevc.get(0).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false) == true,
+                "The run in container value associated with config entry[0] was not true.");
+        Assertions.assertTrue(filteredListDevc.get(1).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false) == true,
+                "The run in container value associated with config entry[1] was not true.");
+        Assertions.assertTrue(filteredListDevc.get(2).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false) == true,
+                "The run in container value associated with config entry[2] was not true.");
+    }
+
+    /**
+     * Tests that the run configuration that ran last is returned.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testRetrieveLastRunConfig() throws Exception {
+        List<ILaunchConfiguration> rawCfgList = getDefaultConfigurationList();
+        List<ILaunchConfiguration> filteredListDev = StartAction
+                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", false);
+        Assertions.assertTrue(filteredListDev.size() == 3,
+                "The resulting list should have contained 3 entries. List size: " + filteredListDev.size());
+
+        // Test 1. Normal run.
+        ILaunchConfiguration lastRunConfigDev = StartAction.getLastRunConfiguration(filteredListDev);
+
+        String cfgNameFoundDev = lastRunConfigDev.getName();
+        String expectedCfgNameDev = "test2";
+        Assertions.assertTrue(expectedCfgNameDev.equals(cfgNameFoundDev),
+                "The expected configuration of " + expectedCfgNameDev + " was not returned. Configuration returned:: " + cfgNameFoundDev);
+
+        long expectedTimeDev = 1000000000003L;
+        long timeFoundDev = Long.valueOf(lastRunConfigDev.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
+        Assertions.assertTrue(timeFoundDev == expectedTimeDev,
+                "The configuration found does not contain the expected value of " + expectedTimeDev + ". Time found: " + timeFoundDev);
+
+        // Test 2. Container run.
+        List<ILaunchConfiguration> filteredListDevc = StartAction
+                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", true);
+        Assertions.assertTrue(filteredListDevc.size() == 3,
+                "The resulting list should have contained 3 entries. List size: " + filteredListDevc.size());
+
+        ILaunchConfiguration lastRunConfigDevc = StartAction.getLastRunConfiguration(filteredListDevc);
+
+        String cfgNameFoundDevc = lastRunConfigDevc.getName();
+        String expectedCfgNameDevc = "test6";
+        Assertions.assertTrue(expectedCfgNameDevc.equals(cfgNameFoundDevc),
+                "The expected configuration of " + expectedCfgNameDevc + " was not returned. Configuration returned:: " + cfgNameFoundDevc);
+
+        long expectedTimeDevc = 1000000000006L;
+        long timeFoundDevc = Long.valueOf(lastRunConfigDevc.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
+        Assertions.assertTrue(timeFoundDevc == expectedTimeDevc,
+                "The configuration found does not contain the expected value of " + expectedTimeDevc + ". Time found: " + timeFoundDevc);
+
+        // Test 3: Normal run. Configurations with equal minimum time. Configuration with max time expected.
+        List<ILaunchConfiguration> filteredListT3Dev = StartAction
+                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project2", false);
+        Assertions.assertTrue(filteredListT3Dev.size() == 3,
+                "The resulting list should have contained 3 entries. List size: " + filteredListT3Dev.size());
+
+        ILaunchConfiguration lastRunConfigT3Dev = StartAction.getLastRunConfiguration(filteredListT3Dev);
+
+        String cfgNameFoundT3Dev = lastRunConfigT3Dev.getName();
+        String expectedCfgNameT3Dev = "test11";
+        Assertions.assertTrue(expectedCfgNameT3Dev.equals(cfgNameFoundT3Dev), "The expected configuration of " + expectedCfgNameT3Dev
+                + " was not returned. Configuration returned:: " + cfgNameFoundT3Dev);
+
+        // Test 4: Container run. Configurations with equal max time. One of the max times is returned.
+        // In this particular case, is the second entry after the entries are sorted.
+        List<ILaunchConfiguration> filteredListT4Devc = StartAction
+                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project3", true);
+        Assertions.assertTrue(filteredListT4Devc.size() == 3,
+                "The resulting list should have contained 3 entries. List size: " + filteredListT4Devc.size());
+
+        ILaunchConfiguration lastRunConfigT4Devc = StartAction.getLastRunConfiguration(filteredListT4Devc);
+
+        String cfgNameFoundT4Devc = lastRunConfigT4Devc.getName();
+        String expectedCfgNameT4Devc = "test16";
+        Assertions.assertTrue(expectedCfgNameT4Devc.equals(cfgNameFoundT4Devc), "The expected configuration of " + expectedCfgNameT4Devc
+                + " was not returned. Configuration returned:: " + cfgNameFoundT4Devc);
+
+    }
+
+    private List<ILaunchConfiguration> getDefaultConfigurationList() throws CoreException {
+        ArrayList<ILaunchConfiguration> configList = new ArrayList<ILaunchConfiguration>();
+        configList.add(mockLaunchConfiguration(Map.of("name", "test1", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
+                "1000000000001", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test2", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
+                "1000000000003", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test3", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
+                "1000000000002", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test4", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
+                "1000000000004", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test5", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
+                "1000000000005", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test6", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
+                "1000000000006", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
+
+        configList.add(mockLaunchConfiguration(Map.of("name", "test10", MainTab.PROJECT_NAME, "project2", MainTab.PROJECT_RUN_TIME,
+                "1000000000010", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test11", MainTab.PROJECT_NAME, "project2", MainTab.PROJECT_RUN_TIME,
+                "1000000000011", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test12", MainTab.PROJECT_NAME, "project2", MainTab.PROJECT_RUN_TIME,
+                "1000000000010", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
+
+        configList.add(mockLaunchConfiguration(Map.of("name", "test15", MainTab.PROJECT_NAME, "project3", MainTab.PROJECT_RUN_TIME,
+                "1000000000011", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test16", MainTab.PROJECT_NAME, "project3", MainTab.PROJECT_RUN_TIME,
+                "1000000000011", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test17", MainTab.PROJECT_NAME, "project3", MainTab.PROJECT_RUN_TIME,
+                "1000000000010", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
+
+        return configList;
+    }
+
+    public static ILaunchConfiguration mockLaunchConfiguration(Map<String, Object> attributes) throws CoreException {
+        ILaunchConfiguration config = mock(ILaunchConfiguration.class);
+        when(config.getName()).thenReturn((String) attributes.get("name"));
+        when(config.getAttribute(eq(MainTab.PROJECT_NAME), anyString())).thenReturn(((String) attributes.get(MainTab.PROJECT_NAME)));
+        when(config.getAttribute(eq(MainTab.PROJECT_RUN_TIME), anyString()))
+                .thenReturn(((String) attributes.get(MainTab.PROJECT_RUN_TIME)));
+        when(config.getAttribute(eq(MainTab.PROJECT_RUN_IN_CONTAINER), anyBoolean()))
+                .thenReturn(((Boolean) attributes.get(MainTab.PROJECT_RUN_IN_CONTAINER)).booleanValue());
+
+        return config;
+    }
+}


### PR DESCRIPTION
This PR among others does the following:
- Adds the start… selection to the Run As configuration shortcuts.
- Further links and standardizes all action commands in the dashboard and the Run As shortcuts.
- Introduces a new checkbox in the run configurations dialog Main tab. This allows the user to select whether or not to run dev mode locally or in a container. It replaces the need for a new “Start in container…“ option.
- Adds configuration filtering based on whether the current action is meant to run in a container or locally.
- Re-defines “start…” in the sense that it now opes the run configurations dialog for user customization.
- Updates the error/warning dialog title from "Liberty Dev Mode" to "Liberty Tools"
- Adds unit tests.
