### PR TITLE
Add keyboard shortcuts for StartTab fields

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -325,7 +325,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     private void createInputParmText(Composite parent) {
         Label inputParmLabel = new Label(parent, SWT.NONE);
         inputParmLabel.setFont(font);
-        inputParmLabel.setText("Start parameters:");
+        inputParmLabel.setText("Start &parameters:");
         GridDataFactory.swtDefaults().indent(20, 0).applyTo(inputParmLabel);
 
         startParmText = new Text(parent, SWT.BORDER);
@@ -376,7 +376,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
      */
     private void createRunInContainerButton(Composite parent) {
         runInContainerCheckBox = new Button(parent, SWT.CHECK);
-        runInContainerCheckBox.setText("Run in Container");
+        runInContainerCheckBox.setText("Run in &Container");
         runInContainerCheckBox.setSelection(false);
         runInContainerCheckBox.setFont(font);
         runInContainerCheckBox.addSelectionListener(new SelectionAdapter() {


### PR DESCRIPTION
Adds:
*  Alt+c for "Run in Container"
* Alt+p for "Start parameters"

Note these are case-insensitive


![image](https://github.com/OpenLiberty/liberty-tools-eclipse/assets/4081634/d0382901-752f-4e54-b20b-45f6f3f03d37)
