### PR TITLE
Use java.home for launching LS processes 

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/jakarta/languageserver/JakartaLSConnection.java
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/jakarta/languageserver/JakartaLSConnection.java
@@ -79,15 +79,9 @@ public class JakartaLSConnection extends ProcessStreamConnectionProvider {
     }
 
     private String computeJavaPath() {
-        String javaPath = "java";
-        boolean existsInPath = Stream.of(System.getenv("PATH").split(Pattern.quote(File.pathSeparator))).map(Paths::get)
-                .anyMatch(path -> Files.exists(path.resolve("java")));
-        if (!existsInPath) {
-            File f = new File(System.getProperty("java.home"),
-                    "bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : ""));
-            javaPath = f.getAbsolutePath();
-        }
-        return javaPath;
+        File f = new File(System.getProperty("java.home"),
+                "bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : ""));
+        return f.getAbsolutePath();
     }
 
     @Override

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/liberty/languageserver/LibertyLSConnection.java
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/liberty/languageserver/LibertyLSConnection.java
@@ -68,15 +68,9 @@ public class LibertyLSConnection extends ProcessStreamConnectionProvider {
 	}
 	
 	private String computeJavaPath() {
-		String javaPath = "java";
-		boolean existsInPath = Stream.of(System.getenv("PATH").split(Pattern.quote(File.pathSeparator))).map(Paths::get)
-				.anyMatch(path -> Files.exists(path.resolve("java")));
-		if (!existsInPath) {
-			File f = new File(System.getProperty("java.home"),
-					"bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : ""));
-			javaPath = f.getAbsolutePath();
-		}
-		return javaPath;
+		 File f = new File(System.getProperty("java.home"),
+                "bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : ""));
+         return f.getAbsolutePath();
 	}
 
 	@Override

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/mpls/LibertyMPLSConnection.java
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/mpls/LibertyMPLSConnection.java
@@ -68,15 +68,9 @@ public class LibertyMPLSConnection extends ProcessStreamConnectionProvider {
 	}
 	
 	private String computeJavaPath() {
-		String javaPath = "java";
-		boolean existsInPath = Stream.of(System.getenv("PATH").split(Pattern.quote(File.pathSeparator))).map(Paths::get)
-				.anyMatch(path -> Files.exists(path.resolve("java")));
-		if (!existsInPath) {
-			File f = new File(System.getProperty("java.home"),
-					"bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : ""));
-			javaPath = f.getAbsolutePath();
-		}
-		return javaPath;
+		File f = new File(System.getProperty("java.home"),
+				"bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : ""));
+		return f.getAbsolutePath();
 	}
 
 	@Override


### PR DESCRIPTION
Signed-off-by: Adam Wisniewski <awisniew@us.ibm.com>

The java.home property will be set with the JRE used to launch Eclipse