### PR TITLE
1 q2023 target platform

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.lsp4e/.classpath
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/.classpath
@@ -8,7 +8,7 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="lib" path="server/liberty-langserver/liberty-langserver.jar"/>
-	<classpathentry kind="lib" path="server/mp-langserver/org.eclipse.lsp4mp.ls-0.5.0-uber.jar"/>
+	<classpathentry kind="lib" path="server/mp-langserver/org.eclipse.lsp4mp.ls.jar"/>
 	<classpathentry kind="lib" path="server/jakarta-langserver/org.eclipse.lsp4jakarta.ls.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools Support for Language Servers
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.ls.plugin.LibertyToolsLSPlugin
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: io.openliberty.tools.eclipse.lsp4e

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-Activator: io.openliberty.tools.eclipse.ls.plugin.LibertyToolsLSPlugin
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: io.openliberty.tools.eclipse.lsp4e
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.eclipse.lsp4mp.jdt.core,
+Require-Bundle: com.google.gson,
+ org.eclipse.lsp4mp.jdt.core,
  org.eclipse.lsp4jakarta.jdt.core,
  org.eclipse.lsp4e,
  org.eclipse.lsp4e.jdt,

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -25,6 +25,6 @@ Require-Bundle: org.eclipse.lsp4mp.jdt.core,
  org.eclipse.jdt.ls.core,
  org.eclipse.ui.workbench
 Bundle-ClassPath: .,
- server/mp-langserver/org.eclipse.lsp4mp.ls-0.5.0-uber.jar,
+ server/mp-langserver/org.eclipse.lsp4mp.ls.jar,
  server/liberty-langserver/liberty-langserver.jar,
  server/jakarta-langserver/org.eclipse.lsp4jakarta.ls.jar

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/build.properties
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/build.properties
@@ -5,7 +5,7 @@ bin.includes = META-INF/,\
                epl-v20.html,\
                plugin.xml,\
                .,\
-               server/mp-langserver/org.eclipse.lsp4mp.ls-0.5.0-uber.jar,\
+               server/mp-langserver/org.eclipse.lsp4mp.ls.jar,\
                server/liberty-lemminx-extn/liberty-langserver-lemminx.jar,\
                server/liberty-langserver/liberty-langserver.jar, \
                server/jakarta-langserver/org.eclipse.lsp4jakarta.ls.jar

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
@@ -27,6 +27,7 @@
     <properties>
         <liberty.ls.version>1.0-M2-SNAPSHOT</liberty.ls.version>
         <jakarta.ls.version>0.1.0</jakarta.ls.version>
+        <mp.ls.version>0.7.0</mp.ls.version>
     </properties>
     <artifactId>io.openliberty.tools.eclipse.lsp4e</artifactId>
     
@@ -36,7 +37,7 @@
        <dependency>
             <groupId>org.eclipse.lsp4mp</groupId>
             <artifactId>org.eclipse.lsp4mp.ls</artifactId>
-            <version>0.5.0</version>
+            <version>${mp.ls.version}</version>
        </dependency>
        <dependency>
             <groupId>io.openliberty.tools</groupId>
@@ -73,10 +74,11 @@
                                 <artifactItem>
                                   <groupId>org.eclipse.lsp4mp</groupId>
                                   <artifactId>org.eclipse.lsp4mp.ls</artifactId>
-                                  <version>0.5.0</version>
+                                  <version>${mp.ls.version}</version>
                                   <classifier>uber</classifier>
                                   <type>jar</type>
                                   <overWrite>true</overWrite>
+                                  <destFileName>org.eclipse.lsp4mp.ls.jar</destFileName>
                                 </artifactItem>
                                </artifactItems> 
                               <outputDirectory>${project.basedir}/server/mp-langserver</outputDirectory>

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.openliberty.tools.eclipse</groupId>
         <artifactId>parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/mpls/LibertyMPLSConnection.java
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/mpls/LibertyMPLSConnection.java
@@ -62,7 +62,7 @@ public class LibertyMPLSConnection extends ProcessStreamConnectionProvider {
 
 	private String computeClasspath() throws IOException {
 		StringBuilder builder = new StringBuilder();
-		URL url = FileLocator.toFileURL(getClass().getResource("/server/mp-langserver/org.eclipse.lsp4mp.ls-0.5.0-uber.jar"));
+		URL url = FileLocator.toFileURL(getClass().getResource("/server/mp-langserver/org.eclipse.lsp4mp.ls.jar"));
 		builder.append(new java.io.File(url.getPath()).getAbsolutePath());
 		return builder.toString();
 	}

--- a/bundles/io.openliberty.tools.eclipse.product/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.product/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.product;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: io.openliberty.tools.eclipse
 Bundle-ActivationPolicy: lazy

--- a/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools UI
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.ui;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.LibertyDevPlugin
 Export-Package: io.openliberty.tools.eclipse;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.ui.dashboard;x-friends:="io.openliberty.tools.eclipse.tests",

--- a/features/io.openliberty.tools.eclipse.feature/feature.xml
+++ b/features/io.openliberty.tools.eclipse.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="io.openliberty.tools.eclipse"
       label="%featureName"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
     plugin="io.openliberty.tools.eclipse.product"
     provider-name="%providerName">
 
@@ -28,21 +28,21 @@
          id="io.openliberty.tools.eclipse.ui"
          download-size="0"
          install-size="0"
-         version="0.8.0.qualifier"
+         version="0.9.0.qualifier"
          unpack="false"/>
 
    <plugin
          id="io.openliberty.tools.eclipse.lsp4e"
          download-size="0"
          install-size="0"
-         version="0.8.0.qualifier"
+         version="0.9.0.qualifier"
          unpack="false"/>
 
    <plugin
          id="io.openliberty.tools.eclipse.product"
          download-size="0"
          install-size="0"
-         version="0.8.0.qualifier"
+         version="0.9.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.openliberty.tools.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>0.8.0-SNAPSHOT</version>
+	<version>0.9.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
     <licenses>
       <license>
@@ -196,7 +196,7 @@
 						<artifact>
 							<groupId>io.openliberty.tools.eclipse</groupId>
 							<artifactId>target-platform-${eclipse.target}</artifactId>
-							<version>0.8.0-SNAPSHOT</version>
+							<version>0.9.0-SNAPSHOT</version>
 							<file>target-platform-${eclipse.target}</file>
 						</artifact>
 					</target>

--- a/releng/io.openliberty.tools.update/category.xml
+++ b/releng/io.openliberty.tools.update/category.xml
@@ -18,6 +18,7 @@
 
     <category-def name="io.openliberty.tools.eclipse" label="Liberty Tools" />
 
+    <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.22.0/" enabled="true" />
     <repository-reference location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository" enabled="true" />
     <repository-reference location="https://download.eclipse.org/lsp4mp/releases/0.7.0/repository" enabled="true" />
     <repository-reference location="https://download.eclipse.org/lsp4jakarta/releases/0.1.0/repository" enabled="true" />

--- a/releng/io.openliberty.tools.update/category.xml
+++ b/releng/io.openliberty.tools.update/category.xml
@@ -19,7 +19,7 @@
     <category-def name="io.openliberty.tools.eclipse" label="Liberty Tools" />
 
     <repository-reference location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository" enabled="true" />
-    <repository-reference location="https://download.eclipse.org/lsp4mp/releases/0.5.0/repository" enabled="true" />
+    <repository-reference location="https://download.eclipse.org/lsp4mp/releases/0.7.0/repository" enabled="true" />
     <repository-reference location="https://download.eclipse.org/lsp4jakarta/releases/0.1.0/repository" enabled="true" />
 
     <!-- Dependencies -->

--- a/releng/io.openliberty.tools.update/category.xml
+++ b/releng/io.openliberty.tools.update/category.xml
@@ -19,7 +19,7 @@
     <category-def name="io.openliberty.tools.eclipse" label="Liberty Tools" />
 
     <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.22.0/" enabled="true" />
-    <repository-reference location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository" enabled="true" />
+    <repository-reference location="https://download.eclipse.org/jdtls/milestones/1.22.0/repository" enabled="true" />
     <repository-reference location="https://download.eclipse.org/lsp4mp/releases/0.7.0/repository" enabled="true" />
     <repository-reference location="https://download.eclipse.org/lsp4jakarta/releases/0.1.0/repository" enabled="true" />
 

--- a/releng/io.openliberty.tools.update/category.xml
+++ b/releng/io.openliberty.tools.update/category.xml
@@ -12,7 +12,7 @@
       IBM Corporation - initial implementation
 -->
 <site>
-    <feature url="features/io.openliberty.tools.eclipse_0.8.0.qualifier.liberty.jar" id="io.openliberty.tools.eclipse" version="0.8.0.qualifier">
+    <feature url="features/io.openliberty.tools.eclipse_0.9.0.qualifier.liberty.jar" id="io.openliberty.tools.eclipse" version="0.9.0.qualifier">
         <category name="io.openliberty.tools.eclipse" />
     </feature>
 

--- a/releng/target-platform-1Q2023/target-platform-1Q2023.target
+++ b/releng/target-platform-1Q2023/target-platform-1Q2023.target
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<!--
+  Copyright (c) 2022 IBM Corporation and others.
+  
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Contributors:
+      IBM Corporation - initial implementation
+-->
+<target includeMode="feature" name="target-platform.target" sequenceNumber="15">
+    <locations>
+
+    <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.0.2/"/>
+        <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="1.0.2.202302250247"/>
+      <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="1.0.2.202301201156"/>
+     </location>
+
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/releases/2023-03/"/>
+            <unit id="org.eclipse.jdt.feature.group" version="3.19.0.v20230302-0300"/>
+            <unit id="org.eclipse.lsp4e" version="0.15.0.202211292024"/>
+            <unit id="org.eclipse.ui.trace" version="1.2.200.v20220310-2159"/>
+            <unit id="org.eclipse.lsp4e.jdt" version="0.10.2.202205031750"/>
+            <unit id="org.eclipse.emf.sdk.feature.group" version="2.33.0.v20230226-0921"/>
+            <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.700.v20230220-1352"/>
+            <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.6.0.20230118-0812"/>
+            <unit id="org.eclipse.platform.sdk" version="4.27.0.I20230302-0300"/>
+            <unit id="org.eclipse.ui.trace" version="1.2.200.v20220310-2159"/>
+            <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
+            <unit id="org.junit" version="4.13.2.v20211018-1956"/>
+            <unit id="junit-jupiter-api" version="5.9.2"/>
+            <unit id="junit-jupiter-engine" version="5.9.2"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository"/>
+            <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
+            <unit id="ch.qos.logback.slf4j.source" version="1.2.3.v20200428-2012"/>
+            <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
+            <unit id="org.slf4j.api.source" version="1.7.30.v20200204-2150"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/technology/swtbot/releases/3.1.0"/>
+            <unit id="org.eclipse.swtbot.eclipse.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.forms.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.ide.feature.group" version="3.1.0.202106041005"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/cdt/releases/10.6"/>
+            <unit id="org.eclipse.tm.terminal.connector.cdtserial.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.cdtserial.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.local.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.remote.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.remote.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.ssh.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.telnet.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.control.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.view.feature.source.feature.group" version="10.6.2.202205081303"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="http://download.eclipse.org/lsp4mp/releases/0.7.0/repository/"/>
+            <unit id="org.eclipse.lsp4mp.jdt.core" version="0.7.0.20230403-1449"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository/"/>
+            <unit id="org.eclipse.jdt.ls.core" version="1.5.0.202110191539"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.6.v20220511-1359/"/>
+            <unit id="org.eclipse.buildship.ui" version="3.1.6.v20220511-1359"/>
+        </location>
+        <location includeDependencyDepth="none" includeDependencyScopes="compile" missingManifest="generate" type="Maven">
+            <dependencies>
+                <dependency>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy-agent</artifactId>
+                    <version>1.12.17</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                    <version>1.12.17</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <version>4.8.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-junit-jupiter</artifactId>
+                    <version>4.8.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                    <version>3.3</version>
+                    <type>jar</type>
+                </dependency>
+            </dependencies>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/lsp4jakarta/releases/0.1.0/repository"/>
+            <unit id="org.eclipse.lsp4jakarta.jdt.core" version="0.0"/>
+        </location>
+                
+    </locations>
+</target>

--- a/releng/target-platform-3Q2022/target-platform-3Q2022.target
+++ b/releng/target-platform-3Q2022/target-platform-3Q2022.target
@@ -66,8 +66,8 @@
             <unit id="org.eclipse.tm.terminal.view.feature.source.feature.group" version="10.6.2.202205081303"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="http://download.eclipse.org/lsp4mp/releases/0.5.0/repository/"/>
-            <unit id="org.eclipse.lsp4mp.jdt.core" version="0.5.0.20220725-1528"/>
+            <repository location="http://download.eclipse.org/lsp4mp/releases/0.7.0/repository/"/>
+            <unit id="org.eclipse.lsp4mp.jdt.core" version="0.7.0.20230403-1449"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository/"/>

--- a/releng/target-platform-4Q2022/target-platform-4Q2022.target
+++ b/releng/target-platform-4Q2022/target-platform-4Q2022.target
@@ -65,8 +65,8 @@
             <unit id="org.eclipse.tm.terminal.view.feature.source.feature.group" version="10.6.2.202205081303"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="http://download.eclipse.org/lsp4mp/releases/0.5.0/repository/"/>
-            <unit id="org.eclipse.lsp4mp.jdt.core" version="0.5.0.20220725-1528"/>
+            <repository location="http://download.eclipse.org/lsp4mp/releases/0.7.0/repository/"/>
+            <unit id="org.eclipse.lsp4mp.jdt.core" version="0.7.0.20230403-1449"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository/"/>

--- a/releng/target-platform-4Q2022/target-platform-4Q2022.target
+++ b/releng/target-platform-4Q2022/target-platform-4Q2022.target
@@ -14,6 +14,13 @@
 -->
 <target includeMode="feature" name="target-platform.target" sequenceNumber="15">
     <locations>
+
+    <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.0.2/"/>
+        <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="1.0.2.202302250247"/>
+      <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="1.0.2.202301201156"/>
+     </location>
+
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/releases/2022-12/"/>
             <unit id="org.eclipse.jdt.feature.group" version="3.18.1400.v20221123-1800"/>
@@ -114,5 +121,6 @@
             <repository location="https://download.eclipse.org/lsp4jakarta/releases/0.1.0/repository"/>
             <unit id="org.eclipse.lsp4jakarta.jdt.core" version="0.0"/>
         </location>
+                
     </locations>
 </target>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-Copyright: Copyright (c) 2022 IBM Corporation and others.
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: io.openliberty.tools.eclipse.tests
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: junit-jupiter-api;bundle-version="[5.8.0,6.0.0)",
  org.eclipse.ui,

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.openliberty.tools.eclipse</groupId>
         <artifactId>parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.openliberty.tools.eclipse.tests</artifactId>


### PR DESCRIPTION
upgrades target platform to the 2023-03 IDE level.

note: I did not change the level of org.eclipse.lsp4mp.jdt.core or org.eclipse.jdt.ls.core
, just the IDE entries to move to 2023-03

In the past moving to the latest org.eclipse.jdt.ls.core from its current version of 1.5.0 caused the LS to fail to come up