### PR TITLE
Fix problems when no project is selected

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -111,7 +111,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
         createInputParmText(parmsGroupComposite);
         createRunInContainerButton(parmsGroupComposite);
 
-        createLabellWithPreferenceLink(mainComposite);
+        createLabelWithPreferenceLink(mainComposite);
     }
 
     /**
@@ -205,15 +205,19 @@ public class StartTab extends AbstractLaunchConfigurationTab {
             String configProjectName = config.getAttribute(PROJECT_NAME, (String) null);
 
             if (configProjectName == null) {
-                super.setErrorMessage("Project name not set");
+                super.setErrorMessage(
+                        "This Run/Debug config is corrupted and can't be used since no project was selected before creating. To create a new Run/Debug config first select a project in the Liberty dashboard, Project/Package explorer view, or via editor.");
                 return false;
             }
 
-            String selectedProjectName = Utils.getActiveProject().getName();
-            if (!configProjectName.equals(selectedProjectName)) {
-                super.setWarningMessage(
-                        "Must use an existing (or new) configuration associated with selected project: " + selectedProjectName);
-                return false;
+            IProject selectedProject = Utils.getActiveProject();
+            if (selectedProject != null) {
+                String selectedProjectName = Utils.getActiveProject().getName();
+                if (!configProjectName.equals(selectedProjectName)) {
+                    super.setWarningMessage(
+                            "Must use an existing (or new) configuration associated with selected project: " + selectedProjectName);
+                    return false;
+                }
             }
         } catch (CoreException e) {
             traceError(e, "Error getting project name");
@@ -348,7 +352,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
      * 
      * @param parent The parent composite.
      */
-    private void createLabellWithPreferenceLink(Composite parent) {
+    private void createLabelWithPreferenceLink(Composite parent) {
         Label emptyLineLabel = new Label(parent, SWT.NONE);
         GridDataFactory.swtDefaults().applyTo(emptyLineLabel);
 

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -133,6 +133,13 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
     public static final void validateBeforeTestRun() {
         dashboard = SWTBotPluginOperations.openDashboardUsingToolbar(bot);
 
+        // Give the app some time to be imported (especially on Windows GHA runs)
+        try {
+            Thread.sleep(40000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
         // Check that the dashboard can be opened and its content retrieved.
         List<String> projectList = SWTBotPluginOperations.getDashboardContent(bot, dashboard);
 

--- a/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
+++ b/tests/src/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
@@ -108,6 +108,7 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
     public static final void validateBeforeTestRun() {
         dashboard = SWTBotPluginOperations.openDashboardUsingToolbar(bot);
 
+        // Give the app some time to be imported (especially on Windows GHA runs)
         try {
             Thread.sleep(60000);
         } catch (InterruptedException e) {


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Fixes two problems when no project is selected:
1. Run/Debug config isn't associated with any project.  Since there's no way to set the project post-creation, this config is now "corrupted" and a new one is needed.  Add validation error message explaining this.
2. Validation blows up with NPE if no project is selected at the time a Run/Debug config is selected.  Add null check