### PR TITLE
Add preferences validation

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import io.openliberty.tools.eclipse.logging.Trace;
+import io.openliberty.tools.eclipse.utils.ErrorHandler;
 import io.openliberty.tools.eclipse.utils.Utils;
 
 public class CommandBuilder {
@@ -46,8 +47,11 @@ public class CommandBuilder {
      * @param pathEnv The PATH env var
      *
      * @return The full Maven command to run on the terminal.
+     * 
+     * @throws CommandNotFoundException
      */
-    public static String getMavenCommandLine(String projectPath, String cmdArgs, String pathEnv) {
+    public static String getMavenCommandLine(String projectPath, String cmdArgs, String pathEnv)
+            throws CommandBuilder.CommandNotFoundException {
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { projectPath, cmdArgs });
         }
@@ -60,7 +64,8 @@ public class CommandBuilder {
         return cmdLine;
     }
 
-    public static String getGradleCommandLine(String projectPath, String cmdArgs, String pathEnv) {
+    public static String getGradleCommandLine(String projectPath, String cmdArgs, String pathEnv)
+            throws CommandBuilder.CommandNotFoundException {
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { projectPath, cmdArgs });
         }
@@ -73,7 +78,7 @@ public class CommandBuilder {
         return cmdLine;
     }
 
-    private String getCommand() {
+    private String getCommand() throws CommandBuilder.CommandNotFoundException {
         String cmd = getCommandFromWrapper();
         if (cmd == null) {
             cmd = getCommandFromPreferences();
@@ -85,10 +90,20 @@ public class CommandBuilder {
         if (Trace.isEnabled()) {
             Trace.getTracer().trace(Trace.TRACE_TOOLS, "Command = " + cmd);
         }
+
         if (cmd == null) {
-            throw new IllegalStateException("Could not find " + (isMaven ? "Maven" : "Gradle")
+
+            String errorMsg = "Could not find " + (isMaven ? "Maven" : "Gradle")
                     + " executable via wrapper, or the Liberty Tools Preferences, or PATH env var.  Please generate a maven or gradle wrapper into the application,"
-                    + " set a path to the executable using the Liberty Tools Preferences page or set the PATH env var to point to a maven or gradle installation.");
+                    + " set a path to the executable using the Liberty Tools Preferences page or set the PATH env var to point to a maven or gradle installation.";
+
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_TOOLS, errorMsg);
+            }
+
+            ErrorHandler.processPreferenceWarningMessage(errorMsg, true);
+
+            throw new CommandNotFoundException(errorMsg);
         }
         return cmd;
     }
@@ -204,4 +219,21 @@ public class CommandBuilder {
         }
     }
 
+    public class CommandNotFoundException extends Exception {
+
+        private static final long serialVersionUID = 8469585975896898403L;
+
+        public CommandNotFoundException() {
+            super();
+        }
+
+        public CommandNotFoundException(String message) {
+            super(message);
+        }
+
+        public CommandNotFoundException(Throwable cause) {
+            super(cause);
+        }
+
+    }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -188,10 +188,31 @@ public class DevModeOperations {
             String cmd = "";
             BuildType buildType = project.getBuildType();
             if (buildType == Project.BuildType.MAVEN) {
-                cmd = CommandBuilder.getMavenCommandLine(projectPath,
+                try {
+                    System.out.println("AJM: trying to get mvn cmd");
+                    cmd = CommandBuilder.getMavenCommandLine(projectPath,
                         "io.openliberty.tools:liberty-maven-plugin:dev " + startParms + " -f " + projectPath, pathEnv);
+                }
+                catch (Exception e) {
+                    String mvnCmdErrMsg = "Unable to get mvn command line";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_TOOLS, mvnCmdErrMsg, e);
+                    }
+                    ErrorHandler.processPreferenceWarningMessage(cmd, e, true);
+                    return;
+                }
             } else if (buildType == Project.BuildType.GRADLE) {
-                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDev " + startParms + " -p=" + projectPath, pathEnv);
+                try {
+                    cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDev " + startParms + " -p=" + projectPath, pathEnv);
+                }
+                catch (Exception e) {
+                    String gradleCmdErrMsg = "Unable to get gradle command line";
+                    if (Trace.isEnabled()) {
+                        Trace.getTracer().trace(Trace.TRACE_TOOLS, gradleCmdErrMsg, e);
+                    }
+                    ErrorHandler.processPreferenceWarningMessage(cmd, e, false);
+                    return;
+                }
             } else {
                 throw new Exception("Unexpected project build type: " + buildType + ". Project" + projectName
                         + "does not appear to be a Maven or Gradle built project.");

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/preferences/LibertyToolsPreferencePage.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/preferences/LibertyToolsPreferencePage.java
@@ -12,22 +12,35 @@
 *******************************************************************************/
 package io.openliberty.tools.eclipse.ui.preferences;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 
+import io.openliberty.tools.eclipse.utils.Utils;
 public class LibertyToolsPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
+    DirectoryFieldEditor mvnInstallFE;
+    DirectoryFieldEditor gradleInstallFE;
+    
     public LibertyToolsPreferencePage() {
         super(GRID);
     }
 
     public void createFieldEditors() {
-        addField(new DirectoryFieldEditor("MVNPATH", "&Maven Install Location:", getFieldEditorParent()));
-        addField(new DirectoryFieldEditor("GRADLEPATH", "&Gradle Install Location:", getFieldEditorParent()));
+        mvnInstallFE = new DirectoryFieldEditor("MVNPATH", "&Maven Install Location:", getFieldEditorParent());
+        gradleInstallFE = new DirectoryFieldEditor("GRADLEPATH", "&Gradle Install Location:", getFieldEditorParent());
+        
+        addField(mvnInstallFE);
+        addField(gradleInstallFE);
     }
 
     @Override
@@ -35,5 +48,66 @@ public class LibertyToolsPreferencePage extends FieldEditorPreferencePage implem
         // second parameter is typically the plug-in id
         setPreferenceStore(new ScopedPreferenceStore(InstanceScope.INSTANCE, "io.openliberty.tools.eclipse.ui"));
         setDescription("Specify the Maven and Gradle installation locations to be used for starting the application in dev mode");
+    }
+    @Override
+    public void propertyChange(PropertyChangeEvent event) {
+        /* Will be called upon any preference update
+         * Must check the validation of both fields in order to output
+         * the correct error message if needed
+         */
+        boolean isMvn;
+        boolean installMvnLocValid = false;
+        boolean installGradleLocValid = false;
+
+        String eventProp = event.getProperty();
+        if (event.getProperty().equals("field_editor_value")) {
+            // field for which validation is required
+            if (event.getSource() == mvnInstallFE) {
+                // validate mvn loc
+                isMvn = true;
+                installMvnLocValid = doValidation(isMvn, mvnInstallFE.getStringValue());
+                installGradleLocValid = doValidation(false, gradleInstallFE.getStringValue());
+            } else {
+                // validate gradle loc
+                isMvn = false;
+                installGradleLocValid = doValidation(isMvn, gradleInstallFE.getStringValue());
+                installMvnLocValid = doValidation(true, mvnInstallFE.getStringValue());
+            }
+
+            if (installMvnLocValid && installGradleLocValid) {
+                setValid(true);
+                setErrorMessage(null);
+                super.performApply();
+                super.propertyChange(event);
+            }
+            // validation fails
+            else {
+                setValid(false);
+                if (!installMvnLocValid && !installGradleLocValid) {
+                    setErrorMessage("Install locations must contain mvn and gradle executables");
+                } else if (!installMvnLocValid && installGradleLocValid){
+                    setErrorMessage("Install location must contain a mvn executable");
+                }
+                else {
+                    setErrorMessage("Install location must contain a gradle executable");
+                }
+            }
+        }
+    }
+    
+    
+    private boolean doValidation(boolean ismvn, String installLoc) {
+        if (installLoc.equals("")) {
+            // an empty field is ok
+            return true;
+        } else {
+            if (ismvn) {
+                Path mvnCmd = Paths.get(installLoc + File.separator, Utils.isWindows() ? "mvn.cmd" : "mvn");
+                return Files.exists(mvnCmd);
+            } else {
+                Path mvnCmd = Paths.get(installLoc + File.separator, Utils.isWindows() ? "gradle.bat" : "gradle");
+                return Files.exists(mvnCmd);
+            }
+        }
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/ErrorHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/ErrorHandler.java
@@ -139,20 +139,21 @@ public class ErrorHandler {
             dialog.open();
         }
     }
-    
+
     /**
      * Logs a message to the platform log and opens the error dialog, if indicated.
      *
      * @param message The message to display.
      * @param displayDialog The indicator to open a dialog.
      */
-    public static void processPreferenceWarningMessage(String message, Throwable t, boolean displayDialog) {
+    public static void processPreferenceWarningMessage(String message, boolean displayDialog) {
         Logger.logWarning(message);
 
         if (displayDialog) {
             Shell shell = Display.getCurrent().getActiveShell();
-            String updatedMessage = appendSuffix(t.getMessage(), SUFFIX_MSG);
-            LibertyToolsMessageDialog ltdialog = new LibertyToolsMessageDialog(shell, TITLE, null, updatedMessage, MessageDialog.ERROR, new String[] { "OK" }, 0);
+            String updatedMessage = appendSuffix(message, SUFFIX_MSG);
+            LibertyToolsMessageDialog ltdialog = new LibertyToolsMessageDialog(shell, TITLE, null, updatedMessage, MessageDialog.ERROR,
+                    new String[] { "OK" }, 0);
             ltdialog.open();
         }
     }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/ErrorHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/ErrorHandler.java
@@ -139,6 +139,23 @@ public class ErrorHandler {
             dialog.open();
         }
     }
+    
+    /**
+     * Logs a message to the platform log and opens the error dialog, if indicated.
+     *
+     * @param message The message to display.
+     * @param displayDialog The indicator to open a dialog.
+     */
+    public static void processPreferenceWarningMessage(String message, Throwable t, boolean displayDialog) {
+        Logger.logWarning(message);
+
+        if (displayDialog) {
+            Shell shell = Display.getCurrent().getActiveShell();
+            String updatedMessage = appendSuffix(t.getMessage(), SUFFIX_MSG);
+            LibertyToolsMessageDialog ltdialog = new LibertyToolsMessageDialog(shell, TITLE, null, updatedMessage, MessageDialog.ERROR, new String[] { "OK" }, 0);
+            ltdialog.open();
+        }
+    }
 
     /**
      * Returns the input message with the input suffix appended.

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/LibertyToolsMessageDialog.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/LibertyToolsMessageDialog.java
@@ -1,0 +1,67 @@
+package io.openliberty.tools.eclipse.utils;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.preference.IPreferencePageContainer;
+import org.eclipse.jface.preference.PreferenceDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.dialogs.PreferencesUtil;
+import org.eclipse.ui.preferences.IWorkbenchPreferenceContainer;
+
+public class LibertyToolsMessageDialog extends MessageDialog {
+
+    public LibertyToolsMessageDialog(Shell parentShell, String dialogTitle, Image dialogTitleImage, String dialogMessage,
+            int dialogImageType, String[] dialogButtonLabels, int defaultIndex) {
+        super(parentShell, dialogTitle, dialogTitleImage, dialogMessage, dialogImageType, defaultIndex, dialogButtonLabels);
+    }
+    
+    @Override
+    protected Control createCustomArea( Composite parent ) {
+      Link link = new Link( parent, SWT.WRAP );
+      link.setText( "Please visit <a>Liberty Preferences</a>" );
+      link.addSelectionListener(new SelectionAdapter() {
+          @Override
+          public void widgetSelected(SelectionEvent e) {
+              PreferenceDialog dialog = PreferencesUtil.createPreferenceDialogOn(
+                      null, "io.openliberty.tools.eclipse.ui.preferences.page",  
+                      new String[] {"io.openliberty.tools.eclipse.ui.preferences.page"}, null);
+                  dialog.open();
+          }
+      });
+      return link;
+    }
+    
+    /*
+    @Override
+    protected Control createMessageArea( Composite composite ) {
+      Image image = getImage();
+      if( image != null ) {
+        imageLabel = new Label( composite, SWT.NULL );
+        image.setBackground( imageLabel.getBackground() );
+        imageLabel.setImage( image );
+        GridDataFactory.fillDefaults().align( SWT.CENTER, SWT.BEGINNING ).applyTo( imageLabel );
+      }
+      if( message != null ) {
+        Link link = new Link( composite, getMessageLabelStyle() );
+        link.setText( "This is a longer nonsense message to show that the link widget wraps text if specified so. Please visit <a>this link</a>." );
+        GridDataFactory.fillDefaults()
+          .align( SWT.FILL, SWT.BEGINNING )
+          .grab( true, false )
+          .hint( convertHorizontalDLUsToPixels( IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH ), SWT.DEFAULT )
+          .applyTo( link );
+      }
+      return composite;
+    }
+    */
+  }
+

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/LibertyToolsMessageDialog.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/LibertyToolsMessageDialog.java
@@ -1,22 +1,28 @@
+/*******************************************************************************
+* Copyright (c) 2022 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial implementation
+*******************************************************************************/
 package io.openliberty.tools.eclipse.utils;
 
-import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.layout.GridDataFactory;
-import org.eclipse.jface.preference.IPreferencePageContainer;
 import org.eclipse.jface.preference.PreferenceDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.dialogs.PreferencesUtil;
-import org.eclipse.ui.preferences.IWorkbenchPreferenceContainer;
 
 public class LibertyToolsMessageDialog extends MessageDialog {
 
@@ -24,44 +30,20 @@ public class LibertyToolsMessageDialog extends MessageDialog {
             int dialogImageType, String[] dialogButtonLabels, int defaultIndex) {
         super(parentShell, dialogTitle, dialogTitleImage, dialogMessage, dialogImageType, defaultIndex, dialogButtonLabels);
     }
-    
-    @Override
-    protected Control createCustomArea( Composite parent ) {
-      Link link = new Link( parent, SWT.WRAP );
-      link.setText( "Please visit <a>Liberty Preferences</a>" );
-      link.addSelectionListener(new SelectionAdapter() {
-          @Override
-          public void widgetSelected(SelectionEvent e) {
-              PreferenceDialog dialog = PreferencesUtil.createPreferenceDialogOn(
-                      null, "io.openliberty.tools.eclipse.ui.preferences.page",  
-                      new String[] {"io.openliberty.tools.eclipse.ui.preferences.page"}, null);
-                  dialog.open();
-          }
-      });
-      return link;
-    }
-    
-    /*
-    @Override
-    protected Control createMessageArea( Composite composite ) {
-      Image image = getImage();
-      if( image != null ) {
-        imageLabel = new Label( composite, SWT.NULL );
-        image.setBackground( imageLabel.getBackground() );
-        imageLabel.setImage( image );
-        GridDataFactory.fillDefaults().align( SWT.CENTER, SWT.BEGINNING ).applyTo( imageLabel );
-      }
-      if( message != null ) {
-        Link link = new Link( composite, getMessageLabelStyle() );
-        link.setText( "This is a longer nonsense message to show that the link widget wraps text if specified so. Please visit <a>this link</a>." );
-        GridDataFactory.fillDefaults()
-          .align( SWT.FILL, SWT.BEGINNING )
-          .grab( true, false )
-          .hint( convertHorizontalDLUsToPixels( IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH ), SWT.DEFAULT )
-          .applyTo( link );
-      }
-      return composite;
-    }
-    */
-  }
 
+    @Override
+    protected Control createCustomArea(Composite parent) {
+        Link link = new Link(parent, SWT.WRAP);
+        link.setText("Please visit <a>Liberty Preferences</a>");
+        link.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                PreferenceDialog dialog = PreferencesUtil.createPreferenceDialogOn(null, "io.openliberty.tools.eclipse.ui.preferences.page",
+                        new String[] { "io.openliberty.tools.eclipse.ui.preferences.page" }, null);
+                dialog.open();
+            }
+        });
+        return link;
+    }
+
+}

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.openliberty.tools.eclipse.CommandBuilder;
+import io.openliberty.tools.eclipse.CommandBuilder.CommandNotFoundException;
 import io.openliberty.tools.eclipse.LibertyNature;
 import io.openliberty.tools.eclipse.Project;
 import io.openliberty.tools.eclipse.test.it.utils.DisabledOnMac;
@@ -204,7 +205,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
 
     @Test
     @DisabledOnMac
-    public void testMavenCommandAssembly() throws IOException, InterruptedException {
+    public void testMavenCommandAssembly() throws IOException, InterruptedException, CommandNotFoundException {
 
         IProject iProject = LibertyPluginTestUtils.getProject(MVN_APP_NAME);
         String projPath = iProject.getLocation().toOSString();
@@ -217,7 +218,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
     }
 
     @Test
-    public void testMavenWrapperCommandAssembly() throws IOException, InterruptedException {
+    public void testMavenWrapperCommandAssembly() throws IOException, InterruptedException, CommandNotFoundException {
         IProject iProject = LibertyPluginTestUtils.getProject(MVN_WRAPPER_APP_NAME);
         String projPath = iProject.getLocation().toOSString();
 


### PR DESCRIPTION
Fixes #234 

I see a couple issues:
1. The 'Apply' and 'Apply and Close' buttons seem to remain greyed out once pushed.  So if you make a mistake, hit 'Apply' then get the error message, and then try to type again you won't see these two buttons become "pushable" again.
2.  The error text is a bit too long.   There's nothing to be gained from looking at the error log either. 
3. Maybe the preference text should explain the precedence order: 1. wrapper, 2. mvn/gradle pref 3. PATH   though this could always be done later. 

Finally... we might benefit from one-char-at-a-time validation, like we see in Mac/Linux Local Terminal validation here:

![image](https://user-images.githubusercontent.com/4081634/202871252-7acd64e6-5a5f-4905-a409-b5da56503bb8.png)

That also could be done separately though.