### PR TITLE
Add refresh on add of Liberty Nature

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyNature.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyNature.java
@@ -15,6 +15,7 @@ package io.openliberty.tools.eclipse;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.swt.widgets.Display;
 
 /**
  * Represents a Liberty nature or type.
@@ -26,10 +27,22 @@ public class LibertyNature implements IProjectNature {
 
     @Override
     public void configure() throws CoreException {
+        Display.getDefault().syncExec(new Runnable() {
+            @Override
+            public void run() {
+                DevModeOperations.getInstance().refreshDashboardView(false);
+            }
+        });
     }
 
     @Override
     public void deconfigure() throws CoreException {
+        Display.getDefault().syncExec(new Runnable() {
+            @Override
+            public void run() {
+                DevModeOperations.getInstance().refreshDashboardView(false);
+            }
+        });
     }
 
     @Override

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/handlers/ExplorerMenuHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/handlers/ExplorerMenuHandler.java
@@ -10,7 +10,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.handlers.HandlerUtil;
 
-import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.LibertyNature;
 import io.openliberty.tools.eclipse.Project;
 import io.openliberty.tools.eclipse.logging.Trace;
@@ -95,8 +94,6 @@ public class ExplorerMenuHandler extends AbstractHandler {
                 ErrorHandler.processErrorMessage(msg, e);
             }
         }
-
-        DevModeOperations.getInstance().getProjectModel().createNewCompleteWorkspaceModelWithClassify();
 
         if (Trace.isEnabled()) {
             Trace.getTracer().traceExit(Trace.TRACE_HANDLERS);


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Currently a "Configure -> Enable Liberty" doesn't auto-refresh the dashboard.  With this change we refresh the DB on Configure AND also if you right-click the proj. and do "Properties -> Project Natures -> Add -> ...Liberty".

Because of this there was no need to do another workspace model build within configure so I removed it.