### PR TITLE
Dispose of terminal tab image

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/terminal/ProjectTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/terminal/ProjectTab.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.tm.internal.terminal.provisional.api.ITerminalConnector;
 import org.eclipse.tm.terminal.view.core.TerminalServiceFactory;
 import org.eclipse.tm.terminal.view.core.interfaces.ITerminalService;
@@ -69,6 +70,9 @@ public class ProjectTab {
      */
     private State state;
 
+    /** Tab image */
+    private Image libertyImage;
+
     /**
      * States.
      */
@@ -85,6 +89,7 @@ public class ProjectTab {
         this.projectName = projectName;
         this.terminalService = TerminalServiceFactory.getService();
         this.tabListener = new TerminalTabListenerImpl(projectName);
+        this.libertyImage = Utils.getImage(PlatformUI.getWorkbench().getDisplay(), DashboardView.LIBERTY_LOGO_PATH);
 
         state = State.INACTIVE;
     }
@@ -173,7 +178,7 @@ public class ProjectTab {
      */
     private void updateImage() {
         projectTab.getDisplay().asyncExec(() -> {
-            projectTab.setImage(Utils.getImage(PlatformUI.getWorkbench().getDisplay(), DashboardView.LIBERTY_LOGO_PATH));
+            projectTab.setImage(libertyImage);
         });
     }
 
@@ -289,6 +294,10 @@ public class ProjectTab {
     public void cleanup() {
         // Remove the registered listener from the calling service.
         terminalService.removeTerminalTabListener(tabListener);
+
+        if (libertyImage != null) {
+            libertyImage.dispose();
+        }
     }
 
     /**

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/terminal/ProjectTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/terminal/ProjectTab.java
@@ -70,7 +70,9 @@ public class ProjectTab {
      */
     private State state;
 
-    /** Tab image */
+    /**
+     * Tab image
+     */
     private Image libertyImage;
 
     /**
@@ -96,6 +98,8 @@ public class ProjectTab {
 
     /**
      * Sets the connector associated with this terminal.
+     * 
+     * @param connector The terminal connector for terminal interaction.
      */
     public void setConnector(ITerminalConnector connector) {
         this.connector = connector;
@@ -103,6 +107,8 @@ public class ProjectTab {
 
     /**
      * Returns the connector associated with this terminal.
+     * 
+     * @return The connector associated with this terminal.
      */
     public ITerminalConnector getConnector() {
         return connector;
@@ -295,6 +301,7 @@ public class ProjectTab {
         // Remove the registered listener from the calling service.
         terminalService.removeTerminalTabListener(tabListener);
 
+        // Dispose of the liberty image associated with this tab.
         if (libertyImage != null) {
             libertyImage.dispose();
         }
@@ -312,6 +319,7 @@ public class ProjectTab {
             }
             return;
         }
+
         IViewPart viewPart = null;
         try {
             viewPart = activePage.showView(IUIConstants.ID, null, IWorkbenchPage.VIEW_ACTIVATE);


### PR DESCRIPTION
fixes #264 

This PR fixes the error below that appears when a terminal tab running a project is closed.

java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:120)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:684)
	at io.openliberty.tools.eclipse.utils.Utils.getImage(Utils.java:68)
	at io.openliberty.tools.eclipse.ui.terminal.ProjectTab.lambda$0(ProjectTab.java:176)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4318)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3941)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1155)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:643)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:550)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:171)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:402)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:596)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1467)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1440)
