### PR TITLE
Add link to LCLS NOTICES at end of EPL v2.0 license

### DIFF
--- a/features/io.openliberty.tools.eclipse.feature/feature.properties
+++ b/features/io.openliberty.tools.eclipse.feature/feature.properties
@@ -288,3 +288,11 @@ version(s), and exceptions or additional permissions here}."\n\
   You may add additional accurate notices of copyright ownership.\n\
 \n\
 \n\
+# End of Eclipse Public License - v 2.0\n\
+\n\
+######################\n\
+# ADDITIONAL NOTICES #\n\
+######################\n\
+\n\
+For additional license information see: \n\
+  Liberty Config Language Server "NOTICES" at: https://raw.githubusercontent.com/OpenLiberty/liberty-language-server/d2919d152218db93e264cd1f3b8417721ed43d1c/NOTICES \n\

--- a/features/io.openliberty.tools.eclipse.feature/license.html
+++ b/features/io.openliberty.tools.eclipse.feature/license.html
@@ -295,5 +295,10 @@
       </p>
       <p>You may add additional accurate notices of copyright ownership.</p>
     </blockquote>
-  
+    <h1>ADDITIONAL NOTICES</h1>
+    <p>See additional information for:
+       <ul>
+           <li>Liberty Config Language Server - see: <a href="https://raw.githubusercontent.com/OpenLiberty/liberty-language-server/d2919d152218db93e264cd1f3b8417721ed43d1c/NOTICES">NOTICES</a></li>
+       </ul>
+    </p>
 </body></html>


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Fixes https://github.com/OpenLiberty/liberty-tools-eclipse/issues/219

As discussed internally, we're going to "lead" with a simple copy/paste of EPL v2.0.

At the end, we're going to link to the particular NOTICES from our various dependencies.  

At the moment, the only dependency with anything interesting captured is the one LCLS dependency.   So I simply ended the license text with a reference to the LCLS NOTICES file in the LCLS source repo.

## EXAMPLE DISPLAY

It ends up looking like this, in the Eclipse UI install wizard panel (scrolling down to the bottom):

![image](https://user-images.githubusercontent.com/4081634/207194275-602ef8ac-8819-4920-b9f7-d213f031dba2.png)

and it looks like this in the `license.html` included with the feature install directory:

![image](https://user-images.githubusercontent.com/4081634/207194762-e4ec238e-7045-4429-91f0-14d9565a7463.png)
