### PR TITLE
Create new config if one does not exist during first project Start...

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
+++ b/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
@@ -266,7 +266,7 @@
       <launchConfigurationType
           name="Liberty"
           delegate="io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher"
-          modes="run, debug"
+          modes="run"
           id="io.openliberty.tools.eclipse.launch.type">
       </launchConfigurationType>
   </extension>
@@ -290,7 +290,7 @@
           icon="icons/openLibertyLogo.png"
           id="io.openliberty.tools.eclipse.launch.start.shortcut"
           label="Liberty Start"
-          modes="run, debug"
+          modes="run"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group1"
           description="Launches the associated project on Liberty using dev mode">
           <contextualLaunch>
@@ -312,7 +312,7 @@
           icon="icons/openLibertyLogo.png"
           id="io.openliberty.tools.eclipse.launch.start.config.shortcut"
           label="Liberty Start..."
-          modes="run, debug"
+          modes="run"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group1"
           description="Launches the configuration dialog to run the associated project on Liberty using dev mode">
           <contextualLaunch>
@@ -334,7 +334,7 @@
           icon="icons/openLibertyLogo.png"
           id="io.openliberty.tools.eclipse.launch.start.container.shortcut"
           label="Liberty Start in Container"
-          modes="run, debug"
+          modes="run"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group1"
           description="Launches the associated project in a container on Liberty using dev mode">
           <contextualLaunch>
@@ -357,7 +357,7 @@
           id="io.openliberty.tools.eclipse.launch.stop.shortcut"
           label="Liberty Stop"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group1"
-          modes="run, debug"
+          modes="run"
           description="Launches a request to stop the associated project">
           <contextualLaunch>
               <enablement>
@@ -378,7 +378,7 @@
           icon="icons/openLibertyLogo.png"
           id="io.openliberty.tools.eclipse.launch.run.tests.shortcut"
           label="Liberty Run Tests"
-          modes="run, debug"
+          modes="run"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group2"
           description="Launches a request to run the tests provided by the associated project">
           <contextualLaunch>
@@ -400,7 +400,7 @@
           icon="icons/openLibertyLogo.png"
           id="io.openliberty.tools.eclipse.launch.maven.itest.report.shortcut"
           label="Liberty View Integration Test Report"
-          modes="run,debug"
+          modes="run"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group2"
           description="Launches a request to display the integration test reports for the associated project">
           <contextualLaunch>
@@ -423,7 +423,7 @@
           icon="icons/openLibertyLogo.png"
           id="io.openliberty.tools.eclipse.launch.maven.utest.report.shortcut"
           label="Liberty View Unit Test Report"
-          modes="run,debug"
+          modes="run"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group2"
           description="Launches a request to display the unit test reports for the associated project">
           <contextualLaunch>
@@ -446,7 +446,7 @@
           icon="icons/openLibertyLogo.png"
           id="io.openliberty.tools.eclipse.launch.gradle.test.report.shortcut"
           label="Liberty View Test Report"
-          modes="run,debug"
+          modes="run"
           path="io.openliberty.tools.eclipse.launch.shortcuts.group2"
           description="Launches a request to display the test reports for the associated project">
           <contextualLaunch>

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
@@ -15,6 +15,7 @@ package io.openliberty.tools.eclipse.ui.dashboard;
 import java.net.URL;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
@@ -39,8 +40,8 @@ import io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenMavenITestReportActi
 import io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenMavenUTestReportAction;
 import io.openliberty.tools.eclipse.ui.launch.shortcuts.RunTestsAction;
 import io.openliberty.tools.eclipse.ui.launch.shortcuts.StartAction;
-import io.openliberty.tools.eclipse.ui.launch.shortcuts.StartInContainerAction;
 import io.openliberty.tools.eclipse.ui.launch.shortcuts.StartConfigurationDialogAction;
+import io.openliberty.tools.eclipse.ui.launch.shortcuts.StartInContainerAction;
 import io.openliberty.tools.eclipse.ui.launch.shortcuts.StopAction;
 import io.openliberty.tools.eclipse.utils.Dialog;
 
@@ -213,9 +214,9 @@ public class DashboardView extends ViewPart {
         startAction = new Action(APP_MENU_ACTION_START) {
             @Override
             public void run() {
-                IProject iproject = devModeOps.getSelectedDashboardProject();
+                IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    StartAction.run(iproject, null, "run");
+                    StartAction.run(iProject, null, ILaunchManager.RUN_MODE);
                 } catch (Exception e) {
                     String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_START + " action.";
                     if (Trace.isEnabled()) {
@@ -236,7 +237,16 @@ public class DashboardView extends ViewPart {
         startConfigDialogAction = new Action(APP_MENU_ACTION_START_CONFIG) {
             @Override
             public void run() {
-                StartConfigurationDialogAction.openLaunchConfigurationsDialog();
+                IProject iProject = devModeOps.getSelectedDashboardProject();
+                try {
+                    StartConfigurationDialogAction.run(iProject, ILaunchManager.RUN_MODE);
+                } catch (Exception e) {
+                    String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_START_CONFIG + " action.";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                    Dialog.displayErrorMessageWithDetails(msg, e);
+                }
             }
         };
         startConfigDialogAction.setImageDescriptor(ActionImg);
@@ -248,9 +258,9 @@ public class DashboardView extends ViewPart {
         startInContainerAction = new Action(APP_MENU_ACTION_START_IN_CONTAINER) {
             @Override
             public void run() {
-                IProject iproject = devModeOps.getSelectedDashboardProject();
+                IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    StartInContainerAction.run(iproject, null, "run");
+                    StartInContainerAction.run(iProject, null, ILaunchManager.RUN_MODE);
                 } catch (Exception e) {
                     String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_START_IN_CONTAINER
                             + " action.";
@@ -270,9 +280,9 @@ public class DashboardView extends ViewPart {
         stopAction = new Action(APP_MENU_ACTION_STOP) {
             @Override
             public void run() {
-                IProject iproject = devModeOps.getSelectedDashboardProject();
+                IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    StopAction.run(iproject);
+                    StopAction.run(iProject);
                 } catch (Exception e) {
                     String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_STOP + " action.";
                     if (Trace.isEnabled()) {
@@ -291,9 +301,9 @@ public class DashboardView extends ViewPart {
         runTestAction = new Action(APP_MENU_ACTION_RUN_TESTS) {
             @Override
             public void run() {
-                IProject iproject = devModeOps.getSelectedDashboardProject();
+                IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    RunTestsAction.run(iproject);
+                    RunTestsAction.run(iProject);
                 } catch (Exception e) {
                     String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_RUN_TESTS + " action.";
                     if (Trace.isEnabled()) {
@@ -312,9 +322,9 @@ public class DashboardView extends ViewPart {
         viewMavenITestReportsAction = new Action(APP_MENU_ACTION_VIEW_MVN_IT_REPORT) {
             @Override
             public void run() {
-                IProject iproject = devModeOps.getSelectedDashboardProject();
+                IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    OpenMavenITestReportAction.run(iproject);
+                    OpenMavenITestReportAction.run(iProject);
                 } catch (Exception e) {
                     String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_VIEW_MVN_IT_REPORT
                             + " action.";
@@ -334,9 +344,9 @@ public class DashboardView extends ViewPart {
         viewMavenUTestReportsAction = new Action(APP_MENU_ACTION_VIEW_MVN_UT_REPORT) {
             @Override
             public void run() {
-                IProject iproject = devModeOps.getSelectedDashboardProject();
+                IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    OpenMavenUTestReportAction.run(iproject);
+                    OpenMavenUTestReportAction.run(iProject);
                 } catch (Exception e) {
                     String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT
                             + " action.";
@@ -356,9 +366,9 @@ public class DashboardView extends ViewPart {
         viewGradleTestReportsAction = new Action(APP_MENU_ACTION_VIEW_GRADLE_TEST_REPORT) {
             @Override
             public void run() {
-                IProject iproject = devModeOps.getSelectedDashboardProject();
+                IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    OpenGradleTestReportAction.run(iproject);
+                    OpenGradleTestReportAction.run(iProject);
                 } catch (Exception e) {
                     String msg = "An error was detected while performing the " + DashboardView.APP_MENU_ACTION_VIEW_GRADLE_TEST_REPORT
                             + " action.";

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
@@ -12,11 +12,19 @@
 *******************************************************************************/
 package io.openliberty.tools.eclipse.ui.launch;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.LaunchConfigurationDelegate;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
@@ -53,6 +61,11 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
     public static final String LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT = "Liberty View Unit Test Report";
     public static final String LAUNCH_SHORTCUT_GRADLE_VIEW_TEST_REPORT = "Liberty View Test Report";
 
+    /** Runtime environments */
+    public static enum RuntimeEnv {
+        UNKNOWN, LOCAL, CONTAINER
+    }
+
     /**
      * {@inheritDocs}
      */
@@ -81,5 +94,154 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
                 }
             }
         });
+    }
+
+    /**
+     * Returns the configuration to be used by the project associated with the action being processed.
+     * 
+     * @param iProject The project for which the configuration will be returned. It must not be null.
+     * @param mode The launch mode.
+     * @param container The indicator of whether or not the caller is running in a container. If true, It allows multiple
+     *        configurations associated to a single project to be filtered based on whether or not the configuration was previously
+     *        used to run the project in a container.
+     * 
+     * @return The configuration to be used by the project associated with the action being processed.
+     * 
+     * @throws Exception
+     */
+    public static ILaunchConfiguration getLaunchConfiguration(IProject iProject, String mode, RuntimeEnv runtimeEnv) throws Exception {
+        ILaunchConfiguration configuration = null;
+        ILaunchManager iLaunchMgr = DebugPlugin.getDefault().getLaunchManager();
+        ILaunchConfigurationType iLaunchConfigType = iLaunchMgr
+                .getLaunchConfigurationType(LaunchConfigurationDelegateLauncher.LAUNCH_CONFIG_TYPE_ID);
+
+        // Find the set of configurations that were used by the currently active project last.
+        ILaunchConfiguration[] existingConfigs = iLaunchMgr.getLaunchConfigurations(iLaunchConfigType);
+
+        List<ILaunchConfiguration> matchingConfigList = LaunchConfigurationDelegateLauncher.filterLaunchConfigurations(existingConfigs,
+                iProject.getName(), runtimeEnv);
+
+        switch (matchingConfigList.size()) {
+        case 0:
+            // Create a new configuration.
+            String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
+            ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
+            workingCopy.setAttribute(MainTab.PROJECT_NAME, iProject.getName());
+            workingCopy.setAttribute(MainTab.PROJECT_START_PARM, "");
+            workingCopy.setAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
+            configuration = workingCopy.doSave();
+            break;
+
+        case 1:
+            // Return the found configuration.
+            configuration = matchingConfigList.get(0);
+            break;
+        default:
+            // Return the configuration that was run last.
+            configuration = LaunchConfigurationDelegateLauncher.getLastRunConfiguration(matchingConfigList);
+            break;
+        }
+
+        return configuration;
+    }
+
+    /**
+     * Returns a filtered list of launch configurations.
+     * 
+     * @param rawConfigList The raw list of Liberty associated launch configurations to be filtered.
+     * @param projectName The project name to be used as filter.
+     * @param container The processing type to be used as filter.
+     * 
+     * @return A filtered list of launch configurations.
+     * 
+     * @throws Exception
+     */
+    public static List<ILaunchConfiguration> filterLaunchConfigurations(ILaunchConfiguration[] rawConfigList, String projectName,
+            RuntimeEnv runtimeEnv) throws Exception {
+        ArrayList<ILaunchConfiguration> matchingConfigList = new ArrayList<>();
+        for (ILaunchConfiguration existingConfig : rawConfigList) {
+            String configProjName = existingConfig.getAttribute(MainTab.PROJECT_NAME, "");
+            if (configProjName.isEmpty()) {
+                continue;
+            }
+
+            if (projectName.equals(configProjName)) {
+                boolean configRanInContainer = existingConfig.getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
+                if (runtimeEnv == RuntimeEnv.CONTAINER) {
+                    if (configRanInContainer) {
+                        matchingConfigList.add(existingConfig);
+                    }
+                } else if ((runtimeEnv == RuntimeEnv.LOCAL)) {
+                    if (!configRanInContainer) {
+                        matchingConfigList.add(existingConfig);
+                    }
+                } else if ((runtimeEnv == RuntimeEnv.UNKNOWN)) {
+                    matchingConfigList.add(existingConfig);
+                } else {
+                    String msg = "Invalid Runtime Environment option: " + runtimeEnv;
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg);
+                    }
+                    throw new Exception(msg);
+                }
+            }
+        }
+
+        return matchingConfigList;
+
+    }
+
+    /**
+     * Returns the last run configuration found in the input list of launch configurations.
+     * 
+     * @param launchConfigList The list of launch configurations.
+     * 
+     * @return The last run configuration found in the input list of launch configurations.
+     */
+    public static ILaunchConfiguration getLastRunConfiguration(List<ILaunchConfiguration> launchConfigList) {
+        launchConfigList.sort(new Comparator<ILaunchConfiguration>() {
+
+            /**
+             * Organizes the items in the descending order. If there are more than one entries with equal value that are considered greater
+             * than the others, the one in the first position after the sort is returned in no particular order.
+             */
+            @Override
+            public int compare(ILaunchConfiguration lc1, ILaunchConfiguration lc2) {
+                int rc = 0;
+                try {
+                    long time1 = Long.valueOf(lc1.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
+                    long time2 = Long.valueOf(lc2.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
+                    rc = (time2 > time1) ? 1 : -1;
+                } catch (Exception e) {
+                    String msg = "An error occurred while trying to determine which configuration ran last. Configuration list: "
+                            + launchConfigList;
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                    }
+                }
+
+                return rc;
+            }
+        });
+
+        return launchConfigList.get(0);
+    }
+
+    /**
+     * Persists the configuration processing time in the configuration itself.
+     * 
+     * @param configuration The configuration being processed.
+     */
+    public static void saveConfigProcessingTime(ILaunchConfiguration configuration) {
+        try {
+            ILaunchConfigurationWorkingCopy configWorkingCopy = configuration.getWorkingCopy();
+            configWorkingCopy.setAttribute(MainTab.PROJECT_RUN_TIME, String.valueOf(System.currentTimeMillis()));
+            configWorkingCopy.doSave();
+        } catch (Exception e) {
+            // Log it and move on.
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_UI, "Unable to set time for configuration " + configuration.getName(), e);
+            }
+        }
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -12,16 +12,8 @@
 *******************************************************************************/
 package io.openliberty.tools.eclipse.ui.launch.shortcuts;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-
 import org.eclipse.core.resources.IProject;
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationType;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.ui.ILaunchShortcut;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IEditorPart;
@@ -29,6 +21,7 @@ import org.eclipse.ui.IEditorPart;
 import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
+import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
 import io.openliberty.tools.eclipse.ui.launch.MainTab;
 import io.openliberty.tools.eclipse.utils.Dialog;
 import io.openliberty.tools.eclipse.utils.Utils;
@@ -92,10 +85,11 @@ public class StartAction implements ILaunchShortcut {
         devModeOps.verifyProjectSupport(iProject);
 
         // If the configuration was not provided by the caller, determine what configuration to use.
-        ILaunchConfiguration configuration = (iConfiguration != null) ? iConfiguration : getLaunchConfiguration(iProject, mode, false);
+        ILaunchConfiguration configuration = (iConfiguration != null) ? iConfiguration
+                : LaunchConfigurationDelegateLauncher.getLaunchConfiguration(iProject, mode, RuntimeEnv.LOCAL);
 
         // Save the time when this configuration was processed.
-        saveConfigProcessingTime(configuration);
+        LaunchConfigurationDelegateLauncher.saveConfigProcessingTime(configuration);
 
         // Retrieve configuration data.
         boolean runInContainer = configuration.getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
@@ -106,146 +100,6 @@ public class StartAction implements ILaunchShortcut {
             devModeOps.startInContainer(iProject, startParms);
         } else {
             devModeOps.start(iProject, startParms);
-        }
-    }
-
-    /**
-     * Returns the configuration to be used by the project associated with the action being processed.
-     * 
-     * @param iProject The project for which the configuration will be returned. It must not be null.
-     * @param mode The launch mode.
-     * @param container The indicator of whether or not the caller is running in a container. If true, It allows multiple
-     *        configurations associated to a single project to be filtered based on whether or not the configuration was previously
-     *        used to run the project in a container.
-     * 
-     * @return The configuration to be used by the project associated with the action being processed.
-     * 
-     * @throws Exception
-     */
-    protected static ILaunchConfiguration getLaunchConfiguration(IProject iProject, String mode, boolean container) throws Exception {
-        ILaunchConfiguration configuration = null;
-        ILaunchManager iLaunchMgr = DebugPlugin.getDefault().getLaunchManager();
-        ILaunchConfigurationType iLaunchConfigType = iLaunchMgr
-                .getLaunchConfigurationType(LaunchConfigurationDelegateLauncher.LAUNCH_CONFIG_TYPE_ID);
-
-        // Find the set of configurations that were used by the currently active project last.
-        ILaunchConfiguration[] existingConfigs = iLaunchMgr.getLaunchConfigurations(iLaunchConfigType);
-
-        List<ILaunchConfiguration> matchingConfigList = filterLaunchConfigurations(existingConfigs, iProject.getName(), container);
-
-        switch (matchingConfigList.size()) {
-        case 0:
-            // Create a new configuration.
-            String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
-            ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
-            workingCopy.setAttribute(MainTab.PROJECT_NAME, iProject.getName());
-            workingCopy.setAttribute(MainTab.PROJECT_START_PARM, "");
-            workingCopy.setAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
-            configuration = workingCopy.doSave();
-            break;
-
-        case 1:
-            // Return the found configuration.
-            configuration = matchingConfigList.get(0);
-            break;
-        default:
-            // Return the configuration that was run last.
-            configuration = getLastRunConfiguration(matchingConfigList);
-            break;
-        }
-
-        return configuration;
-    }
-
-    /**
-     * Returns a filtered list of launch configurations.
-     * 
-     * @param rawConfigList The raw list of Liberty associated launch configurations to be filtered.
-     * @param projectName The project name to be used as filter.
-     * @param container The processing type to be used as filter.
-     * 
-     * @return A filtered list of launch configurations.
-     * 
-     * @throws Exception
-     */
-    public static List<ILaunchConfiguration> filterLaunchConfigurations(ILaunchConfiguration[] rawConfigList, String projectName,
-            boolean container) throws Exception {
-        ArrayList<ILaunchConfiguration> matchingConfigList = new ArrayList<>();
-        for (ILaunchConfiguration existingConfig : rawConfigList) {
-            String configProjName = existingConfig.getAttribute(MainTab.PROJECT_NAME, "");
-            if (configProjName.isEmpty()) {
-                continue;
-            }
-
-            if (projectName.equals(configProjName)) {
-                boolean configRanInContainer = existingConfig.getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
-                if (container) {
-                    if (configRanInContainer) {
-                        matchingConfigList.add(existingConfig);
-                    }
-                } else {
-                    if (!configRanInContainer) {
-                        matchingConfigList.add(existingConfig);
-                    }
-                }
-            }
-        }
-
-        return matchingConfigList;
-
-    }
-
-    /**
-     * Returns the last run configuration found in the input list of launch configurations.
-     * 
-     * @param launchConfigList The list of launch configurations.
-     * 
-     * @return The last run configuration found in the input list of launch configurations.
-     */
-    public static ILaunchConfiguration getLastRunConfiguration(List<ILaunchConfiguration> launchConfigList) {
-        launchConfigList.sort(new Comparator<ILaunchConfiguration>() {
-
-            /**
-             * Organizes the items in the descending order. If there are more than one entries with equal value that are considered greater
-             * than the others, the one in the first position after the sort is returned in no particular order.
-             */
-            @Override
-            public int compare(ILaunchConfiguration lc1, ILaunchConfiguration lc2) {
-                int rc = 0;
-                try {
-                    long time1 = Long.valueOf(lc1.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
-                    long time2 = Long.valueOf(lc2.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
-                    rc = (time2 > time1) ? 1 : -1;
-                } catch (Exception e) {
-                    String msg = "An error occurred while trying to determine which configuration ran last. Configuration list: "
-                            + launchConfigList;
-                    if (Trace.isEnabled()) {
-                        Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
-                    }
-                }
-
-                return rc;
-            }
-        });
-
-        return launchConfigList.get(0);
-    }
-
-    /**
-     * Persists the configuration processing time in the configuration itself.
-     * 
-     * @param configuration The configuration being processed.
-     */
-    protected static void saveConfigProcessingTime(ILaunchConfiguration configuration) {
-        try {
-            ILaunchConfigurationWorkingCopy configWorkingCopy = configuration.getWorkingCopy();
-            configWorkingCopy.setAttribute(MainTab.PROJECT_RUN_TIME, String.valueOf(System.currentTimeMillis()));
-            configWorkingCopy.doSave();
-        } catch (Exception e) {
-            // Log it and move on.
-            if (Trace.isEnabled()) {
-                Trace.getTracer().trace(Trace.TRACE_UI, "Unable to set time for configuration " + configuration.getName(), e);
-            }
         }
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
@@ -21,6 +21,7 @@ import org.eclipse.ui.IEditorPart;
 import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
+import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
 import io.openliberty.tools.eclipse.ui.launch.MainTab;
 import io.openliberty.tools.eclipse.utils.Dialog;
 import io.openliberty.tools.eclipse.utils.Utils;
@@ -88,10 +89,10 @@ public class StartInContainerAction implements ILaunchShortcut {
 
         // If the configuration was not provided by the caller, determine what configuration to use.
         ILaunchConfiguration configuration = (iConfiguration != null) ? iConfiguration
-                : StartAction.getLaunchConfiguration(iProject, mode, true);
+                : LaunchConfigurationDelegateLauncher.getLaunchConfiguration(iProject, mode, RuntimeEnv.CONTAINER);
 
         // Save the time when this configuration was processed.
-        StartAction.saveConfigProcessingTime(configuration);
+        LaunchConfigurationDelegateLauncher.saveConfigProcessingTime(configuration);
 
         // Process the action.
         String startParms = configuration.getAttribute(MainTab.PROJECT_START_PARM, (String) null);

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -205,11 +205,12 @@ public class LibertyPluginSWTBotGradleTest {
         Assertions.assertTrue(runAslibertyToolsEntry != null, "Liberty entry in Run Configurations view was not found.");
         bot.button("Close").click();
 
+        // Commented out pending design discussions.
         // Check that the Debug As -> Debug Configurations... contains the Liberty entry in the menu.
-        SWTBotPluginOperations.launchRunConfigurationsDialog(bot, GRADLE_APP_NAME, "debug");
-        SWTBotTreeItem debugAslibertyToolsEntry = SWTBotPluginOperations.getLibertyToolsConfigMenuItem(bot);
-        Assertions.assertTrue(debugAslibertyToolsEntry != null, "Liberty entry in Debug Configurations view was not found.");
-        bot.button("Close").click();
+        // SWTBotPluginOperations.launchRunConfigurationsDialog(bot, GRADLE_APP_NAME, "debug");
+        // SWTBotTreeItem debugAslibertyToolsEntry = SWTBotPluginOperations.getLibertyToolsConfigMenuItem(bot);
+        // Assertions.assertTrue(debugAslibertyToolsEntry != null, "Liberty entry in Debug Configurations view was not found.");
+        // bot.button("Close").click();
     }
 
     /**
@@ -513,6 +514,7 @@ public class LibertyPluginSWTBotGradleTest {
      * Tests the start action initiated through: project -> Debug As -> Debug Configurations -> Liberty -> New configuration
      * (customized) -> Run.
      */
+    @Disabled("Disabled pending design discussions")
     @Test
     public void tesStartWithCustomDebugAsConfig() {
         // Delete any previously created configs.
@@ -549,6 +551,7 @@ public class LibertyPluginSWTBotGradleTest {
     /**
      * Tests the start/stop debug as shortcut actions.
      */
+    @Disabled("Disabled pending design discussions")
     @Test
     public void testStartWithDebugAsShortcut() {
         // Delete any previously created configs.

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -220,11 +220,12 @@ public class LibertyPluginSWTBotMavenTest {
         Assertions.assertTrue(runAslibertyToolsEntry != null, "Liberty entry in Run Configurations view was not found.");
         bot.button("Close").click();
 
+        // Commented out pending design discussions.
         // Check that the Debug As -> Debug Configurations... contains the Liberty entry in the menu.
-        SWTBotPluginOperations.launchRunConfigurationsDialog(bot, MVN_APP_NAME, "debug");
-        SWTBotTreeItem debugAslibertyToolsEntry = SWTBotPluginOperations.getLibertyToolsConfigMenuItem(bot);
-        Assertions.assertTrue(debugAslibertyToolsEntry != null, "Liberty entry in Debug Configurations view was not found.");
-        bot.button("Close").click();
+        // SWTBotPluginOperations.launchRunConfigurationsDialog(bot, MVN_APP_NAME, "debug");
+        // SWTBotTreeItem debugAslibertyToolsEntry = SWTBotPluginOperations.getLibertyToolsConfigMenuItem(bot);
+        // Assertions.assertTrue(debugAslibertyToolsEntry != null, "Liberty entry in Debug Configurations view was not found.");
+        // bot.button("Close").click();
     }
 
     @Test
@@ -597,6 +598,7 @@ public class LibertyPluginSWTBotMavenTest {
      * Tests the start action initiated through: project -> Debug As -> Debug Configurations -> Liberty -> New configuration
      * (customized) -> Run.
      */
+    @Disabled("Disabled pending design discussions")
     @Test
     public void tesStartWithCustomDebugAsConfig() {
         // Delete any previously created configs.
@@ -632,6 +634,7 @@ public class LibertyPluginSWTBotMavenTest {
     /**
      * Tests the start/stop debug as shortcut actions.
      */
+    @Disabled("Disabled pending design discussions")
     @Test
     public void testStartWithDebugAsShortcut() {
         // Delete any previously created configs.

--- a/tests/src/io/openliberty/tools/eclipse/test/ut/LibertyPluginUnitTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/ut/LibertyPluginUnitTest.java
@@ -18,8 +18,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
+import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
 import io.openliberty.tools.eclipse.ui.launch.MainTab;
-import io.openliberty.tools.eclipse.ui.launch.shortcuts.StartAction;
 
 public class LibertyPluginUnitTest {
 
@@ -49,8 +50,8 @@ public class LibertyPluginUnitTest {
         List<ILaunchConfiguration> rawCfgList = getDefaultConfigurationList();
 
         // Test 1. Normal run.
-        List<ILaunchConfiguration> filteredListDev = StartAction
-                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", false);
+        List<ILaunchConfiguration> filteredListDev = LaunchConfigurationDelegateLauncher
+                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", RuntimeEnv.LOCAL);
         Assertions.assertTrue(filteredListDev.size() == 3,
                 "The resulting list should have contained 3 entries. List size: " + filteredListDev.size());
         Assertions.assertTrue(filteredListDev.get(0).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, true) == false,
@@ -61,8 +62,8 @@ public class LibertyPluginUnitTest {
                 "The run in container value associated with config entry[2] was not false.");
 
         // test 2. Container run.
-        List<ILaunchConfiguration> filteredListDevc = StartAction
-                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", true);
+        List<ILaunchConfiguration> filteredListDevc = LaunchConfigurationDelegateLauncher.filterLaunchConfigurations(
+                rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", RuntimeEnv.CONTAINER);
         Assertions.assertTrue(filteredListDevc.size() == 3,
                 "The resulting list should have contained 3 entries. Found: " + filteredListDevc.size() + ". List: " + filteredListDevc);
         Assertions.assertTrue(filteredListDevc.get(0).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false) == true,
@@ -81,13 +82,13 @@ public class LibertyPluginUnitTest {
     @Test
     public void testRetrieveLastRunConfig() throws Exception {
         List<ILaunchConfiguration> rawCfgList = getDefaultConfigurationList();
-        List<ILaunchConfiguration> filteredListDev = StartAction
-                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", false);
+        List<ILaunchConfiguration> filteredListDev = LaunchConfigurationDelegateLauncher
+                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", RuntimeEnv.LOCAL);
         Assertions.assertTrue(filteredListDev.size() == 3,
                 "The resulting list should have contained 3 entries. List size: " + filteredListDev.size());
 
         // Test 1. Normal run.
-        ILaunchConfiguration lastRunConfigDev = StartAction.getLastRunConfiguration(filteredListDev);
+        ILaunchConfiguration lastRunConfigDev = LaunchConfigurationDelegateLauncher.getLastRunConfiguration(filteredListDev);
 
         String cfgNameFoundDev = lastRunConfigDev.getName();
         String expectedCfgNameDev = "test2";
@@ -100,12 +101,12 @@ public class LibertyPluginUnitTest {
                 "The configuration found does not contain the expected value of " + expectedTimeDev + ". Time found: " + timeFoundDev);
 
         // Test 2. Container run.
-        List<ILaunchConfiguration> filteredListDevc = StartAction
-                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", true);
+        List<ILaunchConfiguration> filteredListDevc = LaunchConfigurationDelegateLauncher.filterLaunchConfigurations(
+                rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", RuntimeEnv.CONTAINER);
         Assertions.assertTrue(filteredListDevc.size() == 3,
                 "The resulting list should have contained 3 entries. List size: " + filteredListDevc.size());
 
-        ILaunchConfiguration lastRunConfigDevc = StartAction.getLastRunConfiguration(filteredListDevc);
+        ILaunchConfiguration lastRunConfigDevc = LaunchConfigurationDelegateLauncher.getLastRunConfiguration(filteredListDevc);
 
         String cfgNameFoundDevc = lastRunConfigDevc.getName();
         String expectedCfgNameDevc = "test6";
@@ -118,12 +119,12 @@ public class LibertyPluginUnitTest {
                 "The configuration found does not contain the expected value of " + expectedTimeDevc + ". Time found: " + timeFoundDevc);
 
         // Test 3: Normal run. Configurations with equal minimum time. Configuration with max time expected.
-        List<ILaunchConfiguration> filteredListT3Dev = StartAction
-                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project2", false);
+        List<ILaunchConfiguration> filteredListT3Dev = LaunchConfigurationDelegateLauncher
+                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project2", RuntimeEnv.LOCAL);
         Assertions.assertTrue(filteredListT3Dev.size() == 3,
                 "The resulting list should have contained 3 entries. List size: " + filteredListT3Dev.size());
 
-        ILaunchConfiguration lastRunConfigT3Dev = StartAction.getLastRunConfiguration(filteredListT3Dev);
+        ILaunchConfiguration lastRunConfigT3Dev = LaunchConfigurationDelegateLauncher.getLastRunConfiguration(filteredListT3Dev);
 
         String cfgNameFoundT3Dev = lastRunConfigT3Dev.getName();
         String expectedCfgNameT3Dev = "test11";
@@ -132,18 +133,31 @@ public class LibertyPluginUnitTest {
 
         // Test 4: Container run. Configurations with equal max time. One of the max times is returned.
         // In this particular case, is the second entry after the entries are sorted.
-        List<ILaunchConfiguration> filteredListT4Devc = StartAction
-                .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project3", true);
+        List<ILaunchConfiguration> filteredListT4Devc = LaunchConfigurationDelegateLauncher.filterLaunchConfigurations(
+                rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project3", RuntimeEnv.CONTAINER);
         Assertions.assertTrue(filteredListT4Devc.size() == 3,
                 "The resulting list should have contained 3 entries. List size: " + filteredListT4Devc.size());
 
-        ILaunchConfiguration lastRunConfigT4Devc = StartAction.getLastRunConfiguration(filteredListT4Devc);
+        ILaunchConfiguration lastRunConfigT4Devc = LaunchConfigurationDelegateLauncher.getLastRunConfiguration(filteredListT4Devc);
 
         String cfgNameFoundT4Devc = lastRunConfigT4Devc.getName();
         String expectedCfgNameT4Devc = "test16";
         Assertions.assertTrue(expectedCfgNameT4Devc.equals(cfgNameFoundT4Devc), "The expected configuration of " + expectedCfgNameT4Devc
                 + " was not returned. Configuration returned:: " + cfgNameFoundT4Devc);
 
+        // Test 5: This is the start... case where we do not really know the runtime environment to be used to run dev mode.
+        // In this case, it is expected that the configuration that ran last irrespective of runtime environment should be returned.
+        List<ILaunchConfiguration> filteredListT5Dev = LaunchConfigurationDelegateLauncher.filterLaunchConfigurations(
+                rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", RuntimeEnv.UNKNOWN);
+        Assertions.assertTrue(filteredListT5Dev.size() == 6,
+                "The resulting list should have contained 6 entries. List size: " + filteredListT5Dev.size());
+
+        ILaunchConfiguration lastRunConfigT5Dev = LaunchConfigurationDelegateLauncher.getLastRunConfiguration(filteredListT5Dev);
+
+        String cfgNameFoundT5Dev = lastRunConfigT5Dev.getName();
+        String expectedCfgNameT5Dev = "test6";
+        Assertions.assertTrue(expectedCfgNameT5Dev.equals(cfgNameFoundT5Dev), "The expected configuration of " + expectedCfgNameT5Dev
+                + " was not returned. Configuration returned:: " + cfgNameFoundT5Dev);
     }
 
     private List<ILaunchConfiguration> getDefaultConfigurationList() throws CoreException {


### PR DESCRIPTION
With this PR:
- A new configuration is created on custom start if there isn't one that is already associated with the project.
- Temporarily remove custom UI Debug As configuration entries.