### PR TITLE
Open debug perspective after successful debugger connection

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DebugModeHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DebugModeHandler.java
@@ -495,10 +495,8 @@ public class DebugModeHandler {
      */
     private String waitForSocketActivation(Project project, String host, String port, IProgressMonitor monitor) throws Exception {
         byte[] handshakeString = "JDWP-Handshake".getBytes(StandardCharsets.US_ASCII);
-        int retryLimit = 75;
+        int retryLimit = 90;
         int envReadMinLimit = 45;
-        int envreadMaxLimit = 75;
-        int envReadInterval = 5;
 
         // Retrieve the location of the server.env in the liberty installation at the default location (wpl/usr/servers/<serverName>).
         Path serverEnvPath = getServerEnvPath(project);
@@ -538,7 +536,7 @@ public class DebugModeHandler {
             // Check the deployed server.env at the default deployment location (wlp/usr/servers/<serverName>) for the WLP_DEBUG_ADDRESS
             // property. If the port is already in use, dev mode will allocate a random debug port and reflect that by updating the
             // server.env file.
-            if (retryCount >= envReadMinLimit && retryCount < envreadMaxLimit && (retryCount % envReadInterval == 0)) {
+            if (retryCount >= envReadMinLimit) {
                 // Look for the server.env.bak file before checking the server.env file.
                 Path serverEnvBakPath = (serverEnvPath != null) ? serverEnvPath.resolveSibling(WLP_SERVER_ENV_BAK_FILE_NAME) : null;
                 if (serverEnvBakPath != null && serverEnvBakPath.toFile().exists()) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
@@ -52,6 +52,9 @@ import io.openliberty.tools.eclipse.utils.ErrorHandler;
  */
 public class DashboardView extends ViewPart {
 
+    /** Dashboard view ID. */
+    public static final String ID = "io.openliberty.tools.eclipse.views.liberty.devmode.dashboard";
+
     /** Liberty logo path. */
     public static final String LIBERTY_LOGO_PATH = "icons/openLibertyLogo.png";
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/terminal/ProjectTabController.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/terminal/ProjectTabController.java
@@ -31,24 +31,19 @@ import io.openliberty.tools.eclipse.ui.terminal.ProjectTab.State;
  */
 public class ProjectTabController {
 
-    /**
-     * The set of active Terminal associated with different application projects.
-     */
-    private static ConcurrentHashMap<String, ProjectTab> projectTabMap = new ConcurrentHashMap<String, ProjectTab>();
+    /** Terminal view ID. */
+    public static final String TERMINAL_VIEW_ID = "org.eclipse.tm.terminal.view.ui.TerminalsView";
 
-    /**
-     * The set of terminal listeners associated with the different application projects.
-     */
-    private static ConcurrentHashMap<String, List<TerminalListener>> projectTerminalListenerMap = new ConcurrentHashMap<String, List<TerminalListener>>();
+    /** The set of active Terminal associated with different application projects. */
+    private static final ConcurrentHashMap<String, ProjectTab> projectTabMap = new ConcurrentHashMap<String, ProjectTab>();
 
-    /**
-     * TerminalManager instance.
-     */
+    /** The set of terminal listeners associated with the different application projects. */
+    private static final ConcurrentHashMap<String, List<TerminalListener>> projectTerminalListenerMap = new ConcurrentHashMap<String, List<TerminalListener>>();
+
+    /** TerminalManager instance. */
     private static ProjectTabController instance;
 
-    /**
-     * Terminal console manager instance.
-     */
+    /** Terminal console manager instance. */
     private ConsoleManager consoleMgr;
 
     /**


### PR DESCRIPTION
This PR does the following:
- When the debugger attaches successfully, the perspective changed to show the debug perspective if it is not already shown.
- Fixes port issues when project specifies a port through server.env.
- Increases the debugger attach wait time to account for longer Gradle wait times.