### PR TITLE
Provide option to run LT plugin stop comand when the stop action is used

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
+* Copyright (c) 2022, 2023 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -50,28 +50,28 @@ public class CommandBuilder {
      * 
      * @throws CommandNotFoundException
      */
-    public static String getMavenCommandLine(String projectPath, String cmdArgs, String pathEnv)
+    public static String getMavenCommandLine(String projectPath, String cmdArgs, String pathEnv, boolean printCmd)
             throws CommandBuilder.CommandNotFoundException {
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { projectPath, cmdArgs });
         }
         CommandBuilder builder = new CommandBuilder(projectPath, pathEnv, true);
         String cmd = builder.getCommand();
-        String cmdLine = builder.getCommandLineFromArgs(cmd, cmdArgs);
+        String cmdLine = builder.getCommandLineFromArgs(cmd, cmdArgs, printCmd);
         if (Trace.isEnabled()) {
             Trace.getTracer().traceExit(Trace.TRACE_TOOLS, cmdLine);
         }
         return cmdLine;
     }
 
-    public static String getGradleCommandLine(String projectPath, String cmdArgs, String pathEnv)
+    public static String getGradleCommandLine(String projectPath, String cmdArgs, String pathEnv, boolean printCmd)
             throws CommandBuilder.CommandNotFoundException {
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { projectPath, cmdArgs });
         }
         CommandBuilder builder = new CommandBuilder(projectPath, pathEnv, false);
         String cmd = builder.getCommand();
-        String cmdLine = builder.getCommandLineFromArgs(cmd, cmdArgs);
+        String cmdLine = builder.getCommandLineFromArgs(cmd, cmdArgs, printCmd);
         if (Trace.isEnabled()) {
             Trace.getTracer().traceExit(Trace.TRACE_TOOLS, cmdLine);
         }
@@ -186,17 +186,19 @@ public class CommandBuilder {
         return foundCmd;
     }
 
-    private String getCommandLineFromArgs(String cmd, String cmdArgs) {
+    private String getCommandLineFromArgs(String cmd, String cmdArgs, boolean printCmd) {
         // Put it all together.
         StringBuilder sb = new StringBuilder();
         if (cmd != null) {
-            if (Utils.isWindows()) {
-                sb.append("/c ");
-                sb.append("echo && ");
-                sb.append("echo Liberty Tools running command: " + cmd + " " + cmdArgs);
-                sb.append(" from directory: " + projectPath + " && ");
-            } else {
-                sb.append(" -x ");
+            if (printCmd) {
+                if (Utils.isWindows()) {
+                    sb.append("/c ");
+                    sb.append("echo && ");
+                    sb.append("echo Liberty Tools running command: " + cmd + " " + cmdArgs);
+                    sb.append(" from directory: " + projectPath + " && ");
+                } else {
+                    sb.append(" -x ");
+                }
             }
             sb.append(cmd).append(" ").append(cmdArgs);
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -12,11 +12,13 @@
 *******************************************************************************/
 package io.openliberty.tools.eclipse;
 
+import java.io.File;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.debug.core.ILaunchManager;
@@ -198,11 +200,11 @@ public class DevModeOperations {
             BuildType buildType = project.getBuildType();
             if (buildType == Project.BuildType.MAVEN) {
                 cmd = CommandBuilder.getMavenCommandLine(projectPath, "io.openliberty.tools:liberty-maven-plugin:dev " + startParms,
-                        pathEnv);
+                        pathEnv, true);
             } else if (buildType == Project.BuildType.GRADLE) {
-                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDev " + startParms, pathEnv);
+                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDev " + startParms, pathEnv, true);
             } else {
-                throw new Exception("Unexpected project build type: " + buildType + ". Project" + projectName
+                throw new Exception("Unexpected project build type: " + buildType + ". Project " + projectName
                         + "does not appear to be a Maven or Gradle built project.");
             }
 
@@ -315,11 +317,11 @@ public class DevModeOperations {
             BuildType buildType = project.getBuildType();
             if (buildType == Project.BuildType.MAVEN) {
                 cmd = CommandBuilder.getMavenCommandLine(projectPath, "io.openliberty.tools:liberty-maven-plugin:devc " + startParms,
-                        pathEnv);
+                        pathEnv, true);
             } else if (buildType == Project.BuildType.GRADLE) {
-                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDevc " + startParms, pathEnv);
+                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDevc " + startParms, pathEnv, true);
             } else {
-                throw new Exception("Unexpected project build type: " + buildType + ". Project" + projectName
+                throw new Exception("Unexpected project build type: " + buildType + ". Project " + projectName
                         + "does not appear to be a Maven or Gradle built project.");
             }
 
@@ -374,29 +376,22 @@ public class DevModeOperations {
 
         // Check if the stop action has already been issued of if a start action was never issued before.
         if (projectTabController.getProjectConnector(projectName) == null) {
-            String msg = "Either Liberty Tools did not previously issue a start request, or a stop request was already issued on project "
-                    + projectName
-                    + ".  To stop a server that was started outside of the current Liberty Tools session, you must use another method. For example, open a new terminal inside or outside of Eclipse and issue the 'mvn liberty:stop' or 'gradle libertyStop' command.";
-            if (Trace.isEnabled()) {
-                Trace.getTracer().trace(Trace.TRACE_TOOLS, msg + " No-op. ProjectTabController: " + projectTabController);
-            }
-            ErrorHandler.processErrorMessage(msg, true);
+            String msg = "Unable to process the stop request on project " + projectName
+                    + " because either Liberty Tools did not previously issue a start request, or a stop request was already issued.";
+            handleStopActionError(projectName, msg);
+
             return;
         }
 
         // Check if the terminal tab associated with this call was marked as closed. This scenario may occur if a previous
-        // attempt to start the server in dev mode was issued successfully, but there was a failure in the process or
-        // there was an unexpected case that caused the terminal process to end. Note that objects associated with the previous
-        // start attempt will be cleaned up on the next restart attempt.
+        // attempt to start the server in dev mode failed due to an invalid custom start parameter, dev mode was terminated manually,
+        // dev mode is already running outside of the Liberty Tools session, or there was an unexpected case that caused
+        // the terminal process to end. Note that objects associated with the previous start attempt will be cleaned up on
+        // the next restart attempt.
         if (projectTabController.isProjectTabMarkedClosed(projectName)) {
-            String msg = "The terminal tab that is running project " + projectName
-                    + " is not active due to an unexpected error or external action. Review the terminal output for more details. "
-                    + "Once the circumstance that caused the terminal tab to be inactive is determined and resolved, "
-                    + "issue a start request before you issue the stop request.";
-            if (Trace.isEnabled()) {
-                Trace.getTracer().trace(Trace.TRACE_TOOLS, msg + " No-op. ProjectTabController: " + projectTabController);
-            }
-            ErrorHandler.processErrorMessage(msg, true);
+            String msg = "The terminal tab associated with project " + projectName + " is not active.";
+            handleStopActionError(projectName, msg);
+
             return;
         }
 
@@ -419,10 +414,8 @@ public class DevModeOperations {
 
         } catch (Exception e) {
             String msg = "An error was detected when the stop request was processed on project " + projectName + ".";
-            if (Trace.isEnabled()) {
-                Trace.getTracer().trace(Trace.TRACE_TOOLS, msg, e);
-            }
-            ErrorHandler.processErrorMessage(msg, e, true);
+            handleStopActionError(projectName, msg);
+
             return;
         }
 
@@ -761,6 +754,84 @@ public class DevModeOperations {
         envs.add("JAVA_HOME=" + javaInstallPath);
 
         projectTabController.runOnTerminal(projectName, projectPath, cmd, envs);
+    }
+
+    /**
+     * Informs the users of the error and prompts them to chose whether or not to allow the Liberty plugin stop command to be issued
+     * for the specified project.
+     * 
+     * @param projectName The name of the project for which the the Liberty plugin stop command is issued.
+     * @param baseMsg The base message to display.
+     */
+    private void handleStopActionError(String projectName, String baseMsg) {
+        String msg = baseMsg
+                + "\n\nWould you like to issue the Liberty plugin stop command for this project to stop a Liberty server that may still be running the project outside of the Liberty Tools session?";
+        Integer response = ErrorHandler.processErrorMessage(msg, true, new String[] { "Yes", "No" }, 0);
+        if (response != null && response == 0) {
+            issueLPStopCommand(projectName);
+        }
+    }
+
+    /**
+     * Issues the Liberty plugin stop command to stop the Liberty server associated with the specified project.
+     * 
+     * @param projectName The name of the project for which the the Liberty plugin stop command is issued.
+     */
+    private void issueLPStopCommand(String projectName) {
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, projectName);
+        }
+
+        try {
+            // Get the internal object representing the input project name.
+            Project project = projectModel.getProject(projectName);
+            if (project == null) {
+                throw new Exception("Unable to find internal the instance of project " + projectName);
+            }
+
+            // Get the absolute path to the application project.
+            String projectPath = project.getPath();
+            if (projectPath == null) {
+                throw new Exception("Unable to find the path associated with project " + projectName);
+            }
+
+            // Build the command.
+            String cmd = "";
+            BuildType buildType = project.getBuildType();
+            if (buildType == Project.BuildType.MAVEN) {
+                cmd = CommandBuilder.getMavenCommandLine(projectPath, "io.openliberty.tools:liberty-maven-plugin:stop", pathEnv, false);
+            } else if (buildType == Project.BuildType.GRADLE) {
+                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyStop", pathEnv, false);
+            } else {
+                throw new Exception("Unexpected project build type: " + buildType + ". Project " + projectName
+                        + "does not appear to be a Maven or Gradle built project.");
+            }
+
+            // Issue the command.
+            String[] cmdParts = cmd.split(" ");
+            ProcessBuilder pb = new ProcessBuilder(cmdParts);
+            pb.directory(new File(projectPath));
+            Process p = pb.start();
+            boolean completed = p.waitFor(30, TimeUnit.SECONDS);
+            if (!completed) {
+                String msg = "The Liberty plugin stop command issued for project " + projectName + " timed out after 30 seconds.";
+                if (Trace.isEnabled()) {
+                    Trace.getTracer().trace(Trace.TRACE_TOOLS, msg);
+                }
+                ErrorHandler.processErrorMessage(msg, false);
+            }
+        } catch (Exception e) {
+            String msg = "An error was detected while processing the Liberty plugin stop command on project " + projectName;
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_TOOLS, msg, e);
+            }
+            ErrorHandler.processErrorMessage(msg, e, false);
+            return;
+        }
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, projectName);
+        }
     }
 
     /**

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/ErrorHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/ErrorHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
+* Copyright (c) 2022, 2023 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -86,6 +86,30 @@ public class ErrorHandler {
     }
 
     /**
+     * Logs a message to the platform log and opens the error dialog, if indicated.
+     *
+     * @param message The message to display.
+     * @param displayDialog The indicator to open a dialog.
+     * @param buttonLabels The array of button labels to be display on the dialog.
+     * @param defaultButton The index number representing the button to be selected as default.
+     * 
+     * @return The index number representing the button that the user selected.
+     */
+    public static Integer processErrorMessage(String message, boolean displayDialog, String[] buttonLabels, int defaultButton) {
+        Integer response = null;
+        Logger.logError(message);
+
+        if (displayDialog) {
+            Shell shell = Display.getCurrent().getActiveShell();
+            MessageDialog dialog = new MessageDialog(shell, TITLE, null, message, MessageDialog.ERROR, buttonLabels, defaultButton);
+            response = Integer.valueOf(dialog.open());
+        }
+
+        return response;
+
+    }
+
+    /**
      * Logs a message to the platform log.
      *
      * @param message The message to display.
@@ -139,7 +163,7 @@ public class ErrorHandler {
             dialog.open();
         }
     }
-    
+
     /**
      * Logs a message to the platform log and opens the error dialog, if indicated.
      *

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -285,7 +285,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
 
         String localMvnCmd = LibertyPluginTestUtils.onWindows() ? "mvn.cmd" : "mvn";
         String opaqueMvnCmd = CommandBuilder.getMavenCommandLine(projPath, "io.openliberty.tools:liberty-maven-plugin:dev -f " + projPath,
-                System.getenv("PATH"));
+                System.getenv("PATH"), true);
         Assertions.assertTrue(opaqueMvnCmd.contains(localMvnCmd + " io.openliberty.tools:liberty-maven-plugin:dev"),
                 "Expected cmd to contain 'mvn io.openliberty.tools...' but cmd = " + opaqueMvnCmd);
     }
@@ -296,7 +296,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         String projPath = iProject.getLocation().toOSString();
 
         String opaqueMvnwCmd = CommandBuilder.getMavenCommandLine(projPath, "io.openliberty.tools:liberty-maven-plugin:dev -f " + projPath,
-                System.getenv("PATH"));
+                System.getenv("PATH"), true);
         Assertions.assertTrue(opaqueMvnwCmd.contains("mvnw"), "Expected cmd to contain 'mvnw' but cmd = " + opaqueMvnwCmd);
     }
 


### PR DESCRIPTION
This PR attempts to provide a workaround for the issue where the start action is run on a project, but it fails because there is a Liberty server already running perhaps due of a prior unexpected session failure or user action.

The workaround allows users to run the Liberty Tools stop action to stop a Liberty server running the project outside of a Liberty tools session. The Liberty Maven/Gradle plugin stop command is issued to stop the Liberty server. 

Since stop is issued in an unconventional way, a choice dialog is displayed to let the user know that the session for the project in question is not active or has not been initialized (start/debug), and to give the user the choice to run the LMP/LGP stop command or not.

For example:

<img width="1023" alt="image" src="https://github.com/OpenLiberty/liberty-tools-eclipse/assets/8353153/26c8689a-ec9f-4214-9129-30d9a5597038">
