### PR TITLE
Config parms

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -78,6 +78,42 @@ public class CommandBuilder {
         return cmdLine;
     }
 
+    public static String getMavenExecutable(String projectPath, String pathEnv) throws CommandBuilder.CommandNotFoundException {
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { projectPath, pathEnv });
+        }
+        CommandBuilder builder = new CommandBuilder(projectPath, pathEnv, true);
+        String fullExecutablePath = builder.getCommand();
+
+        File file = new File(fullExecutablePath);
+
+        String executable = file.getName();
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, executable);
+        }
+
+        return executable;
+    }
+
+    public static String getGradleExecutable(String projectPath, String pathEnv) throws CommandBuilder.CommandNotFoundException {
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { projectPath, pathEnv });
+        }
+        CommandBuilder builder = new CommandBuilder(projectPath, pathEnv, false);
+        String fullExecutablePath = builder.getCommand();
+
+        File file = new File(fullExecutablePath);
+
+        String executable = file.getName();
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, executable);
+        }
+
+        return executable;
+    }
+
     private String getCommand() throws CommandBuilder.CommandNotFoundException {
         String cmd = getCommandFromWrapper();
         if (cmd == null) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -149,10 +149,10 @@ public class DevModeOperations {
      * @param javaHomePath The configuration java installation home to be set in the terminal running dev mode.
      * @param mode The configuration mode.
      */
-    public void start(IProject iProject, String parms, String javaHomePath, String mode) {
+    public void start(IProject iProject, String preStartGoals, String parms, String javaHomePath, String mode) {
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms, javaHomePath, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, preStartGoals, parms, javaHomePath, mode });
         }
 
         if (iProject == null) {
@@ -207,6 +207,8 @@ public class DevModeOperations {
                 throw new Exception("Unable to find the path to selected project " + projectName);
             }
 
+            String userPreStartGoals = (preStartGoals == null) ? "" : preStartGoals.trim();
+
             // If in debug mode, adjust the start parameters.
             String userParms = (parms == null) ? "" : parms.trim();
             String startParms = null;
@@ -222,7 +224,8 @@ public class DevModeOperations {
             String cmd = "";
             BuildType buildType = project.getBuildType();
             if (buildType == Project.BuildType.MAVEN) {
-                cmd = CommandBuilder.getMavenCommandLine(projectPath, "io.openliberty.tools:liberty-maven-plugin:dev " + startParms,
+                cmd = CommandBuilder.getMavenCommandLine(projectPath, userPreStartGoals.trim() +
+                        " io.openliberty.tools:liberty-maven-plugin:dev " + startParms,
                         pathEnv, true);
             } else if (buildType == Project.BuildType.GRADLE) {
                 cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDev " + startParms, pathEnv, true);
@@ -266,7 +269,7 @@ public class DevModeOperations {
      * @param javaHomePath The configuration java installation home to be set in the terminal running dev mode.
      * @param mode The configuration mode.
      */
-    public void startInContainer(IProject iProject, String parms, String javaHomePath, String mode) {
+    public void startInContainer(IProject iProject, String preStartGoals, String parms, String javaHomePath, String mode) {
 
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms, javaHomePath, mode });
@@ -339,7 +342,8 @@ public class DevModeOperations {
             String cmd = "";
             BuildType buildType = project.getBuildType();
             if (buildType == Project.BuildType.MAVEN) {
-                cmd = CommandBuilder.getMavenCommandLine(projectPath, "io.openliberty.tools:liberty-maven-plugin:devc " + startParms,
+                cmd = CommandBuilder.getMavenCommandLine(projectPath,
+                        preStartGoals.trim() + " io.openliberty.tools:liberty-maven-plugin:devc " + startParms,
                         pathEnv, true);
             } else if (buildType == Project.BuildType.GRADLE) {
                 cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDevc " + startParms, pathEnv, true);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -81,6 +81,18 @@ public class DevModeOperations {
             "stopJobCompletionOutput");
     private Map<Job, Boolean> runningJobs = new ConcurrentHashMap<Job, Boolean>();
 
+    /** Default Maven devc command */
+    public static final String DEFAULT_MAVEN_DEVC = "io.openliberty.tools:liberty-maven-plugin:devc";
+
+    /** Default Maven dev command */
+    public static final String DEFAULT_MAVEN_DEV = "io.openliberty.tools:liberty-maven-plugin:dev";
+
+    /** Default Gradle devc command */
+    public static final String DEFAULT_GRADLE_DEVC = "libertyDevc";
+
+    /** Default Gradle dev command */
+    public static final String DEFAULT_GRADLE_DEV = "libertyDev";
+
     /**
      * Project terminal tab controller instance.
      */
@@ -149,10 +161,10 @@ public class DevModeOperations {
      * @param javaHomePath The configuration java installation home to be set in the terminal running dev mode.
      * @param mode The configuration mode.
      */
-    public void start(IProject iProject, String preStartGoals, String parms, String javaHomePath, String mode) {
+    public void start(IProject iProject, String launchCommand, String javaHomePath, String mode) {
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, preStartGoals, parms, javaHomePath, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, launchCommand, javaHomePath, mode });
         }
 
         if (iProject == null) {
@@ -207,28 +219,21 @@ public class DevModeOperations {
                 throw new Exception("Unable to find the path to selected project " + projectName);
             }
 
-            String userPreStartGoals = (preStartGoals == null) ? "" : preStartGoals.trim();
-
-            // If in debug mode, adjust the start parameters.
-            String userParms = (parms == null) ? "" : parms.trim();
-            String startParms = null;
             String debugPort = null;
             if (ILaunchManager.DEBUG_MODE.equals(mode)) {
-                debugPort = debugModeHandler.calculateDebugPort(project, userParms);
-                startParms = debugModeHandler.addDebugDataToStartParms(project, debugPort, userParms);
-            } else {
-                startParms = userParms;
+                debugPort = debugModeHandler.calculateDebugPort(project, launchCommand);
+                launchCommand = debugModeHandler.addDebugDataToStartParms(project, debugPort, launchCommand);
             }
 
             // Prepare the Liberty plugin container dev mode command.
             String cmd = "";
             BuildType buildType = project.getBuildType();
             if (buildType == Project.BuildType.MAVEN) {
-                cmd = CommandBuilder.getMavenCommandLine(projectPath, userPreStartGoals.trim() +
-                        " io.openliberty.tools:liberty-maven-plugin:dev " + startParms,
+                cmd = CommandBuilder.getMavenCommandLine(projectPath, launchCommand,
                         pathEnv, true);
             } else if (buildType == Project.BuildType.GRADLE) {
-                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDev " + startParms, pathEnv, true);
+                cmd = CommandBuilder.getGradleCommandLine(projectPath, launchCommand,
+                        pathEnv, true);
             } else {
                 throw new Exception("Unexpected project build type: " + buildType + ". Project " + projectName
                         + "does not appear to be a Maven or Gradle built project.");
@@ -265,14 +270,14 @@ public class DevModeOperations {
      * Starts the Liberty server in dev mode in a container.
      * 
      * @param iProject The project instance to associate with this action.
-     * @param parms The configuration parameters to be used when starting dev mode.
+     * @param launchCommand The configuration launch comand to be used when starting dev mode.
      * @param javaHomePath The configuration java installation home to be set in the terminal running dev mode.
      * @param mode The configuration mode.
      */
-    public void startInContainer(IProject iProject, String preStartGoals, String parms, String javaHomePath, String mode) {
+    public void startInContainer(IProject iProject, String launchCommand, String javaHomePath, String mode) {
 
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms, javaHomePath, mode });
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, launchCommand, javaHomePath, mode });
         }
 
         if (iProject == null) {
@@ -328,25 +333,19 @@ public class DevModeOperations {
             }
 
             // If in debug mode, adjust the start parameters.
-            String userParms = (parms == null) ? "" : parms.trim();
-            String startParms = null;
             String debugPort = null;
             if (ILaunchManager.DEBUG_MODE.equals(mode)) {
-                debugPort = debugModeHandler.calculateDebugPort(project, userParms);
-                startParms = debugModeHandler.addDebugDataToStartParms(project, debugPort, userParms);
-            } else {
-                startParms = userParms;
+                debugPort = debugModeHandler.calculateDebugPort(project, launchCommand);
+                launchCommand = debugModeHandler.addDebugDataToStartParms(project, debugPort, launchCommand);
             }
 
             // Prepare the Liberty plugin container dev mode command.
             String cmd = "";
             BuildType buildType = project.getBuildType();
             if (buildType == Project.BuildType.MAVEN) {
-                cmd = CommandBuilder.getMavenCommandLine(projectPath,
-                        preStartGoals.trim() + " io.openliberty.tools:liberty-maven-plugin:devc " + startParms,
-                        pathEnv, true);
+                cmd = CommandBuilder.getMavenCommandLine(projectPath, launchCommand, pathEnv, true);
             } else if (buildType == Project.BuildType.GRADLE) {
-                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDevc " + startParms, pathEnv, true);
+                cmd = CommandBuilder.getGradleCommandLine(projectPath, launchCommand, pathEnv, true);
             } else {
                 throw new Exception("Unexpected project build type: " + buildType + ". Project " + projectName
                         + "does not appear to be a Maven or Gradle built project.");

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/WorkspaceProjectsModel.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/WorkspaceProjectsModel.java
@@ -25,7 +25,9 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 
+import io.openliberty.tools.eclipse.Project.BuildType;
 import io.openliberty.tools.eclipse.logging.Trace;
+import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
 import io.openliberty.tools.eclipse.utils.ErrorHandler;
 
 /**
@@ -243,6 +245,44 @@ public class WorkspaceProjectsModel {
             retVal = "";
         }
 
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, retVal);
+        }
+
+        return retVal;
+    }
+
+    /**
+     * @param iProject
+     * 
+     * @return start command to serve as default populating something like a Run Configuration
+     */
+    public String getDefaultStartCommand(IProject iProject, RuntimeEnv runtimeEnv) {
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject });
+        }
+
+        String retVal = null;
+
+        Project project = projectsByName.get(iProject.getName());
+        BuildType buildType = project.getBuildType();
+
+        if (buildType == Project.BuildType.MAVEN) {
+
+            if (runtimeEnv.equals(RuntimeEnv.CONTAINER)) {
+                retVal = DevModeOperations.DEFAULT_MAVEN_DEVC;
+            } else {
+                retVal = DevModeOperations.DEFAULT_MAVEN_DEV;
+            }
+        } else if (buildType == Project.BuildType.GRADLE) {
+
+            if (runtimeEnv.equals(RuntimeEnv.CONTAINER)) {
+                retVal = DevModeOperations.DEFAULT_GRADLE_DEVC;
+            } else {
+                retVal = DevModeOperations.DEFAULT_GRADLE_DEV;
+            }
+        }
         if (Trace.isEnabled()) {
             Trace.getTracer().traceExit(Trace.TRACE_TOOLS, retVal);
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationHelper.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationHelper.java
@@ -69,31 +69,37 @@ public class LaunchConfigurationHelper {
         List<ILaunchConfiguration> matchingConfigList = filterLaunchConfigurations(existingConfigs, iProject.getName(), runtimeEnv);
 
         switch (matchingConfigList.size()) {
-        case 0:
-            // Create a new configuration.
-            String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
-            ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
-            workingCopy.setAttribute(StartTab.PROJECT_NAME, iProject.getName());
-            workingCopy.setAttribute(StartTab.PROJECT_START_PARM, devModeOps.getProjectModel().getDefaultStartParameters(iProject));
-            //default to 'false', no container
-            boolean runInContainer = runtimeEnv.equals(RuntimeEnv.CONTAINER);
-            workingCopy.setAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, runInContainer);
+            case 0:
+                // Create a new configuration.
+                String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
+                ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
+                workingCopy.setAttribute(StartTab.PROJECT_NAME, iProject.getName());
+                workingCopy.setAttribute(StartTab.PROJECT_START_PARM, devModeOps.getProjectModel().getDefaultStartParameters(iProject));
+                workingCopy.setAttribute(StartTab.PROJECT_PRE_START_GOALS, (String) null);
 
-            String defaultJavaDef = JRETab.getDefaultJavaFromBuildPath(iProject);
-            if (defaultJavaDef != null) {
-                workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_JRE_CONTAINER_PATH, defaultJavaDef);
-            }
+                workingCopy.setAttribute(StartTab.PROJECT_LAUNCH_COMMAND,
+                        devModeOps.getProjectModel().getDefaultStartCommand(iProject, runtimeEnv) + " "
+                                + devModeOps.getProjectModel().getDefaultStartParameters(iProject));
 
-            configuration = workingCopy.doSave();
-            break;
-        case 1:
-            // Return the found configuration.
-            configuration = matchingConfigList.get(0);
-            break;
-        default:
-            // Return the configuration that was run last.
-            configuration = getLastRunConfiguration(matchingConfigList);
-            break;
+                // default to 'false', no container
+                boolean runInContainer = runtimeEnv.equals(RuntimeEnv.CONTAINER);
+                workingCopy.setAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, runInContainer);
+
+                String defaultJavaDef = JRETab.getDefaultJavaFromBuildPath(iProject);
+                if (defaultJavaDef != null) {
+                    workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_JRE_CONTAINER_PATH, defaultJavaDef);
+                }
+
+                configuration = workingCopy.doSave();
+                break;
+            case 1:
+                // Return the found configuration.
+                configuration = matchingConfigList.get(0);
+                break;
+            default:
+                // Return the configuration that was run last.
+                configuration = getLastRunConfiguration(matchingConfigList);
+                break;
         }
 
         return configuration;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -51,6 +51,9 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     /** Configuration map key with a value representing the dev mode start parameter. */
     public static final String PROJECT_START_PARM = "io.openliberty.tools.eclipse.launch.start.parm";
 
+    /** Configuration map key with a value representing the pre-start goals. */
+    public static final String PROJECT_PRE_START_GOALS = "io.openliberty.tools.eclipse.launch.pre.start.goals";
+
     /** Configuration map key with a value representing the last project name associated with the configuration. */
     public static final String PROJECT_NAME = "io.openliberty.tools.eclipse.launch.project.name";
 
@@ -67,6 +70,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     public static final String TAB_NAME = "Start";
 
     private static final String EXAMPLE_START_PARMS = "Example: -DhotTests=true";
+    private static final String EXAMPLE_PRE_START_GOAL = "Example: clean";
 
     /** The font to use for the contents of this Tab. */
     private Font font;
@@ -76,6 +80,9 @@ public class StartTab extends AbstractLaunchConfigurationTab {
 
     /** Holds the start parameter text configuration. */
     private Text startParmText;
+
+    /** Holds the pre-start goals text configuration. */
+    private Text preStartGoalsText;
 
     /** Holds the project name associated with the configuration being displayed. */
     private Label projectNameLabel;
@@ -108,6 +115,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
 
         // Parameter group composite.
         Composite parmsGroupComposite = createGroupComposite(mainComposite, "", 2);
+        createPreLaunchGoalText(parmsGroupComposite);
         createInputParmText(parmsGroupComposite);
         createRunInContainerButton(parmsGroupComposite);
 
@@ -152,8 +160,11 @@ public class StartTab extends AbstractLaunchConfigurationTab {
         // Initialize the configuration view with previously saved values.
         try {
 
-            String consoleText = configuration.getAttribute(PROJECT_START_PARM, (String) null);
-            startParmText.setText(consoleText);
+            String savedStartParms = configuration.getAttribute(PROJECT_START_PARM, (String) null);
+            startParmText.setText(savedStartParms);
+
+            String savedPreStartGoals = configuration.getAttribute(PROJECT_PRE_START_GOALS, (String) null);
+            preStartGoalsText.setText(savedPreStartGoals);
 
             boolean runInContainer = configuration.getAttribute(PROJECT_RUN_IN_CONTAINER, false);
             runInContainerCheckBox.setSelection(runInContainer);
@@ -233,10 +244,13 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     public void performApply(ILaunchConfigurationWorkingCopy configuration) {
 
         String startParamStr = startParmText.getText();
+        String preStartGoalsStr = preStartGoalsText.getText();
 
         boolean runInContainerBool = runInContainerCheckBox.getSelection();
 
         configuration.setAttribute(PROJECT_RUN_IN_CONTAINER, runInContainerBool);
+
+        configuration.setAttribute(PROJECT_PRE_START_GOALS, preStartGoalsStr);
 
         configuration.setAttribute(PROJECT_START_PARM, startParamStr);
 
@@ -345,6 +359,36 @@ public class StartTab extends AbstractLaunchConfigurationTab {
 
         });
         GridDataFactory.fillDefaults().grab(true, false).applyTo(startParmText);
+    }
+
+    /**
+     * Creates the labeled input text entry that allows users to enter parameters used to run dev mode.
+     * 
+     * @param parent The parent composite.
+     */
+    private void createPreLaunchGoalText(Composite parent) {
+        Label inputParmLabel = new Label(parent, SWT.NONE);
+        inputParmLabel.setFont(font);
+        inputParmLabel.setText("Pre-start &goals:");
+        GridDataFactory.swtDefaults().indent(20, 0).applyTo(inputParmLabel);
+
+        preStartGoalsText = new Text(parent, SWT.BORDER);
+        preStartGoalsText.setFont(font);
+        preStartGoalsText.setMessage(EXAMPLE_PRE_START_GOAL);
+        preStartGoalsText.addModifyListener(new ModifyListener() {
+
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public void modifyText(ModifyEvent e) {
+                checkForIncorrectTerms();
+                setDirty(true);
+                updateLaunchConfigurationDialog();
+            }
+
+        });
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(preStartGoalsText);
     }
 
     /**

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -119,14 +119,15 @@ public class StartAction implements ILaunchShortcut {
 
         // Retrieve configuration data.
         boolean runInContainer = configuration.getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false);
+        String preStartGoals = configuration.getAttribute(StartTab.PROJECT_PRE_START_GOALS, (String) null);
         String configParms = configuration.getAttribute(StartTab.PROJECT_START_PARM, (String) null);
         String javaHomePath = JRETab.resolveJavaHome(configuration);
 
         // Process the action.
         if (runInContainer) {
-            devModeOps.startInContainer(iProject, configParms, javaHomePath, mode);
+            devModeOps.startInContainer(iProject, preStartGoals, configParms, javaHomePath, mode);
         } else {
-            devModeOps.start(iProject, configParms, javaHomePath, mode);
+            devModeOps.start(iProject, preStartGoals, configParms, javaHomePath, mode);
         }
 
         if (Trace.isEnabled()) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -119,15 +119,14 @@ public class StartAction implements ILaunchShortcut {
 
         // Retrieve configuration data.
         boolean runInContainer = configuration.getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false);
-        String preStartGoals = configuration.getAttribute(StartTab.PROJECT_PRE_START_GOALS, (String) null);
-        String configParms = configuration.getAttribute(StartTab.PROJECT_START_PARM, (String) null);
+        String launchCommand = configuration.getAttribute(StartTab.PROJECT_LAUNCH_COMMAND, (String) null);
         String javaHomePath = JRETab.resolveJavaHome(configuration);
 
         // Process the action.
         if (runInContainer) {
-            devModeOps.startInContainer(iProject, preStartGoals, configParms, javaHomePath, mode);
+            devModeOps.startInContainer(iProject, launchCommand, javaHomePath, mode);
         } else {
-            devModeOps.start(iProject, preStartGoals, configParms, javaHomePath, mode);
+            devModeOps.start(iProject, launchCommand, javaHomePath, mode);
         }
 
         if (Trace.isEnabled()) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
@@ -116,8 +116,8 @@ public class StartInContainerAction implements ILaunchShortcut {
         launchConfigHelper.saveConfigProcessingTime(configuration);
 
         // Process the action.
-        String configParms = configuration.getAttribute(StartTab.PROJECT_START_PARM, (String) null);
+        String launchCommand = configuration.getAttribute(StartTab.PROJECT_LAUNCH_COMMAND, (String) null);
         String javaHomePath = JRETab.resolveJavaHome(configuration);
-        devModeOps.startInContainer(iProject, configParms, javaHomePath, mode);
+        devModeOps.startInContainer(iProject, launchCommand, javaHomePath, mode);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>aarch64</arch>
+						</environment>
 					</environments>
 				</configuration>
 			</plugin>

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -778,7 +778,6 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
             Assertions.assertTrue(comboJREBox.isEnabled(),
                     () -> "The JRE tab box showing Java installation \" + buildPathJRE + \" is not selected.");
         } finally {
-            go("Apply", configShell);
             go("Close", configShell);
         }
     }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -860,7 +860,6 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
             Assertions.assertTrue(comboJREBox.isEnabled(),
                     () -> "The JRE tab box showing Java installation \" + buildPathJRE + \" is not selected.");
         } finally {
-            go("Apply", configShell);
             go("Close", configShell);
         }
     }


### PR DESCRIPTION
NOTE: This PR is still WIP.

Fixes https://github.com/OpenLiberty/liberty-tools-eclipse/issues/210

1. Expands "Start" tab configuration options to allow pre-start goals and start command customization
2. Adds a command preview to the "Start" tab configuration
3. Detects if custom start command is dev or devc and marks the configuration accordingly (subsequent "Start in container" actions will map to the correct configuration)
4. Example text in configuration text boxes changes depending on if the project is maven or gradle

