### PR TITLE
Dispose of image tab properly.

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/MainTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/MainTab.java
@@ -52,6 +52,9 @@ public class MainTab extends AbstractLaunchConfigurationTab {
     /** Configuration map key with a value stating whether or not the associated project ran in a container. */
     public static final String PROJECT_RUN_IN_CONTAINER = "io.openliberty.tools.eclipse.launch.project.container.run";
 
+    /** Tab image */
+    Image image;
+
     /** Currently active project. */
     IProject activeProject;
 
@@ -60,6 +63,13 @@ public class MainTab extends AbstractLaunchConfigurationTab {
 
     /** Holds the run in container check box. */
     private Button runInContainerCheckBox;
+
+    /**
+     * Constructor.
+     */
+    public MainTab() {
+        image = Utils.getLibertyImage(PlatformUI.getWorkbench().getDisplay());
+    }
 
     /**
      * {@inheritDoc}
@@ -186,6 +196,16 @@ public class MainTab extends AbstractLaunchConfigurationTab {
      */
     @Override
     public Image getImage() {
-        return Utils.getLibertyImage(PlatformUI.getWorkbench().getDisplay());
+        return image;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void dispose() {
+        if (image != null) {
+            image.dispose();
+        }
     }
 }


### PR DESCRIPTION
This PR properly disposes of the image when the configuration dialog is closed.

It fixes this error:

java.lang.Error: SWT Resource was not properly disposed
        at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
        at org.eclipse.swt.graphics.Resource.<init>(Resource.java:120)
        at org.eclipse.swt.graphics.Image.<init>(Image.java:684)
        at io.openliberty.tools.eclipse.utils.Utils.getLibertyImage(Utils.java:57)
        at io.openliberty.tools.eclipse.ui.launch.MainTab.getImage(MainTab.java:192)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationTabGroupViewer.refresh(LaunchConfigurationTabGroupViewer.java:539)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationsDialog.updateButtons(LaunchConfigurationsDialog.java:1630)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationsDialog.refreshStatus(LaunchConfigurationsDialog.java:1331)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationTabGroupViewer.refreshStatus(LaunchConfigurationTabGroupViewer.java:1118)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationTabGroupViewer.lambda$4(LaunchConfigurationTabGroupViewer.java:739)
        at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:74)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationTabGroupViewer.inputChanged(LaunchConfigurationTabGroupViewer.java:743)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationTabGroupViewer.setInput0(LaunchConfigurationTabGroupViewer.java:675)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationTabGroupViewer.setInput(LaunchConfigurationTabGroupViewer.java:655)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationsDialog.handleLaunchConfigurationSelectionChanged(LaunchConfigurationsDialog.java:1049)
        at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationsDialog.lambda$1(LaunchConfigurationsDialog.java:612)
        at org.eclipse.jface.viewers.StructuredViewer$3.run(StructuredViewer.java:821)
...