### PR TITLE
Classify and set Liberty nature upon project import;  Add multi-module aware default start cmd; Show server not aggregate module in dashboard

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
+++ b/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
@@ -14,6 +14,10 @@
 <?eclipse version="3.4"?>
 <plugin>
 
+   <extension point="org.eclipse.ui.startup">
+      <startup class="io.openliberty.tools.eclipse.ui.dashboard.ImportListener"/>
+   </extension>
+
    <!-- Contexts -->
    <extension point="org.eclipse.ui.contexts">
       <context

--- a/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
+++ b/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
@@ -15,7 +15,7 @@
 <plugin>
 
    <extension point="org.eclipse.ui.startup">
-      <startup class="io.openliberty.tools.eclipse.ui.dashboard.ImportListener"/>
+      <startup class="io.openliberty.tools.eclipse.EarlyStartupRegistration"/>
    </extension>
 
    <!-- Contexts -->

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
@@ -61,28 +61,31 @@ public class Dashboard {
         ConcurrentHashMap<String, Project> projects = new ConcurrentHashMap<String, Project>();
 
         for (IProject iProject : iProjects) {
-            projects.put(iProject.getLocation().toOSString(), new Project(iProject));
+            if (iProject.isOpen()) {
+                projects.put(iProject.getLocation().toOSString(), new Project(iProject));
+            }
         }
 
         try {
             for (IProject iProject : iProjects) {
                 boolean multimodSet = false;
+                if (iProject.isOpen()) {
+                    for (IResource res : iProject.members()) {
+                        if (res.getType() == IResource.FOLDER) {
+                            IFolder folder = ((IFolder) res);
+                            IFile file = folder.getFile(".project");
+                            if (file.exists()) {
+                                if (!multimodSet) {
+                                    projects.get(iProject.getLocation().toOSString()).setMultimodule(true);
+                                    multimodSet = true;
+                                }
 
-                for (IResource res : iProject.members()) {
-                    if (res.getType() == IResource.FOLDER) {
-                        IFolder folder = ((IFolder) res);
-                        IFile file = folder.getFile(".project");
-                        if (file.exists()) {
-                            if (!multimodSet) {
-                                projects.get(iProject.getLocation().toOSString()).setMultimodule(true);
-                                multimodSet = true;
-                            }
+                                String resLocation = res.getLocation().toOSString();
+                                Project matchLocProj = projects.get(resLocation);
 
-                            String resLocation = res.getLocation().toOSString();
-                            Project matchLocProj = projects.get(resLocation);
-
-                            if (matchLocProj != null) {
-                                projects.remove(resLocation);
+                                if (matchLocProj != null) {
+                                    projects.remove(resLocation);
+                                }
                             }
                         }
                     }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
-*
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v. 2.0 which is available at
-* http://www.eclipse.org/legal/epl-2.0.
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*     IBM Corporation - initial implementation
-*******************************************************************************/
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
 package io.openliberty.tools.eclipse;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -28,152 +28,135 @@ import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.utils.ErrorHandler;
 
 /**
- * Represents the Liberty tools dashboard.
+ * Represents the Liberty tools dashboard and the project model behind it.
  */
 public class Dashboard {
 
-    /**
-     * Maven projects displayed on the dashboard.
-     */
-    public ConcurrentHashMap<String, Project> mavenProjects;
-
-    /**
-     * Gradle projects displayed on the dashboard.
-     */
-    public ConcurrentHashMap<String, Project> gradleProjects;
+    private Map<String, Project> projectsByLocation;
+    private Map<String, Project> projectsByName;
 
     /**
      * Constructor.
      */
     public Dashboard() {
-        mavenProjects = new ConcurrentHashMap<String, Project>();
-        gradleProjects = new ConcurrentHashMap<String, Project>();
+        projectsByLocation = new ConcurrentHashMap<String, Project>();
+        projectsByName = new ConcurrentHashMap<String, Project>();
+    }
+
+    private void createProjectModels(List<IProject> projects, boolean classify) {
+        for (IProject iProject : new ArrayList<IProject>(projects)) {
+            if (iProject.isOpen()) {
+                Project projModel = projectsByLocation.get(iProject.getLocation().toOSString());
+                if (projModel == null) {
+                    projModel = new Project(iProject);
+                    projectsByLocation.put(iProject.getLocation().toOSString(), projModel);
+                    projectsByName.put(iProject.getName(), projModel);
+                }
+                if (classify) {
+                    projModel.classify();
+                }
+            }
+        }
     }
 
     /**
-     * Retrieves a map of suitable projects from the workspace.
-     *
-     * @return A map projects from the workspace that are each themselves NOT nested/contained in another workspace project
+     * Build model
+     * 
+     * @param whether to classify or not
      */
-    private Map<String, Project> getTopLevelWorkspaceProjects() {
+    public void buildCompleteWorkspaceModel(boolean classify) {
         IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
         IProject[] iProjects = workspaceRoot.getProjects();
-        ConcurrentHashMap<String, Project> projects = new ConcurrentHashMap<String, Project>();
+        buildMultiProjectModel(Arrays.asList(iProjects), classify);
+    }
 
-        for (IProject iProject : iProjects) {
-            if (iProject.isOpen()) {
-                projects.put(iProject.getLocation().toOSString(), new Project(iProject));
-            }
-        }
+    public void buildMultiProjectModel(List<IProject> projectsToScan, boolean classify) {
+
+        createProjectModels(projectsToScan, classify);
 
         try {
-            for (IProject iProject : iProjects) {
-                boolean multimodSet = false;
-                if (iProject.isOpen()) {
-                    for (IResource res : iProject.members()) {
-                        if (res.getType() == IResource.FOLDER) {
-                            IFolder folder = ((IFolder) res);
-                            IFile file = folder.getFile(".project");
-                            if (file.exists()) {
-                                if (!multimodSet) {
-                                    projects.get(iProject.getLocation().toOSString()).setMultimodule(true);
-                                    multimodSet = true;
-                                }
-
-                                String resLocation = res.getLocation().toOSString();
-                                Project matchLocProj = projects.get(resLocation);
-
-                                if (matchLocProj != null) {
-                                    projects.remove(resLocation);
-                                }
-                            }
+            for (IProject iProject : projectsToScan) {
+                for (IResource res : iProject.members()) {
+                    if (res.getType() == IResource.FOLDER) {
+                        String resLocation = res.getLocation().toOSString();
+                        Project child = projectsByLocation.get(resLocation);
+                        if (child != null) {
+                            Project parent = projectsByLocation.get(iProject.getLocation().toOSString());
+                            child.setParentDirProject(parent);
+                            parent.addChildDirProject(child);
                         }
                     }
                 }
             }
         } catch (Exception e) {
-            String msg = "An error occurred while searching for top level projects in the workspace.";
+            String msg = "An error occurred while analyzing projects in the workspace.";
             if (Trace.isEnabled()) {
-                Trace.getTracer().trace(Trace.TRACE_UTILS, msg + " Workspace projects: " + iProjects, e);
+                Trace.getTracer().trace(Trace.TRACE_UTILS, msg + " Workspace projects: " + projectsByLocation.values(), e);
             }
             ErrorHandler.processWarningMessage(msg, e, false);
         }
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().trace(Trace.TRACE_UTILS, "Projects: " + projects);
+            Trace.getTracer().trace(Trace.TRACE_UTILS, "Projects: " + projectsByLocation.values());
         }
-
-        return projects;
     }
 
     /**
-     * Returns the project associated with the input name or null if none is found.
+     * Returns the Liberty server project associated with the input name or null if none is found.
      * 
-     * @param name The name of the project.
+     * @param name The name of the project (not the location)
      * 
-     * @return The project associated with the input name or null if none is found.
+     * @return The project associated with the input name or null if none is found. (Note that 'null' may be returned because this is
+     *         not a server project).
      */
-    public Project getProject(String name) {
-        Project p = mavenProjects.get(name);
-        if (p == null) {
-            p = gradleProjects.get(name);
+    public Project getLibertyServerProject(String name) {
+        Project proj = projectsByName.get(name);
+        if (proj != null && proj.isLibertyServerModule()) {
+            return proj;
         }
-        return p;
+        return null;
     }
 
-    /**
-     * Retrieves and caches the set of installed projects that are to appear on the dashboard.
-     *
-     * @throws Exception
-     */
-    public void retrieveSupportedProjects() throws Exception {
-        if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UTILS);
-        }
+    public List<String> getSortedDashboardProjectList() {
 
-        Map<String, Project> projectList = getTopLevelWorkspaceProjects();
-        ConcurrentHashMap<String, Project> finalMavenContent = new ConcurrentHashMap<String, Project>();
-        ConcurrentHashMap<String, Project> finalGradleContent = new ConcurrentHashMap<String, Project>();
-        for (Project p : projectList.values()) {
-            if (p.isSupported()) {
-                String projectName = p.getIProject().getName();
+        List<String> mavenDashboardProjects = new ArrayList<String>();
+        List<String> gradleDashboardProjects = new ArrayList<String>();
+        List<String> retVal = new ArrayList<String>();
+
+        for (Project p : projectsByName.values()) {
+            if (p.isLibertyServerModule()) {
                 if (p.getBuildType() == Project.BuildType.MAVEN) {
-                    finalMavenContent.put(projectName, p);
+                    mavenDashboardProjects.add(p.getName());
                 } else if (p.getBuildType() == Project.BuildType.GRADLE) {
-                    finalGradleContent.put(projectName, p);
+                    gradleDashboardProjects.add(p.getName());
                 } else {
                     if (Trace.isEnabled()) {
                         Trace.getTracer().trace(Trace.TRACE_UTILS,
-                                "Project " + projectName + " could not be identified as being a Maven or Gradle project.");
+                                "Project " + p.getIProject().getName() + " could not be identified as being a Maven or Gradle project.");
                     }
                 }
             }
         }
+        Collections.sort(mavenDashboardProjects);
+        Collections.sort(gradleDashboardProjects);
 
-        mavenProjects = finalMavenContent;
-        gradleProjects = finalGradleContent;
+        retVal.addAll(mavenDashboardProjects);
+        retVal.addAll(gradleDashboardProjects);
+        return retVal;
 
-        if (Trace.isEnabled()) {
-            Trace.getTracer().traceExit(Trace.TRACE_UTILS, new Object[] { mavenProjects, gradleProjects });
+    }
+
+    public String getDefaultStartParameters(IProject iProject) {
+        Project proj = projectsByName.get(iProject.getName());
+        if (proj.isAggregated()) {
+            return "-f ../pom.xml -am -pl " + getModuleNameSegment(iProject);
+        } else {
+            return "";
         }
     }
 
-    /**
-     * Returns a list of names associated with the Maven projects on the dashboard.
-     * 
-     * @return A list of names associated with the Maven projects on the dashboard.
-     */
-    public List<String> getMavenProjectNames() {
-        return new ArrayList<String>(mavenProjects.keySet());
-    }
-
-    /**
-     * Returns a list of names associated with the Gradle projects on the dashboard.
-     * 
-     * @return A list of names associated with the Gradle projects on the dashboard.
-     */
-    public List<String> getGradleProjectNames() {
-        return new ArrayList<String>(gradleProjects.keySet());
+    public String getModuleNameSegment(IProject iProject) {
+        return iProject.getRawLocation().lastSegment();
     }
 
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Dashboard.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -39,8 +40,6 @@ public class Dashboard {
      * Constructor.
      */
     public Dashboard() {
-        projectsByLocation = new ConcurrentHashMap<String, Project>();
-        projectsByName = new ConcurrentHashMap<String, Project>();
     }
 
     private void createProjectModels(List<IProject> projects, boolean classify) {
@@ -60,17 +59,43 @@ public class Dashboard {
     }
 
     /**
-     * Build model
+     * 
+     */
+    public void buildCompleteWorkspaceModelWithClassify() {
+        buildCompleteWorkspaceModel(true);
+    }
+
+    /**
+     * 
+     */
+    public void buildCompleteWorkspaceModelWithoutClassify() {
+        buildCompleteWorkspaceModel(false);
+    }
+
+    /**
+     * Discard previous model and build new model from open projects
      * 
      * @param whether to classify or not
      */
-    public void buildCompleteWorkspaceModel(boolean classify) {
+    private void buildCompleteWorkspaceModel(boolean classify) {
+
         IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
         IProject[] iProjects = workspaceRoot.getProjects();
-        buildMultiProjectModel(Arrays.asList(iProjects), classify);
+
+        List<IProject> openProjects = Arrays.stream(iProjects).filter(project -> project.isOpen()).collect(Collectors.toList());
+
+        // Start over. Throw away existing model
+        projectsByLocation = new ConcurrentHashMap<String, Project>();
+        projectsByName = new ConcurrentHashMap<String, Project>();
+
+        buildMultiProjectModel(openProjects, classify);
     }
 
-    public void buildMultiProjectModel(List<IProject> projectsToScan, boolean classify) {
+    /**
+     * @param projectsToScan Projects to include in model update
+     * @param classify Whether to classify
+     */
+    private void buildMultiProjectModel(List<IProject> projectsToScan, boolean classify) {
 
         createProjectModels(projectsToScan, classify);
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -121,7 +121,7 @@ public class DevModeOperations {
      */
     public void start(IProject iProject, String parms) {
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, iProject);
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms });
         }
 
         if (iProject == null) {
@@ -870,6 +870,11 @@ public class DevModeOperations {
      * @return The project currently selected or null if one was not found.
      */
     public IProject getSelectedDashboardProject() {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS);
+        }
+
         IProject iProject = null;
         IWorkbenchWindow w = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 
@@ -887,6 +892,10 @@ public class DevModeOperations {
                     }
                 }
             }
+        }
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, iProject);
         }
 
         return iProject;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -17,7 +17,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
@@ -40,9 +39,6 @@ import io.openliberty.tools.eclipse.utils.ErrorHandler;
  * Provides the implementation of all supported dev mode operations.
  */
 public class DevModeOperations {
-
-    // TODO: Dashboard display: Handle the case where the project is configured to be built/run by both
-    // Gradle and Maven at the same time.
 
     /**
      * Constants.
@@ -74,12 +70,21 @@ public class DevModeOperations {
     private static DevModeOperations instance;
 
     /**
+     * DashboardView
+     */
+    private DashboardView dashboardView;
+
+    /**
      * Constructor.
      */
     public DevModeOperations() {
         projectTabController = ProjectTabController.getInstance();
         dashboard = new Dashboard();
         pathEnv = System.getenv("PATH");
+    }
+
+    public Dashboard getDashboard() {
+        return dashboard;
     }
 
     /**
@@ -155,7 +160,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getProject(projectName);
+            project = dashboard.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -244,7 +249,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getProject(projectName);
+            project = dashboard.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -476,7 +481,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getProject(projectName);
+            project = dashboard.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -548,7 +553,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getProject(projectName);
+            project = dashboard.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -619,7 +624,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getProject(projectName);
+            project = dashboard.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -871,7 +876,7 @@ public class DevModeOperations {
                 IStructuredSelection structuredSelection = (IStructuredSelection) selection;
                 Object firstElement = structuredSelection.getFirstElement();
                 if (firstElement instanceof String) {
-                    Project project = dashboard.getProject((String) firstElement);
+                    Project project = dashboard.getLibertyServerProject((String) firstElement);
                     if (project != null) {
                         iProject = project.getIProject();
                     }
@@ -884,37 +889,6 @@ public class DevModeOperations {
     }
 
     /**
-     * Returns a sorted list of projects that are configured to run on Liberty.
-     *
-     * @return A sorted list of projects that are configured to run on Liberty.
-     *
-     * @throws Exception
-     */
-    public List<String> getSupportedProjects() throws Exception {
-        dashboard.retrieveSupportedProjects();
-        List<String> mvnProjs = dashboard.getMavenProjectNames();
-        Collections.sort(mvnProjs);
-        List<String> gradleProjs = dashboard.getGradleProjectNames();
-        Collections.sort(gradleProjs);
-
-        ArrayList<String> sortedProjects = new ArrayList<String>();
-        sortedProjects.addAll(mvnProjs);
-        sortedProjects.addAll(gradleProjs);
-        return sortedProjects;
-    }
-
-    /**
-     * Returns the project associated with the input name.
-     * 
-     * @param name The name of the project.
-     * 
-     * @return The project associated with the input name.
-     */
-    public Project getSupportedProject(String name) {
-        return dashboard.getProject(name);
-    }
-
-    /**
      * Verifies that the input project is known to the plugin and that it is a supported project.
      * 
      * @param iProject The project to validate. If null, this operation is a no-op.
@@ -924,15 +898,18 @@ public class DevModeOperations {
     public void verifyProjectSupport(IProject iProject) throws Exception {
         if (iProject != null) {
             String projectName = iProject.getName();
-            Project project = getSupportedProject(projectName);
+            Project project = dashboard.getLibertyServerProject(projectName);
             if (project == null) {
-                getSupportedProjects();
-                project = getSupportedProject(iProject.getName());
-                if (project == null) {
-                    throw new Exception(
-                            "Project " + projectName + " is not a supported project. Make sure the project is a Liberty project.");
-                }
+                throw new Exception("Project " + projectName + " is not a supported project. Make sure the project is a Liberty project.");
             }
         }
+    }
+
+    public DashboardView getDashboardView() {
+        return dashboardView;
+    }
+
+    public void setDashboardView(DashboardView dashboardView) {
+        this.dashboardView = dashboardView;
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -57,7 +57,7 @@ public class DevModeOperations {
     /**
      * Dashboard object reference.
      */
-    private Dashboard dashboard;
+    private WorkspaceProjectsModel projectModel;
 
     /**
      * PATH environment variable.
@@ -79,12 +79,17 @@ public class DevModeOperations {
      */
     public DevModeOperations() {
         projectTabController = ProjectTabController.getInstance();
-        dashboard = new Dashboard();
+        projectModel = new WorkspaceProjectsModel();
         pathEnv = System.getenv("PATH");
     }
 
-    public Dashboard getDashboard() {
-        return dashboard;
+    /**
+     * Because the current class is used as a singleton this effectively provides a singleton for the model object returned
+     * 
+     * @return a complete model of the projects in the workspace
+     */
+    public WorkspaceProjectsModel getProjectModel() {
+        return projectModel;
     }
 
     /**
@@ -160,7 +165,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getLibertyServerProject(projectName);
+            project = projectModel.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -249,7 +254,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getLibertyServerProject(projectName);
+            project = projectModel.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -481,7 +486,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getLibertyServerProject(projectName);
+            project = projectModel.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -553,7 +558,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getLibertyServerProject(projectName);
+            project = projectModel.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -624,7 +629,7 @@ public class DevModeOperations {
         Project project = null;
 
         try {
-            project = dashboard.getLibertyServerProject(projectName);
+            project = projectModel.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Unable to find internal instance of project " + projectName);
             }
@@ -876,7 +881,7 @@ public class DevModeOperations {
                 IStructuredSelection structuredSelection = (IStructuredSelection) selection;
                 Object firstElement = structuredSelection.getFirstElement();
                 if (firstElement instanceof String) {
-                    Project project = dashboard.getLibertyServerProject((String) firstElement);
+                    Project project = projectModel.getLibertyServerProject((String) firstElement);
                     if (project != null) {
                         iProject = project.getIProject();
                     }
@@ -898,7 +903,7 @@ public class DevModeOperations {
     public void verifyProjectSupport(IProject iProject) throws Exception {
         if (iProject != null) {
             String projectName = iProject.getName();
-            Project project = dashboard.getLibertyServerProject(projectName);
+            Project project = projectModel.getLibertyServerProject(projectName);
             if (project == null) {
                 throw new Exception("Project " + projectName + " is not a supported project. Make sure the project is a Liberty project.");
             }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -885,7 +885,6 @@ public class DevModeOperations {
                     if (project != null) {
                         iProject = project.getIProject();
                     }
-
                 }
             }
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/EarlyStartupRegistration.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/EarlyStartupRegistration.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
+package io.openliberty.tools.eclipse;
+
+public class EarlyStartupRegistration implements org.eclipse.ui.IStartup {
+
+    @Override
+    public void earlyStartup() {
+        // Causes AbstractUIPlugin to start() early
+
+        // Don't need to do anything, just registering as an IStartup so
+        // the bundle will eagerly start.
+    }
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyDevPlugin.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyDevPlugin.java
@@ -33,7 +33,7 @@ public class LibertyDevPlugin extends AbstractUIPlugin {
     public static final String PLUGIN_ID = "io.openliberty.tools.eclipse.ui";
 
     public static final String DEBUG_OPTIONS_ID = "io.openliberty.tools.eclipse";
-    
+
     // The shared instance
     private static LibertyDevPlugin plugin;
     private static IResourceChangeListener resourceChangeListener;
@@ -54,7 +54,7 @@ public class LibertyDevPlugin extends AbstractUIPlugin {
         props.put(DebugOptions.LISTENER_SYMBOLICNAME, LibertyDevPlugin.DEBUG_OPTIONS_ID);
         context.registerService(DebugOptionsListener.class.getName(), new Trace(), props);
         resourceChangeListener = new MultiModUpdater();
-        ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceChangeListener);
+        ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceChangeListener, IResourceChangeEvent.PRE_BUILD);
     }
 
     @Override

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyDevPlugin.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyDevPlugin.java
@@ -36,6 +36,7 @@ public class LibertyDevPlugin extends AbstractUIPlugin {
 
     // The shared instance
     private static LibertyDevPlugin plugin;
+
     private static IResourceChangeListener resourceChangeListener;
 
     /**
@@ -53,7 +54,7 @@ public class LibertyDevPlugin extends AbstractUIPlugin {
         Hashtable<String, String> props = new Hashtable<String, String>();
         props.put(DebugOptions.LISTENER_SYMBOLICNAME, LibertyDevPlugin.DEBUG_OPTIONS_ID);
         context.registerService(DebugOptionsListener.class.getName(), new Trace(), props);
-        resourceChangeListener = new MultiModUpdater();
+        resourceChangeListener = new LibertyResourceChangeListener();
         ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceChangeListener, IResourceChangeEvent.PRE_BUILD);
     }
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyDevPlugin.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyDevPlugin.java
@@ -54,6 +54,9 @@ public class LibertyDevPlugin extends AbstractUIPlugin {
         Hashtable<String, String> props = new Hashtable<String, String>();
         props.put(DebugOptions.LISTENER_SYMBOLICNAME, LibertyDevPlugin.DEBUG_OPTIONS_ID);
         context.registerService(DebugOptionsListener.class.getName(), new Trace(), props);
+
+        DevModeOperations.getInstance().getProjectModel().createNewCompleteWorkspaceModelWithClassify();
+
         resourceChangeListener = new LibertyResourceChangeListener();
         ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceChangeListener, IResourceChangeEvent.PRE_BUILD);
     }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyDevPlugin.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyDevPlugin.java
@@ -14,6 +14,9 @@ package io.openliberty.tools.eclipse;
 
 import java.util.Hashtable;
 
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.osgi.service.debug.DebugOptions;
 import org.eclipse.osgi.service.debug.DebugOptionsListener;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -33,6 +36,7 @@ public class LibertyDevPlugin extends AbstractUIPlugin {
     
     // The shared instance
     private static LibertyDevPlugin plugin;
+    private static IResourceChangeListener resourceChangeListener;
 
     /**
      * Constructor.
@@ -49,12 +53,15 @@ public class LibertyDevPlugin extends AbstractUIPlugin {
         Hashtable<String, String> props = new Hashtable<String, String>();
         props.put(DebugOptions.LISTENER_SYMBOLICNAME, LibertyDevPlugin.DEBUG_OPTIONS_ID);
         context.registerService(DebugOptionsListener.class.getName(), new Trace(), props);
+        resourceChangeListener = new MultiModUpdater();
+        ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceChangeListener);
     }
 
     @Override
     public void stop(BundleContext context) throws Exception {
         plugin = null;
         super.stop(context);
+        ResourcesPlugin.getWorkspace().removeResourceChangeListener(resourceChangeListener);
     }
 
     /**

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyResourceChangeListener.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyResourceChangeListener.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
 package io.openliberty.tools.eclipse;
 
 import java.util.ArrayList;
@@ -14,7 +26,7 @@ import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.ui.dashboard.DashboardView;
 import io.openliberty.tools.eclipse.utils.ErrorHandler;
 
-public class MultiModUpdater implements IResourceChangeListener {
+public class LibertyResourceChangeListener implements IResourceChangeListener {
 
     /**
      * {@inheritDoc}
@@ -26,7 +38,7 @@ public class MultiModUpdater implements IResourceChangeListener {
             @Override
             public void run() {
 
-                Dashboard db = DevModeOperations.getInstance().getDashboard();
+                WorkspaceProjectsModel db = DevModeOperations.getInstance().getProjectModel();
                 IResourceDelta delta = event.getDelta();
                 if (delta == null) {
                     return;
@@ -88,7 +100,7 @@ public class MultiModUpdater implements IResourceChangeListener {
                         // We leave this commented out as a marker of the idea that maybe one day we'll only
                         // build the "delta" model instead of the whole workspace model
                         // db.buildMultiProjectModel(projectsChanged, true);
-                        db.buildCompleteWorkspaceModelWithClassify();
+                        db.createNewCompleteWorkspaceModelWithClassify();
 
                         DashboardView dashboardView = DevModeOperations.getInstance().getDashboardView();
                         // Won't be set if dashboard view hasn't been initialized yet

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/MultiModUpdater.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/MultiModUpdater.java
@@ -8,6 +8,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.swt.widgets.Display;
 
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.ui.dashboard.DashboardView;
@@ -20,83 +21,91 @@ public class MultiModUpdater implements IResourceChangeListener {
      */
     @Override
     public void resourceChanged(IResourceChangeEvent event) {
-        IResourceDelta delta = event.getDelta();
-        if (delta == null) {
-            return;
-        }
+        Display.getDefault().syncExec(new Runnable() {
 
-        // On entry the resource type is the root workspace. Find the child resources affected.
-        IResourceDelta[] resourcesChanged = delta.getAffectedChildren();
+            @Override
+            public void run() {
 
-        List<IProject> projectsChanged = new ArrayList<IProject>();
+                Dashboard db = DevModeOperations.getInstance().getDashboard();
+                IResourceDelta delta = event.getDelta();
+                if (delta == null) {
+                    return;
+                }
 
-        boolean refreshNeeded = false;
+                // On entry the resource type is the root workspace. Find the child resources affected.
+                IResourceDelta[] resourcesChanged = delta.getAffectedChildren();
 
-        // Iterate over the affected resources.
-        for (IResourceDelta resourceChanged : resourcesChanged) {
-            IResource iResource = resourceChanged.getResource();
-            if (iResource.getType() != IResource.PROJECT) {
-                continue;
+                List<IProject> projectsChanged = new ArrayList<IProject>();
+
+                boolean refreshNeeded = false;
+
+                // Iterate over the affected resources.
+                for (IResourceDelta resourceChanged : resourcesChanged) {
+                    IResource iResource = resourceChanged.getResource();
+                    if (iResource.getType() != IResource.PROJECT) {
+                        continue;
+                    }
+                    IProject iProject = (IProject) iResource;
+                    projectsChanged.add(iProject);
+                    Project project = db.getLibertyServerProject(iProject.getName());
+
+                    int updateFlag = resourceChanged.getFlags();
+
+                    switch (resourceChanged.getKind()) {
+                    // Project opened/closed.
+                    // Flag OPEN (16384): "Change constant (bit mask) indicating that the resource was opened or closed"
+                    // Flag 147456: Although IResourceDelta does not have a predefined constant, this flag value is used to
+                    // denote open/close actions.
+                    case IResourceDelta.CHANGED:
+                        if (updateFlag == IResourceDelta.OPEN || updateFlag == 147456) {
+                            refreshNeeded = true;
+                        }
+                        break;
+                    // Project created/imported.
+                    // Flag OPEN (16384): "This flag is ... set when the project did not exist in the "before" state."
+                    // Flag 147456: Although IResourceDelta does not have a predefined constant, this flag
+                    // value is set when a project, that previously did not exist, is created.
+                    case IResourceDelta.ADDED:
+                        if (project == null && (updateFlag == IResourceDelta.OPEN || updateFlag == 147456)) {
+                            refreshNeeded = true;
+                        }
+                        break;
+                    // Project deleted.
+                    // Flag NO_CHANGE (0).
+                    // Flag MARKERS (130172).
+                    case IResourceDelta.REMOVED:
+                        if (project != null && (updateFlag == IResourceDelta.NO_CHANGE || updateFlag == IResourceDelta.MARKERS)) {
+                            refreshNeeded = true;
+                        }
+                        break;
+                    default:
+                        break;
+                    }
+                }
+
+                if (refreshNeeded) {
+                    try {
+                        // We leave this commented out as a marker of the idea that maybe one day we'll only
+                        // build the "delta" model instead of the whole workspace model
+                        // db.buildMultiProjectModel(projectsChanged, true);
+                        db.buildCompleteWorkspaceModelWithClassify();
+
+                        DashboardView dashboardView = DevModeOperations.getInstance().getDashboardView();
+                        // Won't be set if dashboard view hasn't been initialized yet
+                        if (dashboardView != null) {
+                            dashboardView.setInput(db.getSortedDashboardProjectList());
+                        }
+                    } catch (Exception e) {
+                        String msg = "An error was detected while auto-refreshing the Liberty dashboard content.";
+                        if (Trace.isEnabled()) {
+                            Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                        }
+                        ErrorHandler.processErrorMessage(msg, e);
+                        return;
+                    }
+                }
             }
-            IProject iProject = (IProject) iResource;
-            projectsChanged.add(iProject);
-
-            // Project project = devModeOps.getDashboard().getLibertyServerProject(iProject.getName());
-            int updateFlag = resourceChanged.getFlags();
-
-            switch (resourceChanged.getKind()) {
-            // Project opened/closed.
-            // Flag OPEN (16384): "Change constant (bit mask) indicating that the resource was opened or closed"
-            // Flag 147456: Although IResourceDelta does not have a predefined constant, this flag value is used to
-            // denote open/close actions.
-            case IResourceDelta.CHANGED:
-                if (updateFlag == IResourceDelta.OPEN || updateFlag == 147456) {
-                    refreshNeeded = true;
-                }
-                break;
-            // Project created/imported.
-            // Flag OPEN (16384): "This flag is ... set when the project did not exist in the "before" state."
-            // Flag 147456: Although IResourceDelta does not have a predefined constant, this flag
-            // value is set when a project, that previously did not exist, is created.
-            case IResourceDelta.ADDED:
-                // if (project == null
-                if (updateFlag == IResourceDelta.OPEN || updateFlag == 147456) {
-                    refreshNeeded = true;
-                }
-                break;
-            // Project deleted.
-            // Flag NO_CHANGE (0).
-            // Flag MARKERS (130172).
-            case IResourceDelta.REMOVED:
-                // if (project != null
-                if (updateFlag == IResourceDelta.NO_CHANGE || updateFlag == IResourceDelta.MARKERS) {
-                    refreshNeeded = true;
-                }
-                break;
-            default:
-                break;
-            }
-        }
-
-        if (refreshNeeded) {
-
-            try {
-                Dashboard dashboard = DevModeOperations.getInstance().getDashboard();
-                dashboard.buildMultiProjectModel(projectsChanged, true);
-                DashboardView dashboardView = DevModeOperations.getInstance().getDashboardView();
-                // Won't be set if dashboard view hasn't been initialized yet
-                if (dashboardView != null) {
-                    dashboardView.setInput(dashboard.getSortedDashboardProjectList());
-                }
-            } catch (Exception e) {
-                String msg = "An error was detected while auto-refreshing the Liberty dashboard content.";
-                if (Trace.isEnabled()) {
-                    Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
-                }
-                ErrorHandler.processErrorMessage(msg, e);
-                return;
-            }
-        }
+        });
     }
 
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/MultiModUpdater.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/MultiModUpdater.java
@@ -1,0 +1,102 @@
+package io.openliberty.tools.eclipse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+
+import io.openliberty.tools.eclipse.logging.Trace;
+import io.openliberty.tools.eclipse.ui.dashboard.DashboardView;
+import io.openliberty.tools.eclipse.utils.ErrorHandler;
+
+public class MultiModUpdater implements IResourceChangeListener {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void resourceChanged(IResourceChangeEvent event) {
+        IResourceDelta delta = event.getDelta();
+        if (delta == null) {
+            return;
+        }
+
+        // On entry the resource type is the root workspace. Find the child resources affected.
+        IResourceDelta[] resourcesChanged = delta.getAffectedChildren();
+
+        List<IProject> projectsChanged = new ArrayList<IProject>();
+
+        boolean refreshNeeded = false;
+
+        // Iterate over the affected resources.
+        for (IResourceDelta resourceChanged : resourcesChanged) {
+            IResource iResource = resourceChanged.getResource();
+            if (iResource.getType() != IResource.PROJECT) {
+                continue;
+            }
+            IProject iProject = (IProject) iResource;
+            projectsChanged.add(iProject);
+
+            // Project project = devModeOps.getDashboard().getLibertyServerProject(iProject.getName());
+            int updateFlag = resourceChanged.getFlags();
+
+            switch (resourceChanged.getKind()) {
+            // Project opened/closed.
+            // Flag OPEN (16384): "Change constant (bit mask) indicating that the resource was opened or closed"
+            // Flag 147456: Although IResourceDelta does not have a predefined constant, this flag value is used to
+            // denote open/close actions.
+            case IResourceDelta.CHANGED:
+                if (updateFlag == IResourceDelta.OPEN || updateFlag == 147456) {
+                    refreshNeeded = true;
+                }
+                break;
+            // Project created/imported.
+            // Flag OPEN (16384): "This flag is ... set when the project did not exist in the "before" state."
+            // Flag 147456: Although IResourceDelta does not have a predefined constant, this flag
+            // value is set when a project, that previously did not exist, is created.
+            case IResourceDelta.ADDED:
+                // if (project == null
+                if (updateFlag == IResourceDelta.OPEN || updateFlag == 147456) {
+                    refreshNeeded = true;
+                }
+                break;
+            // Project deleted.
+            // Flag NO_CHANGE (0).
+            // Flag MARKERS (130172).
+            case IResourceDelta.REMOVED:
+                // if (project != null
+                if (updateFlag == IResourceDelta.NO_CHANGE || updateFlag == IResourceDelta.MARKERS) {
+                    refreshNeeded = true;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (refreshNeeded) {
+
+            try {
+                Dashboard dashboard = DevModeOperations.getInstance().getDashboard();
+                dashboard.buildMultiProjectModel(projectsChanged, true);
+                DashboardView dashboardView = DevModeOperations.getInstance().getDashboardView();
+                // Won't be set if dashboard view hasn't been initialized yet
+                if (dashboardView != null) {
+                    dashboardView.setInput(dashboard.getSortedDashboardProjectList());
+                }
+            } catch (Exception e) {
+                String msg = "An error was detected while auto-refreshing the Liberty dashboard content.";
+                if (Trace.isEnabled()) {
+                    Trace.getTracer().trace(Trace.TRACE_UI, msg, e);
+                }
+                ErrorHandler.processErrorMessage(msg, e);
+                return;
+            }
+        }
+    }
+
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Project.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Project.java
@@ -266,7 +266,8 @@ public class Project {
     @Override
     public String toString() {
         return "IProject: " + iProject.toString() + ". BuildType: " + type + ". Liberty Server Module: " + libertyServerModule
-                + ". parentDirProj: " + parentDirProject + ". childDirProjects: " + childDirProjects;
+                + ". parentDirProj: " + (parentDirProject != null ? parentDirProject.getName() : "<null> ") + ". childDirProjects: "
+                + childDirProjects.stream().map(e -> e.toString()).reduce(",", String::concat);
     }
 
     public boolean isLibertyServerModule() {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Project.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Project.java
@@ -265,7 +265,7 @@ public class Project {
 
     @Override
     public String toString() {
-        return "IProject: " + iProject.toString() + ". BuildType: " + type + ". Liberty Server Module: " + isLibertyNature()
+        return "IProject: " + iProject.toString() + ". BuildType: " + type + ". Liberty Server Module: " + libertyServerModule
                 + ". parentDirProj: " + parentDirProject + ". childDirProjects: " + childDirProjects;
     }
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Project.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/Project.java
@@ -263,11 +263,25 @@ public class Project {
         }
     }
 
+    private String formatChildProjectToString() {
+        if (childDirProjects.isEmpty()) {
+            return "<empty>";
+        } else {
+            StringBuilder sb = new StringBuilder();
+            sb.append("[");
+            for (Project p : childDirProjects) {
+                sb.append(p.getName()).append(",");
+            }
+            sb.append("]");
+            return sb.toString();
+        }
+    }
+
     @Override
     public String toString() {
         return "IProject: " + iProject.toString() + ". BuildType: " + type + ". Liberty Server Module: " + libertyServerModule
                 + ". parentDirProj: " + (parentDirProject != null ? parentDirProject.getName() : "<null> ") + ". childDirProjects: "
-                + childDirProjects.stream().map(e -> e.toString()).reduce(",", String::concat);
+                + formatChildProjectToString() + ";";
     }
 
     public boolean isLibertyServerModule() {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/WorkspaceProjectsModel.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/WorkspaceProjectsModel.java
@@ -40,6 +40,7 @@ public class WorkspaceProjectsModel {
      * Constructor.
      */
     public WorkspaceProjectsModel() {
+        initProjectModels();
     }
 
     private void createProjectModels(List<IProject> projects, boolean classify) {
@@ -78,12 +79,15 @@ public class WorkspaceProjectsModel {
 
         List<IProject> openProjects = Arrays.stream(iProjects).filter(project -> project.isOpen()).collect(Collectors.toList());
 
+        initProjectModels();
+        createProjectModels(openProjects, classify);
+        buildMultiProjectModel(openProjects, classify);
+    }
+
+    private void initProjectModels() {
         // Start over. Throw away existing model
         projectsByLocation = new ConcurrentHashMap<String, Project>();
         projectsByName = new ConcurrentHashMap<String, Project>();
-
-        createProjectModels(openProjects, classify);
-        buildMultiProjectModel(openProjects, classify);
     }
 
     /**

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/WorkspaceProjectsModel.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/WorkspaceProjectsModel.java
@@ -74,6 +74,10 @@ public class WorkspaceProjectsModel {
      */
     private void createNewCompleteWorkspaceModel(boolean classify) {
 
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_UTILS, new Object[] { classify });
+        }
+
         IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
         IProject[] iProjects = workspaceRoot.getProjects();
 
@@ -82,6 +86,10 @@ public class WorkspaceProjectsModel {
         initProjectModels();
         createProjectModels(openProjects, classify);
         buildMultiProjectModel(openProjects, classify);
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_UTILS);
+        }
     }
 
     private void initProjectModels() {
@@ -132,11 +140,23 @@ public class WorkspaceProjectsModel {
      *         not a server project).
      */
     public Project getLibertyServerProject(String name) {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_UTILS, name);
+        }
+
+        Project retVal = null;
+
         Project proj = projectsByName.get(name);
         if (proj != null && proj.isLibertyServerModule()) {
-            return proj;
+            retVal = proj;
         }
-        return null;
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_UTILS, retVal);
+        }
+
+        return retVal;
     }
 
     /**
@@ -147,6 +167,10 @@ public class WorkspaceProjectsModel {
      * @return Liberty server project names sorted and grouped.
      */
     public List<String> getSortedDashboardProjectList() {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_UTILS);
+        }
 
         List<String> mavenDashboardProjects = new ArrayList<String>();
         List<String> gradleDashboardProjects = new ArrayList<String>();
@@ -171,6 +195,11 @@ public class WorkspaceProjectsModel {
 
         retVal.addAll(mavenDashboardProjects);
         retVal.addAll(gradleDashboardProjects);
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_UTILS, retVal);
+        }
+
         return retVal;
 
     }
@@ -182,12 +211,25 @@ public class WorkspaceProjectsModel {
      *         like there is a multi-module relationship or not
      */
     public String getDefaultStartParameters(IProject iProject) {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_UTILS, new Object[] { iProject });
+        }
+
+        String retVal = null;
+
         Project proj = projectsByName.get(iProject.getName());
         if (proj.isAggregated()) {
-            return "-f ../pom.xml -am -pl " + getModuleNameSegment(iProject);
+            retVal = "-f ../pom.xml -am -pl " + getModuleNameSegment(iProject);
         } else {
-            return "";
+            retVal = "";
         }
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_UTILS, retVal);
+        }
+
+        return retVal;
     }
 
     private String getModuleNameSegment(IProject iProject) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
@@ -93,4 +93,15 @@ public class DashboardEntryLabelProvider extends LabelProvider implements ITable
 
         return columnText;
     }
+
+    @Override
+    public void dispose() {
+        if (gradleImg != null) {
+            gradleImg.dispose();
+        }
+        if (mavenImg != null) {
+            mavenImg.dispose();
+        }
+    }
+
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
@@ -64,7 +64,7 @@ public class DashboardEntryLabelProvider extends LabelProvider implements ITable
         Image img = null;
         if (element != null && element instanceof String) {
             projectName = (String) element;
-            Project project = devModeOps.getDashboard().getLibertyServerProject(projectName);
+            Project project = devModeOps.getProjectModel().getLibertyServerProject(projectName);
 
             if (project != null) {
                 if (project.getBuildType() == Project.BuildType.GRADLE) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
@@ -64,7 +64,7 @@ public class DashboardEntryLabelProvider extends LabelProvider implements ITable
         Image img = null;
         if (element != null && element instanceof String) {
             projectName = (String) element;
-            Project project = devModeOps.getSupportedProject(projectName);
+            Project project = devModeOps.getDashboard().getLibertyServerProject(projectName);
 
             if (project != null) {
                 if (project.getBuildType() == Project.BuildType.GRADLE) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
@@ -34,7 +34,7 @@ import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.part.ViewPart;
 
-import io.openliberty.tools.eclipse.Dashboard;
+import io.openliberty.tools.eclipse.WorkspaceProjectsModel;
 import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.Project;
 import io.openliberty.tools.eclipse.logging.Trace;
@@ -117,8 +117,8 @@ public class DashboardView extends ViewPart {
         viewer.setLabelProvider(new DashboardEntryLabelProvider(devModeOps));
 
         try {
-            Dashboard dashboard = devModeOps.getDashboard();
-            dashboard.buildCompleteWorkspaceModelWithClassify();
+            WorkspaceProjectsModel dashboard = devModeOps.getProjectModel();
+            dashboard.createNewCompleteWorkspaceModelWithClassify();
             viewer.setInput(dashboard.getSortedDashboardProjectList());
         } catch (Exception e) {
             String msg = "An error was detected while retrieving Liberty projects.";
@@ -190,7 +190,7 @@ public class DashboardView extends ViewPart {
     private void addActionsToContextMenu(IMenuManager mgr) {
         IProject iProject = devModeOps.getSelectedDashboardProject();
         String projectName = iProject.getName();
-        Project project = devModeOps.getDashboard().getLibertyServerProject(projectName);
+        Project project = devModeOps.getProjectModel().getLibertyServerProject(projectName);
 
         if (project != null) {
             mgr.add(startAction);
@@ -419,8 +419,8 @@ public class DashboardView extends ViewPart {
             @Override
             public void run() {
                 try {
-                    Dashboard dashboard = devModeOps.getDashboard();
-                    dashboard.buildCompleteWorkspaceModelWithClassify();
+                    WorkspaceProjectsModel dashboard = devModeOps.getProjectModel();
+                    dashboard.createNewCompleteWorkspaceModelWithClassify();
                     viewer.setInput(dashboard.getSortedDashboardProjectList());
                 } catch (Exception e) {
                     String msg = "An error was detected while retrieving Liberty projects.";

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
@@ -34,9 +34,9 @@ import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.part.ViewPart;
 
-import io.openliberty.tools.eclipse.WorkspaceProjectsModel;
 import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.Project;
+import io.openliberty.tools.eclipse.WorkspaceProjectsModel;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenGradleTestReportAction;
 import io.openliberty.tools.eclipse.ui.launch.shortcuts.OpenMavenITestReportAction;
@@ -149,9 +149,8 @@ public class DashboardView extends ViewPart {
     @Override
     public void dispose() {
         super.dispose();
-        if (viewer == null) {
-            return;
-        }
+        // null out viewer so we don't try to update upon a resource change listener notification
+        viewer = null;
     }
 
     /**
@@ -435,7 +434,8 @@ public class DashboardView extends ViewPart {
     }
 
     public void setInput(List<String> sortedDashboardProjectList) {
-        viewer.setInput(sortedDashboardProjectList);
+        if (viewer != null) {
+            viewer.setInput(sortedDashboardProjectList);
+        }
     }
-
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
@@ -1,25 +1,22 @@
 /*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
-*
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v. 2.0 which is available at
-* http://www.eclipse.org/legal/epl-2.0.
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*     IBM Corporation - initial implementation
-*******************************************************************************/
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
 package io.openliberty.tools.eclipse.ui.dashboard;
 
 import java.net.URL;
+import java.util.List;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
-import org.eclipse.core.resources.IResourceDelta;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuListener;
@@ -32,12 +29,12 @@ import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.part.ViewPart;
 
+import io.openliberty.tools.eclipse.Dashboard;
 import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.Project;
 import io.openliberty.tools.eclipse.logging.Trace;
@@ -90,7 +87,7 @@ public class DashboardView extends ViewPart {
     /**
      * Table viewer that holds the entries in the dashboard.
      */
-    private TableViewer viewer;
+    TableViewer viewer;
 
     /**
      * Listener object that updates the dashboard content as actions take place on the projects it contains.
@@ -100,13 +97,14 @@ public class DashboardView extends ViewPart {
     /**
      * DevModeOperations reference.
      */
-    private DevModeOperations devModeOps;
+    DevModeOperations devModeOps;
 
     /**
      * Constructor.
      */
     public DashboardView() {
         devModeOps = DevModeOperations.getInstance();
+        devModeOps.setDashboardView(this);
     }
 
     /**
@@ -119,7 +117,9 @@ public class DashboardView extends ViewPart {
         viewer.setLabelProvider(new DashboardEntryLabelProvider(devModeOps));
 
         try {
-            viewer.setInput(devModeOps.getSupportedProjects());
+            Dashboard dashboard = devModeOps.getDashboard();
+            dashboard.buildCompleteWorkspaceModel(false);
+            viewer.setInput(dashboard.getSortedDashboardProjectList());
         } catch (Exception e) {
             String msg = "An error was detected while retrieving Liberty projects.";
             if (Trace.isEnabled()) {
@@ -133,7 +133,6 @@ public class DashboardView extends ViewPart {
         createContextMenu();
         addToolbarActions();
         getSite().setSelectionProvider(viewer);
-        registerResourceListener();
     }
 
     /**
@@ -153,7 +152,6 @@ public class DashboardView extends ViewPart {
         if (viewer == null) {
             return;
         }
-        ResourcesPlugin.getWorkspace().removeResourceChangeListener(projectStateListener);
     }
 
     /**
@@ -192,7 +190,7 @@ public class DashboardView extends ViewPart {
     private void addActionsToContextMenu(IMenuManager mgr) {
         IProject iProject = devModeOps.getSelectedDashboardProject();
         String projectName = iProject.getName();
-        Project project = devModeOps.getSupportedProject(projectName);
+        Project project = devModeOps.getDashboard().getLibertyServerProject(projectName);
 
         if (project != null) {
             mgr.add(startAction);
@@ -421,7 +419,9 @@ public class DashboardView extends ViewPart {
             @Override
             public void run() {
                 try {
-                    viewer.setInput(devModeOps.getSupportedProjects());
+                    Dashboard dashboard = devModeOps.getDashboard();
+                    dashboard.buildCompleteWorkspaceModel(true);
+                    viewer.setInput(dashboard.getSortedDashboardProjectList());
                 } catch (Exception e) {
                     String msg = "An error was detected while retrieving Liberty projects.";
                     if (Trace.isEnabled()) {
@@ -434,95 +434,8 @@ public class DashboardView extends ViewPart {
         refreshAction.setImageDescriptor(refreshImg);
     }
 
-    /**
-     * Registers a resource change listener to process project open/close and project create/import/delete.
-     */
-    private void registerResourceListener() {
-        projectStateListener = new IResourceChangeListener() {
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public void resourceChanged(IResourceChangeEvent event) {
-                Display.getDefault().syncExec(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        IResourceDelta delta = event.getDelta();
-                        if (delta == null) {
-                            return;
-                        }
-
-                        // On entry the resource type is the root workspace. Find the child resources affected.
-                        IResourceDelta[] resourcesChanged = delta.getAffectedChildren();
-
-                        // Iterate over the affected resources.
-                        for (IResourceDelta resourceChanged : resourcesChanged) {
-                            IResource iResource = resourceChanged.getResource();
-                            if (iResource.getType() != IResource.PROJECT) {
-                                continue;
-                            }
-
-                            boolean updateCompleted = false;
-                            IProject iProject = (IProject) iResource;
-                            Project project = devModeOps.getSupportedProject(iProject.getName());
-                            int updateFlag = resourceChanged.getFlags();
-
-                            try {
-                                switch (resourceChanged.getKind()) {
-                                // Project opened/closed.
-                                // Flag OPEN (16384): "Change constant (bit mask) indicating that the resource was opened or closed"
-                                // Flag 147456: Although IResourceDelta does not have a predefined constant, this flag value is used to
-                                // denote open/close actions.
-                                case IResourceDelta.CHANGED:
-                                    if (updateFlag == IResourceDelta.OPEN || updateFlag == 147456) {
-                                        viewer.setInput(devModeOps.getSupportedProjects());
-                                        updateCompleted = true;
-                                    }
-                                    break;
-                                // Project created/imported.
-                                // Flag OPEN (16384): "This flag is ... set when the project did not exist in the "before" state."
-                                // Flag 147456: Although IResourceDelta does not have a predefined constant, this flag
-                                // value is set when a project, that previously did not exist, is created.
-                                case IResourceDelta.ADDED:
-                                    if (project == null && (updateFlag == IResourceDelta.OPEN || updateFlag == 147456)) {
-                                        viewer.setInput(devModeOps.getSupportedProjects());
-                                        updateCompleted = true;
-                                    }
-                                    break;
-                                // Project deleted.
-                                // Flag NO_CHANGE (0).
-                                // Flag MARKERS (130172).
-                                case IResourceDelta.REMOVED:
-                                    if (project != null
-                                            && (updateFlag == IResourceDelta.NO_CHANGE || updateFlag == IResourceDelta.MARKERS)) {
-                                        viewer.setInput(devModeOps.getSupportedProjects());
-                                        updateCompleted = true;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                                }
-                            } catch (Exception e) {
-                                Dialog.displayErrorMessageWithDetails(
-                                        "An error was detected while auto-refreshing the Liberty dashboard content.", e);
-                                return;
-                            }
-
-                            // If the update completed for the project we are done.
-                            if (updateCompleted) {
-                                break;
-                            }
-                        }
-                    }
-                });
-            }
-        };
-
-        // Register the resource listener to be invoked on PRE-BUILD events only. The event is triggered during resource create, modify,
-        // and delete actions. This event type allows for workspace/resource modification while the registered listener is running.
-        // The listener is registered when the the dashboard is opened and unregistered when the dashboard is closed/disposed.
-        ResourcesPlugin.getWorkspace().addResourceChangeListener(projectStateListener, IResourceChangeEvent.PRE_BUILD);
+    public void setInput(List<String> sortedDashboardProjectList) {
+        viewer.setInput(sortedDashboardProjectList);
     }
+
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
@@ -118,7 +118,7 @@ public class DashboardView extends ViewPart {
 
         try {
             Dashboard dashboard = devModeOps.getDashboard();
-            dashboard.buildCompleteWorkspaceModel(false);
+            dashboard.buildCompleteWorkspaceModelWithClassify();
             viewer.setInput(dashboard.getSortedDashboardProjectList());
         } catch (Exception e) {
             String msg = "An error was detected while retrieving Liberty projects.";
@@ -420,7 +420,7 @@ public class DashboardView extends ViewPart {
             public void run() {
                 try {
                     Dashboard dashboard = devModeOps.getDashboard();
-                    dashboard.buildCompleteWorkspaceModel(true);
+                    dashboard.buildCompleteWorkspaceModelWithClassify();
                     viewer.setInput(dashboard.getSortedDashboardProjectList());
                 } catch (Exception e) {
                     String msg = "An error was detected while retrieving Liberty projects.";

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/ImportListener.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/ImportListener.java
@@ -1,8 +1,0 @@
-package io.openliberty.tools.eclipse.ui.dashboard;
-
-public class ImportListener implements org.eclipse.ui.IStartup {
-    @Override
-    public void earlyStartup() {
-        // Causes AbstractUIPlugin to start() early
-    }
-}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/ImportListener.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/ImportListener.java
@@ -1,0 +1,8 @@
+package io.openliberty.tools.eclipse.ui.dashboard;
+
+public class ImportListener implements org.eclipse.ui.IStartup {
+    @Override
+    public void earlyStartup() {
+        // Causes AbstractUIPlugin to start() early
+    }
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigTabGroup.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigTabGroup.java
@@ -26,6 +26,6 @@ public class LaunchConfigTabGroup extends AbstractLaunchConfigurationTabGroup {
      */
     @Override
     public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-        setTabs(new ILaunchConfigurationTab[] { new MainTab() });
+        setTabs(new ILaunchConfigurationTab[] { new StartTab() });
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
@@ -121,9 +121,9 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
                 // Create a new configuration.
                 String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
                 ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
-                workingCopy.setAttribute(MainTab.PROJECT_NAME, iProject.getName());
-                workingCopy.setAttribute(MainTab.PROJECT_START_PARM, devModeOps.getDashboard().getDefaultStartParameters(iProject));
-                workingCopy.setAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
+                workingCopy.setAttribute(StartTab.PROJECT_NAME, iProject.getName());
+                workingCopy.setAttribute(StartTab.PROJECT_START_PARM, devModeOps.getDashboard().getDefaultStartParameters(iProject));
+                workingCopy.setAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false);
                 configuration = workingCopy.doSave();
                 break;
 
@@ -155,13 +155,13 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
             RuntimeEnv runtimeEnv) throws Exception {
         ArrayList<ILaunchConfiguration> matchingConfigList = new ArrayList<>();
         for (ILaunchConfiguration existingConfig : rawConfigList) {
-            String configProjName = existingConfig.getAttribute(MainTab.PROJECT_NAME, "");
+            String configProjName = existingConfig.getAttribute(StartTab.PROJECT_NAME, "");
             if (configProjName.isEmpty()) {
                 continue;
             }
 
             if (projectName.equals(configProjName)) {
-                boolean configRanInContainer = existingConfig.getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
+                boolean configRanInContainer = existingConfig.getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false);
                 if (runtimeEnv == RuntimeEnv.CONTAINER) {
                     if (configRanInContainer) {
                         matchingConfigList.add(existingConfig);
@@ -204,8 +204,8 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
             public int compare(ILaunchConfiguration lc1, ILaunchConfiguration lc2) {
                 int rc = 0;
                 try {
-                    long time1 = Long.valueOf(lc1.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
-                    long time2 = Long.valueOf(lc2.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
+                    long time1 = Long.valueOf(lc1.getAttribute(StartTab.PROJECT_RUN_TIME, "0"));
+                    long time2 = Long.valueOf(lc2.getAttribute(StartTab.PROJECT_RUN_TIME, "0"));
                     rc = (time2 > time1) ? 1 : -1;
                 } catch (Exception e) {
                     String msg = "An error occurred while trying to determine which configuration ran last. Configuration list: "
@@ -230,7 +230,7 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
     public static void saveConfigProcessingTime(ILaunchConfiguration configuration) {
         try {
             ILaunchConfigurationWorkingCopy configWorkingCopy = configuration.getWorkingCopy();
-            configWorkingCopy.setAttribute(MainTab.PROJECT_RUN_TIME, String.valueOf(System.currentTimeMillis()));
+            configWorkingCopy.setAttribute(StartTab.PROJECT_RUN_TIME, String.valueOf(System.currentTimeMillis()));
             configWorkingCopy.doSave();
         } catch (Exception e) {
             // Log it and move on.

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
@@ -122,7 +122,7 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
                 String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
                 ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
                 workingCopy.setAttribute(StartTab.PROJECT_NAME, iProject.getName());
-                workingCopy.setAttribute(StartTab.PROJECT_START_PARM, devModeOps.getDashboard().getDefaultStartParameters(iProject));
+                workingCopy.setAttribute(StartTab.PROJECT_START_PARM, devModeOps.getProjectModel().getDefaultStartParameters(iProject));
                 workingCopy.setAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false);
                 configuration = workingCopy.doSave();
                 break;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
@@ -138,7 +138,8 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
             workingCopy.setAttribute(StartTab.PROJECT_NAME, iProject.getName());
             String startParms = devModeOps.getProjectModel().getDefaultStartParameters(iProject);
             workingCopy.setAttribute(StartTab.PROJECT_START_PARM, startParms);
-            workingCopy.setAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false);
+            boolean runInContainerBool = runtimeEnv.equals(RuntimeEnv.CONTAINER);
+            workingCopy.setAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, runInContainerBool);
             configuration = workingCopy.doSave();
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI,

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
@@ -28,7 +28,6 @@ import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.LaunchConfigurationDelegate;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
 import io.openliberty.tools.eclipse.DevModeOperations;
@@ -44,12 +43,6 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
 
     /** Launch configuration type ID as specified in plugin.xml. */
     public static final String LAUNCH_CONFIG_TYPE_ID = "io.openliberty.tools.eclipse.launch.type";
-
-    /** DevModeOperations instance. */
-    DevModeOperations devModeOps = DevModeOperations.getInstance();
-
-    /** Currently active workbench window. */
-    IWorkbenchWindow activeWindow;
 
     /** Launch shortcuts */
     public static final String LAUNCH_SHORTCUT_START = "Liberty Start";
@@ -71,11 +64,10 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
      */
     @Override
     public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor) throws CoreException {
-        // Processing paths: Explorer-> Run As-> Run Configurations, and Dashboard-> project -> Start...
-        if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { configuration, mode, launch, monitor });
-        }
-
+        // Processing paths:
+        // - Explorer-> Run As-> Run Configurations
+        // - Dashboard-> project -> Start...
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
         IWorkbench workbench = PlatformUI.getWorkbench();
         Display display = workbench.getDisplay();
         display.syncExec(new Runnable() {
@@ -96,10 +88,6 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
                 }
             }
         });
-
-        if (Trace.isEnabled()) {
-            Trace.getTracer().traceExit(Trace.TRACE_UI);
-        }
     }
 
     /**
@@ -116,6 +104,7 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
      * @throws Exception
      */
     public static ILaunchConfiguration getLaunchConfiguration(IProject iProject, String mode, RuntimeEnv runtimeEnv) throws Exception {
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
         ILaunchConfiguration configuration = null;
         ILaunchManager iLaunchMgr = DebugPlugin.getDefault().getLaunchManager();
         ILaunchConfigurationType iLaunchConfigType = iLaunchMgr
@@ -133,7 +122,7 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
                 String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
                 ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
                 workingCopy.setAttribute(MainTab.PROJECT_NAME, iProject.getName());
-                workingCopy.setAttribute(MainTab.PROJECT_START_PARM, "");
+                workingCopy.setAttribute(MainTab.PROJECT_START_PARM, devModeOps.getDashboard().getDefaultStartParameters(iProject));
                 workingCopy.setAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
                 configuration = workingCopy.doSave();
                 break;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -56,7 +56,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
 
     /** Tab image */
     Image image;
-    
+
     /** Configuration map key with a value stating whether or not the associated project ran in a container. */
     public static final String START_TAB_NAME = "Start";
 
@@ -77,7 +77,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     /**
      * Constructor.
      */
-    public MainTab() {
+    public StartTab() {
         image = Utils.getLibertyImage(PlatformUI.getWorkbench().getDisplay());
     }
 
@@ -167,6 +167,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
         } catch (CoreException ce) {
             // Trace and ignore.
             String msg = "An error was detected during Run Configuration initialization.";
+            ErrorHandler.processErrorMessage(msg, ce, true);
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, ce);
             }
@@ -196,8 +197,6 @@ public class StartTab extends AbstractLaunchConfigurationTab {
         return START_TAB_NAME;
     }
 
-    private Image libertyImage;
-
     /**
      * {@inheritDoc}
      */
@@ -215,7 +214,6 @@ public class StartTab extends AbstractLaunchConfigurationTab {
             image.dispose();
         }
     }
-    
 
     /**
      * Returns the default start parameters.

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -229,7 +229,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
                 // Verify that the existing projects are projects are read and classified. This maybe the first time
                 // this plugin's function is being used.
                 devModeOps.verifyProjectSupport(activeProject);
-                parms = devModeOps.getDashboard().getDefaultStartParameters(activeProject);
+                parms = devModeOps.getProjectModel().getDefaultStartParameters(activeProject);
             }
         } catch (Exception e) {
             // Report the issue and continue without a initial start command.

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -40,7 +40,7 @@ import io.openliberty.tools.eclipse.utils.Utils;
 /**
  * Main configuration tab.
  */
-public class MainTab extends AbstractLaunchConfigurationTab {
+public class StartTab extends AbstractLaunchConfigurationTab {
 
     /** Configuration map key with a value representing the dev mode start parameter. */
     public static final String PROJECT_START_PARM = "io.openliberty.tools.eclipse.launch.start.parm";
@@ -56,6 +56,11 @@ public class MainTab extends AbstractLaunchConfigurationTab {
 
     /** Tab image */
     Image image;
+    
+    /** Configuration map key with a value stating whether or not the associated project ran in a container. */
+    public static final String START_TAB_NAME = "Start";
+
+    private static final String EXAMPLE_START_PARMS = "Example: -DhotTests=true";
 
     /** Currently active project. */
     IProject activeProject;
@@ -117,7 +122,7 @@ public class MainTab extends AbstractLaunchConfigurationTab {
 
         // Add the input parameter text box.
         startParmText = new Text(composite, SWT.BORDER);
-        startParmText.setMessage("Example: -DhotTests=true");
+        startParmText.setMessage(EXAMPLE_START_PARMS);
         startParmText.addModifyListener(new ModifyListener() {
 
             /**
@@ -188,7 +193,7 @@ public class MainTab extends AbstractLaunchConfigurationTab {
      */
     @Override
     public String getName() {
-        return "Main";
+        return START_TAB_NAME;
     }
 
     private Image libertyImage;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -150,9 +150,17 @@ public class StartTab extends AbstractLaunchConfigurationTab {
      */
     @Override
     public void initializeFrom(ILaunchConfiguration configuration) {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { configuration });
+        }
+
         // Initialize the configuration view with previously saved values.
         try {
             activeProject = Utils.getActiveProject();
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_UI, "Active project = " + activeProject);
+            }
             if (activeProject == null) {
                 activeProject = devModeOps.getSelectedDashboardProject();
             }
@@ -172,6 +180,10 @@ public class StartTab extends AbstractLaunchConfigurationTab {
                 Trace.getTracer().trace(Trace.TRACE_UI, msg, ce);
             }
         }
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_UI);
+        }
     }
 
     /**
@@ -179,6 +191,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
      */
     @Override
     public void performApply(ILaunchConfigurationWorkingCopy configuration) {
+
         // Save the active project's name in the configuration.
         if (activeProject != null) {
             configuration.setAttribute(PROJECT_NAME, activeProject.getName());
@@ -187,6 +200,12 @@ public class StartTab extends AbstractLaunchConfigurationTab {
         // Capture the entries typed on the currently active launch configuration.
         configuration.setAttribute(PROJECT_START_PARM, startParmText.getText());
         configuration.setAttribute(PROJECT_RUN_IN_CONTAINER, runInContainerCheckBox.getSelection());
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().trace(Trace.TRACE_UI, "In performApply with activeProject = " + activeProject + ", startParm text = "
+                    + startParmText.getText() + ", runInContainer = " + runInContainerCheckBox.getSelection());
+        }
+
     }
 
     /**

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -94,6 +94,11 @@ public class StartAction implements ILaunchShortcut {
      * @throws Exception
      */
     public static void run(IProject iProject, ILaunchConfiguration iConfiguration, String mode) throws Exception {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, iConfiguration, mode });
+        }
+
         if (iProject == null) {
             throw new Exception("Invalid project. Be sure to select a project first.");
         }
@@ -118,6 +123,10 @@ public class StartAction implements ILaunchShortcut {
             devModeOps.startInContainer(iProject, startParms);
         } else {
             devModeOps.start(iProject, startParms);
+        }
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_UI);
         }
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -22,7 +22,7 @@ import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
-import io.openliberty.tools.eclipse.ui.launch.MainTab;
+import io.openliberty.tools.eclipse.ui.launch.StartTab;
 import io.openliberty.tools.eclipse.utils.ErrorHandler;
 import io.openliberty.tools.eclipse.utils.Utils;
 
@@ -110,8 +110,8 @@ public class StartAction implements ILaunchShortcut {
         LaunchConfigurationDelegateLauncher.saveConfigProcessingTime(configuration);
 
         // Retrieve configuration data.
-        boolean runInContainer = configuration.getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false);
-        String startParms = configuration.getAttribute(MainTab.PROJECT_START_PARM, (String) null);
+        boolean runInContainer = configuration.getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false);
+        String startParms = configuration.getAttribute(StartTab.PROJECT_START_PARM, (String) null);
 
         // Process the action.
         if (runInContainer) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
@@ -22,7 +22,7 @@ import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
-import io.openliberty.tools.eclipse.ui.launch.MainTab;
+import io.openliberty.tools.eclipse.ui.launch.StartTab;
 import io.openliberty.tools.eclipse.utils.ErrorHandler;
 import io.openliberty.tools.eclipse.utils.Utils;
 
@@ -113,7 +113,7 @@ public class StartInContainerAction implements ILaunchShortcut {
         LaunchConfigurationDelegateLauncher.saveConfigProcessingTime(configuration);
 
         // Process the action.
-        String startParms = configuration.getAttribute(MainTab.PROJECT_START_PARM, (String) null);
+        String startParms = configuration.getAttribute(StartTab.PROJECT_START_PARM, (String) null);
         devModeOps.startInContainer(iProject, startParms);
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/terminal/ProjectTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/terminal/ProjectTab.java
@@ -44,8 +44,7 @@ public class ProjectTab {
     private String projectName;
 
     /**
-     * Terminal connector instance set by the LocalDevModeLauncherDelegate when the connector is created during initial
-     * connection.
+     * Terminal connector instance set by the LocalDevModeLauncherDelegate when the connector is created during initial connection.
      */
     private ITerminalConnector connector;
 
@@ -112,7 +111,7 @@ public class ProjectTab {
      */
     public void runCommand(String projectPath, String command, List<String> envs) {
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { command, envs });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { projectPath, command, envs });
         }
 
         ITerminalService.Done done = new ITerminalService.Done() {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/Utils.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/Utils.java
@@ -82,6 +82,11 @@ public class Utils {
      * @return An org.eclipse.core.resources.IProject object associated with the input active part.
      */
     public static IProject getProjectFromPart(IWorkbenchPart part) {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { part });
+        }
+
         IProject iProject = null;
         if (part != null && part instanceof IEditorPart) {
             IEditorPart editorPart = (IEditorPart) part;
@@ -90,6 +95,10 @@ public class Utils {
             if (resource != null) {
                 iProject = resource.getProject();
             }
+        }
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, iProject);
         }
 
         return iProject;
@@ -103,6 +112,11 @@ public class Utils {
      * @return An org.eclipse.core.resources.IProject object associated with the input selection.
      */
     public static IProject getProjectFromSelection(ISelection selection) {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { selection });
+        }
+
         IProject iProject = null;
         if (selection != null && (selection instanceof IStructuredSelection)) {
 
@@ -117,6 +131,10 @@ public class Utils {
             }
         }
 
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, iProject);
+        }
+
         return iProject;
     }
 
@@ -127,6 +145,11 @@ public class Utils {
      *         returned.
      */
     public static IProject getActiveProject() {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS);
+        }
+
         IProject iProject = null;
         IWorkbench workbench = PlatformUI.getWorkbench();
         IWorkbenchWindow activeWindow = workbench.getActiveWorkbenchWindow();
@@ -147,6 +170,11 @@ public class Utils {
             }
         }
 
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, iProject);
+        }
+
         return iProject;
+
     }
 }

--- a/releng/target-platform/target-platform.target
+++ b/releng/target-platform/target-platform.target
@@ -110,7 +110,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://raw.githubusercontent.com/eclipse/lsp4jakarta/build-p2-update-site-0.0.1"/>
-            <unit id="org.eclipse.lsp4jakarta.jdt.core" version="0.0.1.20221019-1931"/>
+            <unit id="org.eclipse.lsp4jakarta.jdt.core" version="0.0.1.20221028-1834"/>
         </location>
     </locations>
 </target>

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
 **/.gradle
 **/build/
 **/.project
+**/.classpath

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -59,6 +59,16 @@
                                 <id>org.eclipse.jdt.feature.group</id>
                                 <versionRange>3.18.1300.v20220831-1800</versionRange>
                             </requirement>
+                            <requirement>
+                                <type>p2-installable-unit</type>
+                                <id>org.eclipse.buildship.ui</id>
+                                <versionRange>3.1.6.v20220511-1359</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>p2-installable-unit</type>
+                                <id>org.eclipse.m2e.core.ui</id>
+                                <versionRange>2.0.0.20220726-0935</versionRange>
+                            </requirement>
                         </extraRequirements>
                     </dependency-resolution>
                 </configuration>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/Dockerfile
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/Dockerfile
@@ -1,0 +1,8 @@
+FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+
+# Add config
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/server.xml /config/
+COPY --chown=1001:0  pom/target/liberty/wlp/usr/servers/defaultServer/configDropins/overrides/liberty-plugin-variable-config.xml /config/configDropins/overrides/
+
+# Add application
+COPY --chown=1001:0  ear/target/guide-maven-multimodules-ear.ear /config/apps/ 

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/jar/pom.xml
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/jar/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-jar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/pom.xml
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jar</module>
+        <module>war1</module>
+        <module>war2</module>
+        <module>pom</module>
+    </modules>
+</project>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/pom/pom.xml
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/pom/pom.xml
@@ -1,0 +1,110 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+    <repositories>
+        <!-- Sonatype repository used to get the latest binary scanner jar -->
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war1</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-war2</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.7.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <deployPackages>dependencies</deployPackages>
+                    <stripVersion>true</stripVersion>
+                </configuration>
+            </plugin>
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/pom/src/main/liberty/config/server.xml
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/pom/src/main/liberty/config/server.xml
@@ -1,0 +1,16 @@
+<server description="Sample Liberty server">
+    <featureManager>
+        <feature>jsp-2.3</feature>
+        <feature>mpHealth-2.2</feature>
+    </featureManager>
+
+    <variable name="default.http.port" defaultValue="9080" />
+    <variable name="default.https.port" defaultValue="9443" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <webApplication id="guide-maven-multimodules-war1-test" location="guide-maven-multimodules-war1.war" name="Converter web app 1" contextRoot="/converter1/" />
+
+    <webApplication id="guide-maven-multimodules-war2" location="guide-maven-multimodules-war2.war" name="Converter web app 2" contextRoot="/converter2/" />
+
+</server>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/pom/src/test/java/it/io/openliberty/guides/multimodules/IT.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package it.io.openliberty.guides.multimodules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class IT {
+    String port = System.getProperty("default.http.port");
+    String war = "converter1";
+    String urlBase = "http://localhost:" + port + "/" + war + "/";
+
+    @Test
+    public void testIndexPage() throws Exception {
+        String url = this.urlBase;
+        HttpURLConnection con = testRequestHelper(url, "GET");
+        assertEquals(200, con.getResponseCode(), "Incorrect response code from " + url);
+        assertTrue(testBufferHelper(con).contains("Enter the height in centimeters"),
+                        "Incorrect response from " + url);
+    }
+
+    @Test
+    public void testHeightsPage() throws Exception {
+        String url = this.urlBase + "heights.jsp?heightCm=10";
+        HttpURLConnection con = testRequestHelper(url, "POST");
+        assertTrue(testBufferHelper(con).contains("3        inches"),
+                        "Incorrect response from " + url);
+    }
+
+    private HttpURLConnection testRequestHelper(String url, String method)
+                    throws Exception {
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        // optional default is GET
+        con.setRequestMethod(method);
+        return con;
+    }
+
+    private String testBufferHelper(HttpURLConnection con) throws Exception {
+        BufferedReader in = new BufferedReader(
+                        new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+}

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war1/pom.xml
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war1/pom.xml
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war1</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war1</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter1</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+
+            <!-- Enable liberty-maven plugin -->
+            <!-- <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.7.1</version>
+            </plugin> -->
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter1</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war1/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war1/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war1/src/main/webapp/WEB-INF/web.xml
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war1/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war1/src/main/webapp/heights.jsp
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war1/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war1/src/main/webapp/index.jsp
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war1/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter 1</title>
+</head>
+<body>
+    <h1>Height Converter 1</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war2/pom.xml
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war2/pom.xml
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.guides</groupId>
+    <artifactId>guide-maven-multimodules-war2</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>guide-maven-multimodules-war2</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Liberty configuration -->
+        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    </properties>
+
+    <dependencies>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openliberty.guides</groupId>
+            <artifactId>guide-maven-multimodules-jar</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <modules>
+                        <jarModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-jar</artifactId>
+                            <uri>/guide-maven-multimodules-jar-1.0-SNAPSHOT.jar</uri>
+                        </jarModule>
+                        <webModule>
+                            <groupId>io.openliberty.guides</groupId>
+                            <artifactId>guide-maven-multimodules-war</artifactId>
+                            <uri>/guide-maven-multimodules-war-1.0-SNAPSHOT.war</uri>
+                            <!-- Set custom context root -->
+                            <contextRoot>/converter2</contextRoot>
+                        </webModule>
+                    </modules>
+                </configuration>
+            </plugin>
+
+            <!-- Enable liberty-maven plugin -->
+            <!-- <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.7.1</version>
+            </plugin> -->
+
+            <!-- Since the package type is ear,
+            need to run testCompile to compile the tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to run integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <default.http.port>
+                            ${liberty.var.default.http.port}
+                        </default.http.port>
+                        <default.https.port>
+                            ${liberty.var.default.https.port}
+                        </default.https.port>
+                        <cf.context.root>/converter2</cf.context.root>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/java/io/openliberty/guides/multimodules/web/HeightsBean.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.web;
+
+public class HeightsBean implements java.io.Serializable {
+    private String heightCm = null;
+    private String heightFeet = null;
+    private String heightInches = null;
+    private int cm = 0;
+    private int feet = 0;
+    private int inches = 0;
+
+    public HeightsBean() {
+    }
+
+    // Capitalize the first letter of the name i.e. first letter after get
+    // If first letter is not capitalized, it must match the property name in
+    // index.jsp
+    public String getHeightCm() {
+        return heightCm;
+    }
+
+    public String getHeightFeet() {
+        return heightFeet;
+    }
+
+    public String getHeightInches() {
+        return heightInches;
+    }
+
+    public void setHeightCm(String heightcm) {
+        this.heightCm = heightcm;
+    }
+
+    // Need an input as placeholder, you can choose not to use the input
+    public void setHeightFeet(String heightfeet) {
+        this.cm = Integer.valueOf(heightCm);
+        this.feet = io.openliberty.guides.multimodules.lib.Converter.getFeet(cm);
+        String result = String.valueOf(feet);
+        this.heightFeet = result;
+    }
+
+    public void setHeightInches(String heightinches) {
+        this.cm = Integer.valueOf(heightCm);
+        this.inches = io.openliberty.guides.multimodules.lib.Converter.getInches(cm);
+        String result = String.valueOf(inches);
+        this.heightInches = result;
+    }
+
+}

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/webapp/WEB-INF/web.xml
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+    <display-name>Archetype Created Web Application</display-name>
+</web-app>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/webapp/heights.jsp
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/webapp/heights.jsp
@@ -1,0 +1,42 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter</title>
+</head>
+<body>
+    <h1>Height Converter</h1>
+
+    <jsp:useBean id="height" class="io.openliberty.guides.multimodules.web.HeightsBean"></jsp:useBean>
+    <jsp:setProperty name="height" property="heightCm" />
+    <jsp:setProperty name="height" property="heightFeet" value="0" />
+    <jsp:setProperty name="height" property="heightInches" value="0" />
+
+    <p>
+        Height in centimeters:
+        <jsp:getProperty name="height" property="heightCm" />
+        cm
+    </p>
+
+    <br>
+
+    <p>
+        Height in feet and inches:
+        <jsp:getProperty name="height" property="heightFeet" />
+        feet
+        <jsp:getProperty name="height" property="heightInches" />
+        inches
+    </p>
+
+</body>
+</html>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/webapp/index.jsp
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/webapp/index.jsp
@@ -1,0 +1,27 @@
+<%--
+*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************
+--%>
+<html>
+<head>
+<title>Height Converter 2</title>
+</head>
+<body>
+    <h1>Height Converter 2</h1>
+    <h2>Enter the height in centimeters</h2>
+
+    <form action="heights.jsp" method="post">
+        <input type="text" name="heightCm" /> cm <br> <input type="submit"
+            value="SUBMIT" />
+    </form>
+
+</body>
+</html>

--- a/tests/resources/ci/debug.opts
+++ b/tests/resources/ci/debug.opts
@@ -1,0 +1,5 @@
+io.openliberty.tools.eclipse/trace/utils=true
+io.openliberty.tools.eclipse/debug=true
+io.openliberty.tools.eclipse/trace/tools=true
+io.openliberty.tools.eclipse/trace/handlers=true
+io.openliberty.tools.eclipse/trace/ui=true

--- a/tests/resources/ci/scripts/exec.sh
+++ b/tests/resources/ci/scripts/exec.sh
@@ -36,7 +36,7 @@ main() {
     fi
     
     # Run the plugin's install goal.
-    mvn clean install 
+    mvn clean install -Dosgi.debug=./tests/resources/ci/debug.opts -Dtycho.showEclipseLog
 
     # If there were any errors, gather some debug data before exiting.
     rc=$?

--- a/tests/src/io/openliberty/tools/eclipse/test/it/AbstractLibertyPluginSWTBotTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/AbstractLibertyPluginSWTBotTest.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
+package io.openliberty.tools.eclipse.test.it;
+
+import static io.openliberty.tools.eclipse.test.it.utils.LibertyPluginTestUtils.isInternalBrowserSupportAvailable;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.buildship.core.BuildConfiguration;
+import org.eclipse.buildship.core.GradleBuild;
+import org.eclipse.buildship.core.GradleCore;
+import org.eclipse.buildship.core.GradleWorkspace;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.embedder.MavenModelManager;
+import org.eclipse.m2e.core.project.IProjectConfigurationManager;
+import org.eclipse.m2e.core.project.LocalProjectScanner;
+import org.eclipse.m2e.core.project.MavenProjectInfo;
+import org.eclipse.m2e.core.project.ProjectImportConfiguration;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+import io.openliberty.tools.eclipse.test.it.utils.LibertyPluginTestUtils;
+import io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations;
+
+public abstract class AbstractLibertyPluginSWTBotTest {
+
+    /**
+     * Wokbench bot instance.
+     */
+    static SWTWorkbenchBot bot;
+
+    /**
+     * Dashboard instance.
+     */
+    static SWTBotView dashboard;
+
+    /**
+     * Cleanup.
+     */
+    @AfterAll
+    public static void commonCleanup() {
+        bot.closeAllEditors();
+        bot.closeAllShells();
+        bot.resetWorkbench();
+    }
+
+    protected static void commonSetup() {
+        bot = new SWTWorkbenchBot();
+        SWTBotPluginOperations.closeWelcomePage(bot);
+        // Update browser preferences.
+        if (isInternalBrowserSupportAvailable()) {
+            boolean success = LibertyPluginTestUtils.updateBrowserPreferences(true);
+            Assertions.assertTrue(success, () -> "Unable to update browser preferences.");
+        }
+
+    }
+
+    public AbstractLibertyPluginSWTBotTest() {
+        super();
+    }
+
+    @BeforeEach
+    public void beforeEach(TestInfo info) {
+        System.out.println("INFO: Test " + info.getDisplayName() + " entry: " + java.time.LocalDateTime.now());
+    }
+
+    @AfterEach
+    public void afterEach(TestInfo info) {
+        System.out.println("INFO: Test " + info.getDisplayName() + " exit: " + java.time.LocalDateTime.now());
+    }
+
+    /**
+     * Imports the specified list of projects.
+     *
+     * @param workspaceRoot The workspace root location.
+     * @param folders The list of folders containing the projects to install.
+     *
+     * @throws InterruptedException
+     * @throws CoreException
+     */
+    protected static void importProjects(File workspaceRoot, List<String> folders) throws InterruptedException, CoreException {
+        // Get the list of projects to install.
+        MavenModelManager modelManager = MavenPlugin.getMavenModelManager();
+        LocalProjectScanner lps = new LocalProjectScanner(folders, false, modelManager);
+        lps.run(new NullProgressMonitor());
+        List<MavenProjectInfo> projects = lps.getProjects();
+
+        // Import the projects.
+        ProjectImportConfiguration projectImportConfig = new ProjectImportConfiguration();
+        IProjectConfigurationManager projectConfigurationManager = MavenPlugin.getProjectConfigurationManager();
+        projectConfigurationManager.importProjects(projects, projectImportConfig, new NullProgressMonitor());
+    }
+
+    /**
+     * Imports the specified list of projects.
+     *
+     * @param workspaceRoot The workspace root location.
+     * @param folders The list of folders containing the projects to install.
+     *
+     * @throws InterruptedException
+     * @throws CoreException
+     */
+    public static void importMavenProjects(File workspaceRoot, List<String> folders) {
+        Display.getDefault().syncExec(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    // Get the list of projects to install.
+                    MavenModelManager modelManager = MavenPlugin.getMavenModelManager();
+                    LocalProjectScanner lps = new LocalProjectScanner(folders, false, modelManager);
+                    lps.run(new NullProgressMonitor());
+                    List<MavenProjectInfo> projects = lps.getProjects();
+
+                    // Import the projects.
+                    ProjectImportConfiguration projectImportConfig = new ProjectImportConfiguration();
+                    IProjectConfigurationManager projectConfigurationManager = MavenPlugin.getProjectConfigurationManager();
+                    projectConfigurationManager.importProjects(projects, projectImportConfig, new NullProgressMonitor());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+        });
+    }
+
+    /**
+     * Imports the specified list of projects.
+     *
+     * @param projectsToInstall The list of File objects representing the location of the projects to install.
+     *
+     * @throws InterruptedException
+     * @throws CoreException
+     */
+    public static void importGradleApplications(ArrayList<File> projectsToInstall) {
+        Display.getDefault().syncExec(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    for (File projectFile : projectsToInstall) {
+                        IPath projectLocation = org.eclipse.core.runtime.Path
+                                .fromOSString(Paths.get(projectFile.getPath()).toAbsolutePath().toString());
+                        BuildConfiguration configuration = BuildConfiguration.forRootProjectDirectory(projectLocation.toFile()).build();
+                        GradleWorkspace workspace = GradleCore.getWorkspace();
+                        GradleBuild newBuild = workspace.createBuild(configuration);
+                        newBuild.synchronize(new NullProgressMonitor());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+        });
+    }
+}

--- a/tests/src/io/openliberty/tools/eclipse/test/it/AbstractLibertyPluginSWTBotTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/AbstractLibertyPluginSWTBotTest.java
@@ -83,12 +83,14 @@ public abstract class AbstractLibertyPluginSWTBotTest {
 
     @BeforeEach
     public void beforeEach(TestInfo info) {
-        System.out.println("INFO: Test " + info.getDisplayName() + " entry: " + java.time.LocalDateTime.now());
+        System.out.println(
+                "INFO: Test " + this.getClass().getSimpleName() + "#" + info.getDisplayName() + " entry: " + java.time.LocalDateTime.now());
     }
 
     @AfterEach
     public void afterEach(TestInfo info) {
-        System.out.println("INFO: Test " + info.getDisplayName() + " exit: " + java.time.LocalDateTime.now());
+        System.out.println(
+                "INFO: Test " + this.getClass().getSimpleName() + "#" + info.getDisplayName() + " exit: " + java.time.LocalDateTime.now());
     }
 
     /**

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDashboardTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDashboardTest.java
@@ -12,9 +12,6 @@
 *******************************************************************************/
 package io.openliberty.tools.eclipse.test.it;
 
-import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
-import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -23,35 +20,14 @@ import io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations;
 /**
  * Tests Open Liberty Eclipse plugin functions.
  */
-public class LibertyPluginSWTBotDashboardTest {
-
-    /**
-     * Wokbench bot instance.
-     */
-    static SWTWorkbenchBot bot;
-
-    /**
-     * Dashboard instance.
-     */
-    static SWTBotView dashboard;
+public class LibertyPluginSWTBotDashboardTest extends AbstractLibertyPluginSWTBotTest {
 
     /**
      * Setup.
      */
     @BeforeAll
     public static void setup() {
-        bot = new SWTWorkbenchBot();
-        SWTBotPluginOperations.closeWelcomePage(bot);
-    }
-
-    /**
-     * Cleanup.
-     */
-    @AfterAll
-    public static void cleanup() {
-        bot.closeAllEditors();
-        bot.closeAllShells();
-        bot.resetWorkbench();
+        commonSetup();
     }
 
     /**
@@ -62,4 +38,5 @@ public class LibertyPluginSWTBotDashboardTest {
         // Open the dashboard view.
         SWTBotPluginOperations.openDashboardUsingToolbar(bot);
     }
+
 }

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
@@ -1,0 +1,222 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
+package io.openliberty.tools.eclipse.test.it;
+
+import static io.openliberty.tools.eclipse.test.it.utils.LibertyPluginTestUtils.validateApplicationOutcomeCustom;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations;
+import io.openliberty.tools.eclipse.ui.dashboard.DashboardView;
+import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
+
+/**
+ * Tests Open Liberty Eclipse plugin functions.
+ */
+public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginSWTBotTest {
+
+    /**
+     * Application name.
+     */
+    static final String MVN_APP_NAME = "guide-maven-multimodules-pom";
+
+    /**
+     * Path to import from, in this case the multi-module root
+     */
+    static final Path project1Path = Paths.get("resources", "applications", "maven", "maven-multi-module", "typeJ");
+    static final Path serverModule1Path = project1Path.resolve("pom");
+
+    /**
+     * Expected menu items.
+     */
+    static String[] mvnMenuItems = new String[] { DashboardView.APP_MENU_ACTION_START, DashboardView.APP_MENU_ACTION_START_CONFIG,
+            DashboardView.APP_MENU_ACTION_START_IN_CONTAINER, DashboardView.APP_MENU_ACTION_STOP, DashboardView.APP_MENU_ACTION_RUN_TESTS,
+            DashboardView.APP_MENU_ACTION_VIEW_MVN_IT_REPORT, DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT };
+
+    /**
+     * Run As configuration menu items.
+     */
+    static String[] runAsShortcuts = new String[] { LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START,
+            LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER, LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_STOP,
+            LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_RUN_TESTS,
+            LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT,
+            LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT, };
+
+    static File workspaceRoot = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile();
+
+    /**
+     * Setup.
+     */
+    @BeforeAll
+    public static void setup() {
+
+        commonSetup();
+
+        List<String> projectPaths = new ArrayList<String>();
+        projectPaths.add(project1Path.resolve("pom").toString());
+        projectPaths.add(project1Path.resolve("jar").toString());
+        projectPaths.add(project1Path.resolve("war1").toString());
+        projectPaths.add(project1Path.resolve("war2").toString());
+
+        // Could be an interesting variation to stop with the above, which would cause the execution to run
+        // in a single module context, since the aggregator POM wouldn't be present. The rest of the test class
+        // isn't factored now to complete this idea, so leaving this as an idea if we want to expand in this direction later.
+        projectPaths.add(project1Path.toString());
+
+        importMavenProjects(workspaceRoot, projectPaths);
+
+        // Check basic plugin artifacts are functioning before running tests.
+        validateBeforeTestRun();
+    }
+
+    /**
+     * Makes sure that some basics actions can be performed before running the tests:
+     * 
+     * <pre>
+     * 1. The dashboard can be opened and its content retrieved. 
+     * 2. The dashboard contains the expected applications. 
+     * 3. The dashboard menu associated with a selected application contains the required actions. 
+     * 4. The Run As menu for the respective application contains the required shortcut actions. 
+     * 5. The Run As configuration view contains the Liberty entry for creating a configuration.
+     * 6. The Debug As configuration view contains the Liberty entry for creating a configuration.
+     * </pre>
+     */
+    public static final void validateBeforeTestRun() {
+        dashboard = SWTBotPluginOperations.openDashboardUsingToolbar(bot);
+
+        // Check that the dashboard can be opened and its content retrieved.
+        List<String> projectList = SWTBotPluginOperations.getDashboardContent(bot, dashboard);
+
+        // Check that dashboard contains the expected applications.
+        boolean foundApp = false;
+        for (String project : projectList) {
+            if (MVN_APP_NAME.equals(project)) {
+                foundApp = true;
+                break;
+            }
+        }
+        Assertions.assertTrue(foundApp, () -> "The dashboard does not contain expected application: " + MVN_APP_NAME);
+
+        // Check that the menu that the application in the dashboard contains the required actions.
+        List<String> menuItems = SWTBotPluginOperations.getDashboardItemMenuActions(bot, dashboard, MVN_APP_NAME);
+        Assertions.assertTrue(menuItems.size() == mvnMenuItems.length,
+                () -> "Maven application " + MVN_APP_NAME + " does not contain the expected number of menu items: " + mvnMenuItems.length);
+        Assertions.assertTrue(menuItems.containsAll(Arrays.asList(mvnMenuItems)),
+                () -> "Maven application " + MVN_APP_NAME + " does not contain the expected menu items: " + mvnMenuItems);
+
+        // Check that the Run As menu contains the expected shortcut
+        SWTBotMenu runAsMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, MVN_APP_NAME);
+        Assertions.assertTrue(runAsMenu != null, "The runAs menu associated with project: " + MVN_APP_NAME + " is null.");
+        List<String> runAsMenuItems = runAsMenu.menuItems();
+        Assertions.assertTrue(runAsMenuItems != null && !runAsMenuItems.isEmpty(),
+                "The runAs menu associated with project: " + MVN_APP_NAME + " is null or empty.");
+        int foundItems = 0;
+
+        for (String expectedItem : runAsShortcuts) {
+            for (String item : runAsMenuItems) {
+                if (item.contains(expectedItem)) {
+                    foundItems++;
+                    break;
+                }
+            }
+        }
+
+        Assertions.assertTrue(foundItems == runAsShortcuts.length,
+                "The runAs menu associated with project: " + MVN_APP_NAME
+                        + " does not contain one or more expected entries. Expected number of entries: " + runAsShortcuts.length
+                        + "Found entry count: " + foundItems + ". Found menu entries: " + runAsMenuItems);
+
+        // Check that the Run As -> Run Configurations... contains the Liberty entry in the menu.
+        SWTBotPluginOperations.launchRunConfigurationsDialog(bot, MVN_APP_NAME, "run");
+        SWTBotTreeItem runAslibertyToolsEntry = SWTBotPluginOperations.getLibertyToolsConfigMenuItem(bot);
+        Assertions.assertTrue(runAslibertyToolsEntry != null, "Liberty entry in Run Configurations view was not found.");
+        bot.button("Close").click();
+
+        // Commented out pending design discussions.
+        // Check that the Debug As -> Debug Configurations... contains the Liberty entry in the menu.
+        // SWTBotPluginOperations.launchRunConfigurationsDialog(bot, MVN_APP_NAME, "debug");
+        // SWTBotTreeItem debugAslibertyToolsEntry = SWTBotPluginOperations.getLibertyToolsConfigMenuItem(bot);
+        // Assertions.assertTrue(debugAslibertyToolsEntry != null, "Liberty entry in Debug Configurations view was not found.");
+        // bot.button("Close").click();
+    }
+
+    /**
+     * Tests the start menu action on a dashboard listed application.
+     */
+    @Test
+    public void testDashboardStartAction() {
+        // Start dev mode.
+        SWTBotPluginOperations.launchStartWithDashboardAction(bot, dashboard, MVN_APP_NAME);
+        SWTBotView terminal = bot.viewByTitle("Terminal");
+        terminal.show();
+
+        validateApplicationOutcomeCustom("http://localhost:9080/converter1/heights.jsp?heightCm=10", true, "Height in feet and inches",
+                serverModule1Path + "/target/liberty");
+        validateApplicationOutcomeCustom("http://localhost:9080/converter2/heights.jsp?heightCm=20", true, "Height in feet and inches",
+                serverModule1Path + "/target/liberty");
+
+        // Stop dev mode.
+        SWTBotPluginOperations.launchStopWithDashboardAction(bot, dashboard, MVN_APP_NAME);
+        terminal.show();
+
+        // Validate application stopped.
+        validateApplicationOutcomeCustom("http://localhost:9080/converter1/heights.jsp?heightCm=10", false, "N/A",
+                serverModule1Path + "/target/liberty");
+
+        // Close the terminal.
+        terminal.close();
+    }
+
+    /**
+     * Tests the start action initiated through: project -> Run As -> Run Configurations -> Liberty -> New configuration (default) ->
+     * Run.
+     */
+    @Test
+    public void testStartWithDefaultRunAsConfig() {
+        // Delete any previously created configs.
+        SWTBotPluginOperations.deleteLibertyToolsConfigEntries(bot, MVN_APP_NAME, "run");
+
+        // Start dev mode.
+        SWTBotPluginOperations.launchStartWithDefaultConfig(bot, MVN_APP_NAME, "run");
+        SWTBotView terminal = bot.viewByTitle("Terminal");
+        terminal.show();
+
+        // Validate application is up and running.
+        validateApplicationOutcomeCustom("http://localhost:9080/converter1/heights.jsp?heightCm=30", true, "Height in feet and inches",
+                serverModule1Path + "/target/liberty");
+
+        // Stop dev mode.
+        SWTBotPluginOperations.launchStopWithRunDebugAsShortcut(bot, MVN_APP_NAME, "run");
+        terminal.show();
+
+        // Validate application stopped.
+        validateApplicationOutcomeCustom("http://localhost:9080/converter1/heights.jsp?heightCm=30", false, "N/A",
+                serverModule1Path + "/target/liberty");
+
+        // Close the terminal.
+        terminal.close();
+    }
+}

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
@@ -105,20 +105,20 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
      * </pre>
      */
     public static final void validateBeforeTestRun() {
-        // dashboard = SWTBotPluginOperations.openDashboardUsingToolbar(bot);
+        dashboard = SWTBotPluginOperations.openDashboardUsingToolbar(bot);
 
         // Check that the dashboard can be opened and its content retrieved.
-        // List<String> projectList = SWTBotPluginOperations.getDashboardContent(bot, dashboard);
+        List<String> projectList = SWTBotPluginOperations.getDashboardContent(bot, dashboard);
 
         // Check that dashboard contains the expected applications.
-        // boolean foundApp = false;
-        // for (String project : projectList) {
-        // if (MVN_APP_NAME.equals(project)) {
-        // foundApp = true;
-        // break;
-        // }
-        // }
-        // Assertions.assertTrue(foundApp, () -> "The dashboard does not contain expected application: " + MVN_APP_NAME);
+        boolean foundApp = false;
+        for (String project : projectList) {
+            if (MVN_APP_NAME.equals(project)) {
+                foundApp = true;
+                break;
+            }
+        }
+        Assertions.assertTrue(foundApp, () -> "The dashboard does not contain expected application: " + MVN_APP_NAME);
 
         // Check that the menu that the application in the dashboard contains the required actions.
         List<String> menuItems = SWTBotPluginOperations.getDashboardItemMenuActions(bot, dashboard, MVN_APP_NAME);

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
@@ -105,20 +105,20 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
      * </pre>
      */
     public static final void validateBeforeTestRun() {
-        dashboard = SWTBotPluginOperations.openDashboardUsingToolbar(bot);
+        // dashboard = SWTBotPluginOperations.openDashboardUsingToolbar(bot);
 
         // Check that the dashboard can be opened and its content retrieved.
-        List<String> projectList = SWTBotPluginOperations.getDashboardContent(bot, dashboard);
+        // List<String> projectList = SWTBotPluginOperations.getDashboardContent(bot, dashboard);
 
         // Check that dashboard contains the expected applications.
-        boolean foundApp = false;
-        for (String project : projectList) {
-            if (MVN_APP_NAME.equals(project)) {
-                foundApp = true;
-                break;
-            }
-        }
-        Assertions.assertTrue(foundApp, () -> "The dashboard does not contain expected application: " + MVN_APP_NAME);
+        // boolean foundApp = false;
+        // for (String project : projectList) {
+        // if (MVN_APP_NAME.equals(project)) {
+        // foundApp = true;
+        // break;
+        // }
+        // }
+        // Assertions.assertTrue(foundApp, () -> "The dashboard does not contain expected application: " + MVN_APP_NAME);
 
         // Check that the menu that the application in the dashboard contains the required actions.
         List<String> menuItems = SWTBotPluginOperations.getDashboardItemMenuActions(bot, dashboard, MVN_APP_NAME);

--- a/tests/src/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
@@ -57,7 +57,7 @@ public class LibertyPluginTestUtils {
      * @param expectSuccess True if the validation is expected to be successful. False, otherwise.
      */
     public static void validateApplicationOutcomeCustom(String appUrl, boolean expectSuccess, String expectedResponse, String testAppPath) {
-        int retryCountLimit = 50;
+        int retryCountLimit = 180;
         int reryIntervalSecs = 3;
         int retryCount = 0;
 

--- a/tests/src/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
@@ -39,13 +39,24 @@ import org.osgi.service.prefs.Preferences;
 public class LibertyPluginTestUtils {
 
     /**
+     * This is the format we started with.
+     * 
+     * @param ctxRoot
+     * @param expectSuccess
+     * @param testAppPath
+     */
+    public static void validateApplicationOutcome(String ctxRoot, boolean expectSuccess, String testAppPath) {
+        String expectedResponse = "Hello! How are you today?";
+        String appUrl = "http://localhost:9080/" + ctxRoot + "/servlet";
+        validateApplicationOutcomeCustom(appUrl, expectSuccess, expectedResponse, testAppPath);
+    }
+
+    /**
      * Validates that the deployed application is active.
      *
      * @param expectSuccess True if the validation is expected to be successful. False, otherwise.
      */
-    public static void validateApplicationOutcome(String appName, boolean expectSuccess, String testAppPath) {
-        String expectedMvnAppResp = "Hello! How are you today?";
-        String appUrl = "http://localhost:9080/" + appName + "/servlet";
+    public static void validateApplicationOutcomeCustom(String appUrl, boolean expectSuccess, String expectedResponse, String testAppPath) {
         int retryCountLimit = 50;
         int reryIntervalSecs = 3;
         int retryCount = 0;
@@ -76,7 +87,7 @@ public class LibertyPluginTestUtils {
                         content.append(responseLine).append(System.lineSeparator());
                     }
 
-                    if (!(content.toString().contains(expectedMvnAppResp))) {
+                    if (!(content.toString().contains(expectedResponse))) {
                         Thread.sleep(reryIntervalSecs * 1000);
                         con.disconnect();
                         continue;

--- a/tests/src/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
@@ -137,7 +137,7 @@ public class LibertyPluginTestUtils {
      * @param pathToTestReport The path to the report.
      */
     public static void validateTestReportExists(Path pathToTestReport) {
-        int retryCountLimit = 50;
+        int retryCountLimit = 100;
         int reryIntervalSecs = 1;
         int retryCount = 0;
 

--- a/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -106,7 +106,7 @@ public class SWTBotPluginOperations {
      */
     public static List<String> getDashboardContent(SWTWorkbenchBot bot, SWTBotView dashboard) {
         if (dashboard == null) {
-        	SWTBotPluginOperations.openDashboardUsingToolbar(bot);
+            SWTBotPluginOperations.openDashboardUsingToolbar(bot);
         } else {
             dashboard.show();
         }
@@ -258,11 +258,12 @@ public class SWTBotPluginOperations {
      * @return The object representing the active project matching the input project name.
      */
     public static SWTBotTreeItem getInstalledProjectItem(SWTWorkbenchBot bot, String item) {
-        SWTBotView peView = bot.viewByTitle("Project Explorer");
+        openJavaPerspective();
+        SWTBotView peView = bot.viewByTitle("Package Explorer");
         peView.show();
-        SWTBotTree projectExplorerContent = peView.bot().tree();
+        SWTBotTree packageExplorerContent = peView.bot().tree();
         SWTBotTreeItem project = null;
-        for (SWTBotTreeItem projectFromTree : projectExplorerContent.getAllItems()) {
+        for (SWTBotTreeItem projectFromTree : packageExplorerContent.getAllItems()) {
             if (projectFromTree.getText().contains(item)) {
                 project = projectFromTree;
                 break;
@@ -672,7 +673,7 @@ public class SWTBotPluginOperations {
      */
     public static SWTBotRootMenu getAppContextMenu(SWTWorkbenchBot bot, SWTBotView dashboard, String item) {
         if (dashboard == null) {
-        	SWTBotPluginOperations.openDashboardUsingToolbar(bot);
+            SWTBotPluginOperations.openDashboardUsingToolbar(bot);
         } else {
             dashboard.show();
             dashboard.setFocus();

--- a/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -322,7 +322,7 @@ public class SWTBotPluginOperations {
      */
     public static void launchRunConfigurationsDialog(SWTWorkbenchBot bot, String item, String mode) {
         Assertions.assertTrue(("run".equals(mode) || "debug".equals(mode)),
-                () -> "Invalid configration mode: " + mode + ". Accepted values: run, debug.");
+                () -> "Invalid configuration mode: " + mode + ". Accepted values: run, debug.");
 
         SWTBotMenu modeAsMenu = ("run".equals(mode)) ? getAppRunAsMenu(bot, item) : getAppDebugAsMenu(bot, item);
         String configMenuText = ("run".equals(mode)) ? "Run Configurations..." : "Debug Configurations...";

--- a/tests/src/io/openliberty/tools/eclipse/test/ut/LibertyPluginUnitTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/ut/LibertyPluginUnitTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.TestInfo;
 
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
-import io.openliberty.tools.eclipse.ui.launch.MainTab;
+import io.openliberty.tools.eclipse.ui.launch.StartTab;
 
 public class LibertyPluginUnitTest {
 
@@ -54,11 +54,11 @@ public class LibertyPluginUnitTest {
                 .filterLaunchConfigurations(rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", RuntimeEnv.LOCAL);
         Assertions.assertTrue(filteredListDev.size() == 3,
                 "The resulting list should have contained 3 entries. List size: " + filteredListDev.size());
-        Assertions.assertTrue(filteredListDev.get(0).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, true) == false,
+        Assertions.assertTrue(filteredListDev.get(0).getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, true) == false,
                 "The run in container value associated with config entry[0] was not false.");
-        Assertions.assertTrue(filteredListDev.get(1).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, true) == false,
+        Assertions.assertTrue(filteredListDev.get(1).getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, true) == false,
                 "The run in container value associated with config entry[1] was not false.");
-        Assertions.assertTrue(filteredListDev.get(2).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, true) == false,
+        Assertions.assertTrue(filteredListDev.get(2).getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, true) == false,
                 "The run in container value associated with config entry[2] was not false.");
 
         // test 2. Container run.
@@ -66,11 +66,11 @@ public class LibertyPluginUnitTest {
                 rawCfgList.toArray(new ILaunchConfiguration[rawCfgList.size()]), "project1", RuntimeEnv.CONTAINER);
         Assertions.assertTrue(filteredListDevc.size() == 3,
                 "The resulting list should have contained 3 entries. Found: " + filteredListDevc.size() + ". List: " + filteredListDevc);
-        Assertions.assertTrue(filteredListDevc.get(0).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false) == true,
+        Assertions.assertTrue(filteredListDevc.get(0).getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false) == true,
                 "The run in container value associated with config entry[0] was not true.");
-        Assertions.assertTrue(filteredListDevc.get(1).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false) == true,
+        Assertions.assertTrue(filteredListDevc.get(1).getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false) == true,
                 "The run in container value associated with config entry[1] was not true.");
-        Assertions.assertTrue(filteredListDevc.get(2).getAttribute(MainTab.PROJECT_RUN_IN_CONTAINER, false) == true,
+        Assertions.assertTrue(filteredListDevc.get(2).getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false) == true,
                 "The run in container value associated with config entry[2] was not true.");
     }
 
@@ -96,7 +96,7 @@ public class LibertyPluginUnitTest {
                 "The expected configuration of " + expectedCfgNameDev + " was not returned. Configuration returned:: " + cfgNameFoundDev);
 
         long expectedTimeDev = 1000000000003L;
-        long timeFoundDev = Long.valueOf(lastRunConfigDev.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
+        long timeFoundDev = Long.valueOf(lastRunConfigDev.getAttribute(StartTab.PROJECT_RUN_TIME, "0"));
         Assertions.assertTrue(timeFoundDev == expectedTimeDev,
                 "The configuration found does not contain the expected value of " + expectedTimeDev + ". Time found: " + timeFoundDev);
 
@@ -114,7 +114,7 @@ public class LibertyPluginUnitTest {
                 "The expected configuration of " + expectedCfgNameDevc + " was not returned. Configuration returned:: " + cfgNameFoundDevc);
 
         long expectedTimeDevc = 1000000000006L;
-        long timeFoundDevc = Long.valueOf(lastRunConfigDevc.getAttribute(MainTab.PROJECT_RUN_TIME, "0"));
+        long timeFoundDevc = Long.valueOf(lastRunConfigDevc.getAttribute(StartTab.PROJECT_RUN_TIME, "0"));
         Assertions.assertTrue(timeFoundDevc == expectedTimeDevc,
                 "The configuration found does not contain the expected value of " + expectedTimeDevc + ". Time found: " + timeFoundDevc);
 
@@ -162,32 +162,32 @@ public class LibertyPluginUnitTest {
 
     private List<ILaunchConfiguration> getDefaultConfigurationList() throws CoreException {
         ArrayList<ILaunchConfiguration> configList = new ArrayList<ILaunchConfiguration>();
-        configList.add(mockLaunchConfiguration(Map.of("name", "test1", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
-                "1000000000001", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
-        configList.add(mockLaunchConfiguration(Map.of("name", "test2", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
-                "1000000000003", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
-        configList.add(mockLaunchConfiguration(Map.of("name", "test3", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
-                "1000000000002", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
-        configList.add(mockLaunchConfiguration(Map.of("name", "test4", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
-                "1000000000004", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
-        configList.add(mockLaunchConfiguration(Map.of("name", "test5", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
-                "1000000000005", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
-        configList.add(mockLaunchConfiguration(Map.of("name", "test6", MainTab.PROJECT_NAME, "project1", MainTab.PROJECT_RUN_TIME,
-                "1000000000006", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test1", StartTab.PROJECT_NAME, "project1", StartTab.PROJECT_RUN_TIME,
+                "1000000000001", StartTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test2", StartTab.PROJECT_NAME, "project1", StartTab.PROJECT_RUN_TIME,
+                "1000000000003", StartTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test3", StartTab.PROJECT_NAME, "project1", StartTab.PROJECT_RUN_TIME,
+                "1000000000002", StartTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test4", StartTab.PROJECT_NAME, "project1", StartTab.PROJECT_RUN_TIME,
+                "1000000000004", StartTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test5", StartTab.PROJECT_NAME, "project1", StartTab.PROJECT_RUN_TIME,
+                "1000000000005", StartTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test6", StartTab.PROJECT_NAME, "project1", StartTab.PROJECT_RUN_TIME,
+                "1000000000006", StartTab.PROJECT_RUN_IN_CONTAINER, true)));
 
-        configList.add(mockLaunchConfiguration(Map.of("name", "test10", MainTab.PROJECT_NAME, "project2", MainTab.PROJECT_RUN_TIME,
-                "1000000000010", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
-        configList.add(mockLaunchConfiguration(Map.of("name", "test11", MainTab.PROJECT_NAME, "project2", MainTab.PROJECT_RUN_TIME,
-                "1000000000011", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
-        configList.add(mockLaunchConfiguration(Map.of("name", "test12", MainTab.PROJECT_NAME, "project2", MainTab.PROJECT_RUN_TIME,
-                "1000000000010", MainTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test10", StartTab.PROJECT_NAME, "project2", StartTab.PROJECT_RUN_TIME,
+                "1000000000010", StartTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test11", StartTab.PROJECT_NAME, "project2", StartTab.PROJECT_RUN_TIME,
+                "1000000000011", StartTab.PROJECT_RUN_IN_CONTAINER, false)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test12", StartTab.PROJECT_NAME, "project2", StartTab.PROJECT_RUN_TIME,
+                "1000000000010", StartTab.PROJECT_RUN_IN_CONTAINER, false)));
 
-        configList.add(mockLaunchConfiguration(Map.of("name", "test15", MainTab.PROJECT_NAME, "project3", MainTab.PROJECT_RUN_TIME,
-                "1000000000011", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
-        configList.add(mockLaunchConfiguration(Map.of("name", "test16", MainTab.PROJECT_NAME, "project3", MainTab.PROJECT_RUN_TIME,
-                "1000000000011", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
-        configList.add(mockLaunchConfiguration(Map.of("name", "test17", MainTab.PROJECT_NAME, "project3", MainTab.PROJECT_RUN_TIME,
-                "1000000000010", MainTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test15", StartTab.PROJECT_NAME, "project3", StartTab.PROJECT_RUN_TIME,
+                "1000000000011", StartTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test16", StartTab.PROJECT_NAME, "project3", StartTab.PROJECT_RUN_TIME,
+                "1000000000011", StartTab.PROJECT_RUN_IN_CONTAINER, true)));
+        configList.add(mockLaunchConfiguration(Map.of("name", "test17", StartTab.PROJECT_NAME, "project3", StartTab.PROJECT_RUN_TIME,
+                "1000000000010", StartTab.PROJECT_RUN_IN_CONTAINER, true)));
 
         return configList;
     }
@@ -195,11 +195,11 @@ public class LibertyPluginUnitTest {
     public static ILaunchConfiguration mockLaunchConfiguration(Map<String, Object> attributes) throws CoreException {
         ILaunchConfiguration config = mock(ILaunchConfiguration.class);
         when(config.getName()).thenReturn((String) attributes.get("name"));
-        when(config.getAttribute(eq(MainTab.PROJECT_NAME), anyString())).thenReturn(((String) attributes.get(MainTab.PROJECT_NAME)));
-        when(config.getAttribute(eq(MainTab.PROJECT_RUN_TIME), anyString()))
-                .thenReturn(((String) attributes.get(MainTab.PROJECT_RUN_TIME)));
-        when(config.getAttribute(eq(MainTab.PROJECT_RUN_IN_CONTAINER), anyBoolean()))
-                .thenReturn(((Boolean) attributes.get(MainTab.PROJECT_RUN_IN_CONTAINER)).booleanValue());
+        when(config.getAttribute(eq(StartTab.PROJECT_NAME), anyString())).thenReturn(((String) attributes.get(StartTab.PROJECT_NAME)));
+        when(config.getAttribute(eq(StartTab.PROJECT_RUN_TIME), anyString()))
+                .thenReturn(((String) attributes.get(StartTab.PROJECT_RUN_TIME)));
+        when(config.getAttribute(eq(StartTab.PROJECT_RUN_IN_CONTAINER), anyBoolean()))
+                .thenReturn(((Boolean) attributes.get(StartTab.PROJECT_RUN_IN_CONTAINER)).booleanValue());
 
         return config;
     }


### PR DESCRIPTION
This PR makes the following external changes:
 
* Fixes #8  - classify project / update dashboard on import
* Fixes #194 - multi-mod aware default start command
* Fixes #206  - classify as Liberty w/ bootstrap.properties or server.env in src/main/liberty/config too
* Changes Run Config tab name from "Main" to "Start" per UFO

In addition there are also some refactoring/renaming changes
* **Dashboard** class renamed to **WorkspaceProjectModel**
* There was an attempt to break apart the classification code to make it clearer when we are only attempting to "read" the model and when we are "writing".  From a high-level perspective, we haven't moved away from essentially reloading the entire model, and still doing a classification, on the initial dashboard load, on refresh, and upon any change.   
The thought here is, though, that if ever need to revist this, and say do a "delta" model update, or do a load without classify, then we will be one step closer to being able to do this with this PR.

Follow-up issue to add tests:  
* https://github.com/OpenLiberty/liberty-tools-eclipse/issues/215