### PR TITLE
Launch debug from original LaunchConfiguration rather than copy in order to persist source lookup modifications

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DebugModeHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DebugModeHandler.java
@@ -500,10 +500,17 @@ public class DebugModeHandler {
         remoteJavaAppConfigWCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_CONNECT_MAP, connectMap);
         remoteJavaAppConfigWCopy.setAttribute(StartTab.PROJECT_RUN_TIME, String.valueOf(System.currentTimeMillis()));
 
-        remoteJavaAppConfigWCopy.doSave();
-
-        // Use original to launch so changes get persisted in metadata file store
-        return remoteJavaAppConfigWCopy.getOriginal().launch(ILaunchManager.DEBUG_MODE, monitor);
+        //
+        // Fixed issue:  https://github.com/OpenLiberty/liberty-tools-eclipse/issues/372
+        // by launching with the return value of remoteJavaAppConfigWCopy.doSave(), rather than the
+        // object (the "working copy") itself.
+        // 
+        // Debated calling launch() with the doSave() return value vs. the value of  
+        // remoteJavaAppConfigWCopy.getOriginal().  Decided on the former which
+        // seemed to be the more common usage pattern, though not entirely clear which is better.
+        //  
+        ILaunchConfiguration updatedConfig = remoteJavaAppConfigWCopy.doSave();
+        return updatedConfig.launch(ILaunchManager.DEBUG_MODE, monitor);
     }
 
     /**

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DebugModeHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DebugModeHandler.java
@@ -502,7 +502,8 @@ public class DebugModeHandler {
 
         remoteJavaAppConfigWCopy.doSave();
 
-        return remoteJavaAppConfigWCopy.launch(ILaunchManager.DEBUG_MODE, monitor);
+        // Use original to launch so changes get persisted in metadata file store
+        return remoteJavaAppConfigWCopy.getOriginal().launch(ILaunchManager.DEBUG_MODE, monitor);
     }
 
     /**


### PR DESCRIPTION
Fixes #372 

This might be all that's needed. 

I'm not familiar enough with the underlying APIs, e.g. **org.eclipse.debug.core.ILaunchConfigurationWorkingCopy** to really know what I'm talking about... BUT.. it seems like I could kind of rationalize it by saying the working copy is for editing but use the original launch config for actually calling launch().

Might try to read a bit more.