### PR TITLE
Add trace dependency for Java Devs Eclipse IDE

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenGradleTestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenGradleTestReportAction.java
@@ -36,7 +36,7 @@ public class OpenGradleTestReportAction implements ILaunchShortcut {
         IProject iProject = Utils.getProjectFromSelection(selection);
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, selection, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, mode });
         }
 
         try {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenITestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenITestReportAction.java
@@ -36,7 +36,7 @@ public class OpenMavenITestReportAction implements ILaunchShortcut {
         IProject iProject = Utils.getProjectFromSelection(selection);
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, selection, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, mode });
         }
 
         try {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenUTestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenUTestReportAction.java
@@ -36,7 +36,7 @@ public class OpenMavenUTestReportAction implements ILaunchShortcut {
         IProject iProject = Utils.getProjectFromSelection(selection);
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, selection, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, mode });
         }
 
         try {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/RunTestsAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/RunTestsAction.java
@@ -36,7 +36,7 @@ public class RunTestsAction implements ILaunchShortcut {
         IProject iProject = Utils.getProjectFromSelection(selection);
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, selection, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, mode });
         }
 
         try {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -39,7 +39,7 @@ public class StartAction implements ILaunchShortcut {
         IProject iProject = Utils.getProjectFromSelection(selection);
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, selection, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, mode });
         }
 
         try {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartConfigurationDialogAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartConfigurationDialogAction.java
@@ -32,7 +32,7 @@ public class StartConfigurationDialogAction implements ILaunchShortcut {
         IProject iProject = Utils.getProjectFromSelection(selection);
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, selection, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, mode });
         }
 
         try {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
@@ -39,7 +39,7 @@ public class StartInContainerAction implements ILaunchShortcut {
         IProject iProject = Utils.getProjectFromSelection(selection);
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, selection, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, mode });
         }
 
         try {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StopAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StopAction.java
@@ -36,7 +36,7 @@ public class StopAction implements ILaunchShortcut {
         IProject iProject = Utils.getProjectFromSelection(selection);
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, selection, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, mode });
         }
 
         try {

--- a/releng/io.openliberty.tools.update/category.xml
+++ b/releng/io.openliberty.tools.update/category.xml
@@ -12,12 +12,19 @@
       IBM Corporation - initial implementation
 -->
 <site>
-   <feature url="features/io.openliberty.tools.eclipse.feature_0.4.0.qualifier.liberty.jar" id="io.openliberty.tools.eclipse.feature" version="0.4.0.qualifier">
-      <category name="io.openliberty.tools.eclipse"/>
-   </feature>
-   <category-def name="io.openliberty.tools.eclipse" label="Liberty Tools"/>
-   <repository-reference location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/lsp4mp/releases/0.5.0/repository" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/webtools/repository/latest" enabled="true" />
-   <repository-reference location="https://raw.githubusercontent.com/eclipse/lsp4jakarta/build-p2-update-site-0.0.1" enabled="true" />
+    <feature url="features/io.openliberty.tools.eclipse.feature_0.4.0.qualifier.liberty.jar" id="io.openliberty.tools.eclipse.feature" version="0.4.0.qualifier">
+        <category name="io.openliberty.tools.eclipse" />
+    </feature>
+
+    <category-def name="io.openliberty.tools.eclipse" label="Liberty Tools" />
+
+    <repository-reference location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository" enabled="true" />
+    <repository-reference location="https://download.eclipse.org/lsp4mp/releases/0.5.0/repository" enabled="true" />
+    <repository-reference location="https://download.eclipse.org/webtools/repository/latest" enabled="true" />
+    <repository-reference location="https://raw.githubusercontent.com/eclipse/lsp4jakarta/build-p2-update-site-0.0.1" enabled="true" />
+
+    <!-- Dependencies -->
+    <bundle id="org.eclipse.ui.trace" version="1.2.200.v20220310-2159">
+        <category name="io.openliberty.tools.eclipse" />
+    </bundle>
 </site>


### PR DESCRIPTION
This PR allows the tracing facility to be enabled when using Eclipse IDE for Java Developers.
<img width="765" alt="image" src="https://user-images.githubusercontent.com/8353153/199367553-280bda14-11d4-45a4-bfde-93e8c5b61239.png">
