### PR TITLE
2023-06 IDE support

### DIFF
--- a/.github/workflows/run-regression-tests.yml
+++ b/.github/workflows/run-regression-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         runtime: [ linux, mac, windows ]
-        targetPlatform: [ 1Q2023 ]
+        targetPlatform: [ 2Q2023 ]
         include:
         - runtime: linux
           os: ubuntu-latest

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools Support for Language Servers
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.lsp4e;singleton:=true
-Bundle-Version: 23.0.8.qualifier
+Bundle-Version: 23.0.9.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.ls.plugin.LibertyToolsLSPlugin
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: io.openliberty.tools.eclipse.lsp4e

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
@@ -20,12 +20,12 @@
     <parent>
         <groupId>io.openliberty.tools.eclipse</groupId>
         <artifactId>parent</artifactId>
-        <version>23.0.8-SNAPSHOT</version>
+        <version>23.0.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <properties>
-        <liberty.ls.version>1.0</liberty.ls.version>
+        <liberty.ls.version>2.0.1</liberty.ls.version>
         <jakarta.ls.version>0.1.1</jakarta.ls.version>
         <mp.ls.version>0.7.0</mp.ls.version>
     </properties>

--- a/bundles/io.openliberty.tools.eclipse.product/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.product/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.product;singleton:=true
-Bundle-Version: 23.0.8.qualifier
+Bundle-Version: 23.0.9.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: io.openliberty.tools.eclipse
 Bundle-ActivationPolicy: lazy

--- a/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools UI
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.ui;singleton:=true
-Bundle-Version: 23.0.8.qualifier
+Bundle-Version: 23.0.9.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.LibertyDevPlugin
 Export-Package: io.openliberty.tools.eclipse;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.ui.dashboard;x-friends:="io.openliberty.tools.eclipse.tests",

--- a/ci/jenkins/run-tests
+++ b/ci/jenkins/run-tests
@@ -38,18 +38,18 @@ pipeline {
             }
         }
         
-        stage('Test on Eclipse 1Q2023') {
+        stage('Test on Eclipse 2Q2023') {
             steps {
                 dir('liberty-tools-eclipse') {
                     script {
                         try {
                             wrap([$class: 'Xvfb', installationName: 'gui-test', autoDisplayName: true, debug: true, parallelBuild: true, screen: '1680x1050x24']) {
                                 sh "metacity --sm-disable --replace &"
-                                sh "mvn clean verify -Dtycho.disableP2Mirrors=true -Declipse.target=1Q2023 -Dosgi.debug=./tests/resources/ci/debug.opts -DmvnImportWait=60000 -Dtycho.showEclipseLog -e"
+                                sh "mvn clean verify -Dtycho.disableP2Mirrors=true -Declipse.target=2Q2023 -Dosgi.debug=./tests/resources/ci/debug.opts -DmvnImportWait=60000 -Dtycho.showEclipseLog -e"
                             }
                         } finally {
-                            sh "cd tests/target/surefire-reports && zip -r 1Q2023-test-reports.zip ."
-                            archiveArtifacts artifacts: 'tests/target/surefire-reports/1Q2023-test-reports.zip', fingerprint: true
+                            sh "cd tests/target/surefire-reports && zip -r 2Q2023-test-reports.zip ."
+                            archiveArtifacts artifacts: 'tests/target/surefire-reports/2Q2023-test-reports.zip', fingerprint: true
                         }
                     }
                 }

--- a/ci/jenkins/run-tests
+++ b/ci/jenkins/run-tests
@@ -45,7 +45,7 @@ pipeline {
                         try {
                             wrap([$class: 'Xvfb', installationName: 'gui-test', autoDisplayName: true, debug: true, parallelBuild: true, screen: '1680x1050x24']) {
                                 sh "metacity --sm-disable --replace &"
-                                sh "mvn clean verify -Dtycho.disableP2Mirrors=true -Declipse.target=2Q2023 -Dosgi.debug=./tests/resources/ci/debug.opts -DmvnImportWait=60000 -Dtycho.showEclipseLog -e"
+                                sh "mvn clean verify -Dtycho.disableP2Mirrors=true -Declipse.target=2Q2023 -Dosgi.debug=./tests/resources/ci/debug.opts -DtestAppImportWait=120000 -Dtycho.showEclipseLog -e"
                             }
                         } finally {
                             sh "cd tests/target/surefire-reports && zip -r 2Q2023-test-reports.zip ."

--- a/features/io.openliberty.tools.eclipse.feature/feature.xml
+++ b/features/io.openliberty.tools.eclipse.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="io.openliberty.tools.eclipse"
       label="%featureName"
-      version="23.0.8.qualifier"
+      version="23.0.9.qualifier"
     plugin="io.openliberty.tools.eclipse.product"
     provider-name="%providerName">
 
@@ -28,21 +28,21 @@
          id="io.openliberty.tools.eclipse.ui"
          download-size="0"
          install-size="0"
-         version="23.0.8.qualifier"
+         version="23.0.9.qualifier"
          unpack="false"/>
 
    <plugin
          id="io.openliberty.tools.eclipse.lsp4e"
          download-size="0"
          install-size="0"
-         version="23.0.8.qualifier"
+         version="23.0.9.qualifier"
          unpack="false"/>
 
    <plugin
          id="io.openliberty.tools.eclipse.product"
          download-size="0"
          install-size="0"
-         version="23.0.8.qualifier"
+         version="23.0.9.qualifier"
          unpack="false"/>
 
 </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.openliberty.tools.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>23.0.8-SNAPSHOT</version>
+	<version>23.0.9-SNAPSHOT</version>
 	<packaging>pom</packaging>
     <licenses>
       <license>
@@ -42,7 +42,7 @@
         
         <!-- default version of the eclipse IDE to run tests against -->
         <!-- must be one of the target platform files defined in this project under releng -->
-        <eclipse.target>1Q2023</eclipse.target>
+        <eclipse.target>2Q2023</eclipse.target>
             
 	</properties>
 	
@@ -196,7 +196,7 @@
 						<artifact>
 							<groupId>io.openliberty.tools.eclipse</groupId>
 							<artifactId>target-platform-${eclipse.target}</artifactId>
-							<version>23.0.8-SNAPSHOT</version>
+							<version>23.0.9-SNAPSHOT</version>
 							<file>target-platform-${eclipse.target}</file>
 						</artifact>
 					</target>

--- a/releng/io.openliberty.tools.update/category.xml
+++ b/releng/io.openliberty.tools.update/category.xml
@@ -12,7 +12,7 @@
       IBM Corporation - initial implementation
 -->
 <site>
-    <feature url="features/io.openliberty.tools.eclipse_23.0.8.qualifier.liberty.jar" id="io.openliberty.tools.eclipse" version="23.0.8.qualifier">
+    <feature url="features/io.openliberty.tools.eclipse_23.0.9.qualifier.liberty.jar" id="io.openliberty.tools.eclipse" version="23.0.9.qualifier">
         <category name="io.openliberty.tools.eclipse" />
     </feature>
 
@@ -24,7 +24,7 @@
     <repository-reference location="https://download.eclipse.org/lsp4jakarta/releases/0.1.1/repository" enabled="true" />
 
     <!-- Dependencies -->
-    <bundle id="org.eclipse.ui.trace" version="1.2.200.v20220310-2159">
+    <bundle id="org.eclipse.ui.trace" version="1.3.0.v20230515-0022">
         <category name="io.openliberty.tools.eclipse" />
     </bundle>
 </site>

--- a/releng/io.openliberty.tools.update/category.xml
+++ b/releng/io.openliberty.tools.update/category.xml
@@ -18,8 +18,8 @@
 
     <category-def name="io.openliberty.tools.eclipse" label="Liberty Tools" />
 
-    <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.22.0/" enabled="true" />
-    <repository-reference location="https://download.eclipse.org/jdtls/milestones/1.23.0/repository" enabled="true" />
+    <repository-reference location="https://download.eclipse.org/lsp4e/releases/0.23.0/" enabled="true" />
+    <repository-reference location="https://download.eclipse.org/jdtls/milestones/1.25.0/repository" enabled="true" />
     <repository-reference location="https://download.eclipse.org/lsp4mp/releases/0.7.0/repository" enabled="true" />
     <repository-reference location="https://download.eclipse.org/lsp4jakarta/releases/0.1.1/repository" enabled="true" />
 

--- a/releng/target-platform-2Q2023/target-platform-2Q2023.target
+++ b/releng/target-platform-2Q2023/target-platform-2Q2023.target
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<!--
+  Copyright (c) 2023 IBM Corporation and others.
+  
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Contributors:
+      IBM Corporation - initial implementation
+-->
+<target includeMode="feature" name="target-platform.target" sequenceNumber="15">
+    <locations>
+        <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <!-- Matches level from category.xml -->
+            <repository location="https://download.eclipse.org/lsp4e/releases/0.23.0/"/>
+            <unit id="org.eclipse.lsp4e" version="0.16.1.202305241229"/>
+            <unit id="org.eclipse.lsp4e.jdt" version="0.11.0.202301312314"/>
+        </location>
+        <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.1.0/"/>
+            <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="1.1.0.202305041915"/>
+          <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="1.1.0.202304242122"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/releases/2023-06/"/>
+            <unit id="org.eclipse.jdt.feature.group" version="3.19.100.v20230605-0440"/>
+            <unit id="org.eclipse.ui.trace" version="1.3.0.v20230515-0022"/>
+            <unit id="org.eclipse.emf.sdk.feature.group" version="2.34.0.v20230406-1334"/>
+            <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.800.v20230523-2142"/>
+            <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.6.0.20230118-0812"/>
+            <unit id="org.eclipse.platform.sdk" version="4.28.0.I20230605-0440"/>
+            <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
+            <unit id="org.junit" version="4.13.2.v20211018-1956"/>
+            <unit id="junit-jupiter-api" version="5.9.3"/>
+            <unit id="junit-jupiter-engine" version="5.9.3"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository"/>
+            <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
+            <unit id="ch.qos.logback.slf4j.source" version="1.2.3.v20200428-2012"/>
+            <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
+            <unit id="org.slf4j.api.source" version="1.7.30.v20200204-2150"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/technology/swtbot/releases/3.1.0"/>
+            <unit id="org.eclipse.swtbot.eclipse.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.forms.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.ide.feature.group" version="3.1.0.202106041005"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/cdt/releases/10.6"/>
+            <unit id="org.eclipse.tm.terminal.connector.cdtserial.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.cdtserial.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.local.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.remote.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.remote.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.ssh.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.telnet.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.control.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.view.feature.source.feature.group" version="10.6.2.202205081303"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="http://download.eclipse.org/lsp4mp/releases/0.7.0/repository/"/>
+            <unit id="org.eclipse.lsp4mp.jdt.core" version="0.7.0.20230403-1449"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/jdtls/milestones/1.25.0/repository/"/>
+            <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.6.v20220511-1359/"/>
+            <unit id="org.eclipse.buildship.ui" version="3.1.6.v20220511-1359"/>
+        </location>
+        <location includeDependencyDepth="none" includeDependencyScopes="compile" missingManifest="generate" type="Maven">
+            <dependencies>
+                <dependency>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy-agent</artifactId>
+                    <version>1.12.17</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                    <version>1.12.17</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <version>4.8.1</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-junit-jupiter</artifactId>
+                    <version>4.8.1</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                    <version>3.3</version>
+                    <type>jar</type>
+                </dependency>
+            </dependencies>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/lsp4jakarta/releases/0.1.1/repository"/>
+            <unit id="org.eclipse.lsp4jakarta.jdt.core" version="0.0"/>
+        </location>
+                
+    </locations>
+</target>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-Copyright: Copyright (c) 2022 IBM Corporation and others.
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: io.openliberty.tools.eclipse.tests
-Bundle-Version: 23.0.8.qualifier
+Bundle-Version: 23.0.9.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: junit-jupiter-api;bundle-version="[5.8.0,6.0.0)",
  org.eclipse.ui,

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -38,6 +38,7 @@
                     <useUIThread>false</useUIThread>
                     <providerHint>junit5</providerHint>
                     <trimStackTrace>false</trimStackTrace>
+                    <runOrder>alphabetical</runOrder>
                     <systemProperties>
                         <org.eclipse.swtbot.search.timeout>20000</org.eclipse.swtbot.search.timeout>
                         <io.liberty.tools.eclipse.tests.mvnexecutable.path>${mvnPath}</io.liberty.tools.eclipse.tests.mvnexecutable.path>
@@ -123,6 +124,7 @@
                             <version>${tycho-version}</version>
                             <configuration>
                                 <argLine>-XstartOnFirstThread</argLine>
+                                <runOrder>alphabetical</runOrder>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.openliberty.tools.eclipse</groupId>
         <artifactId>parent</artifactId>
-        <version>23.0.8-SNAPSHOT</version>
+        <version>23.0.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.openliberty.tools.eclipse.tests</artifactId>
@@ -38,9 +38,6 @@
                     <useUIThread>false</useUIThread>
                     <providerHint>junit5</providerHint>
                     <trimStackTrace>false</trimStackTrace>
-                    <!--
-                    <runOrder>alphabetical</runOrder>
-                    -->
                     <systemProperties>
                         <org.eclipse.swtbot.search.timeout>20000</org.eclipse.swtbot.search.timeout>
                         <io.liberty.tools.eclipse.tests.mvnexecutable.path>${mvnPath}</io.liberty.tools.eclipse.tests.mvnexecutable.path>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,7 +24,7 @@
     <packaging>eclipse-test-plugin</packaging>
 
     <properties>
-        <mvnImportWait>12000</mvnImportWait>
+        <testAppImportWait>60000</testAppImportWait>
     </properties>
 
     <build>
@@ -41,7 +41,7 @@
                     <systemProperties>
                         <org.eclipse.swtbot.search.timeout>20000</org.eclipse.swtbot.search.timeout>
                         <io.liberty.tools.eclipse.tests.mvnexecutable.path>${mvnPath}</io.liberty.tools.eclipse.tests.mvnexecutable.path>
-                        <io.liberty.tools.eclipse.tests.mvn.import.wait>${mvnImportWait}</io.liberty.tools.eclipse.tests.mvn.import.wait>
+                        <io.liberty.tools.eclipse.tests.app.import.wait>${testAppImportWait}</io.liberty.tools.eclipse.tests.app.import.wait>
                         <io.liberty.tools.eclipse.tests.gradleexecutable.path>${gradlePath}</io.liberty.tools.eclipse.tests.gradleexecutable.path>
                     </systemProperties>
                 </configuration>

--- a/tests/resources/applications/gradle/liberty-gradle-test-app/build.gradle
+++ b/tests/resources/applications/gradle/liberty-gradle-test-app/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.2'
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.6.2'
     }
 }
 

--- a/tests/resources/applications/gradle/liberty-gradle-test-wrapper-app/build.gradle
+++ b/tests/resources/applications/gradle/liberty-gradle-test-wrapper-app/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
         dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.2'
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.6.2'
     }
 }
 

--- a/tests/resources/ci/scripts/exec.sh
+++ b/tests/resources/ci/scripts/exec.sh
@@ -40,7 +40,7 @@ main() {
         metacity --sm-disable --replace 2> metacity.err &
     fi
     
-    mvn clean install -Declipse.target="$TARGET" -Dosgi.debug=./tests/resources/ci/debug.opts -Dtycho.showEclipseLog -DmvnImportWait=60000 -DmvnPath="${PWD}/test-tools/liberty-dev-tools/apache-maven-3.8.6" -DgradlePath="${PWD}/test-tools/liberty-dev-tools/gradle-7.4.2"
+    mvn clean install -Declipse.target="$TARGET" -Dosgi.debug=./tests/resources/ci/debug.opts -Dtycho.showEclipseLog -DtestAppImportWait=120000 -DmvnPath="${PWD}/test-tools/liberty-dev-tools/apache-maven-3.8.6" -DgradlePath="${PWD}/test-tools/liberty-dev-tools/gradle-7.4.2"
 
     # If there were any errors, gather some debug data before exiting.
     rc=$?

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDashboardTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDashboardTest.java
@@ -12,10 +12,10 @@
 *******************************************************************************/
 package io.openliberty.tools.eclipse.test.it;
 
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.openDashboardUsingToolbar;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.*;
 
 /**
  * Tests Open Liberty Eclipse plugin functions.

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -182,6 +182,15 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
      */
     public static final void validateBeforeTestRun() {
 
+        // Though supposedly we use blocking methods to do the import, it seems Eclipse has the ability to break out of a deadlock
+        // by interrupting our thread, and we also seem to be causing one due to changing compiler settings.  Since we haven't debugged
+        // the latter, we'll introduce this wait.
+        try {
+            Thread.sleep(Integer.parseInt(System.getProperty("io.liberty.tools.eclipse.tests.app.import.wait", "0")));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
         Path projPath = Paths.get("resources", "applications", "gradle", GRADLE_APP_NAME);
         File projectFile = projPath.toFile();
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -193,13 +193,16 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
 
         // Check that dashboard contains the expected applications.
         boolean foundApp = false;
+        boolean foundWrapperApp = false;
         for (String project : projectList) {
             if (GRADLE_APP_NAME.equals(project)) {
                 foundApp = true;
-                break;
+            } else if (GRADLE_WRAPPER_APP_NAME.equals(project)) {
+                foundWrapperApp = true;
             }
         }
         Assertions.assertTrue(foundApp, () -> "The dashboard does not contain expected application: " + GRADLE_APP_NAME);
+        Assertions.assertTrue(foundWrapperApp, () -> "The dashboard does not contain expected application: " + GRADLE_WRAPPER_APP_NAME);
 
         // Check that the menu for the expected application contains the required actions.
         List<String> menuItems = getDashboardItemMenuActions(GRADLE_APP_NAME);

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -191,7 +191,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
 
         // Give the app some time to be imported (especially on Windows GHA runs)
         try {
-            Thread.sleep(Integer.parseInt(System.getProperty("io.liberty.tools.eclipse.tests.mvn.import.wait", "0")));
+            Thread.sleep(Integer.parseInt(System.getProperty("io.liberty.tools.eclipse.tests.app.import.wait", "0")));
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
@@ -12,13 +12,18 @@
  *******************************************************************************/
 package io.openliberty.tools.eclipse.test.it;
 
+import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.go;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.deleteLibertyToolsRunConfigEntriesFromAppRunAs;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getDashboardContent;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getDashboardItemMenuActions;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getLibertyTreeItem;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.*;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDebugConfigurationsDialogFromAppRunAs;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchRunConfigurationsDialogFromAppRunAs;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStartWithDefaultRunConfigFromAppRunAs;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStopWithRunAsShortcut;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.pressWorkspaceErrorDialogProceedButton;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.setBuildCmdPathInPreferences;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.unsetBuildCmdPathInPreferences;
-import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.*;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -35,12 +40,11 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import io.openliberty.tools.eclipse.test.it.utils.LibertyPluginTestUtils;
-import io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder;
 import io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations;
 import io.openliberty.tools.eclipse.ui.dashboard.DashboardView;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
@@ -48,6 +52,7 @@ import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLaunche
 /**
  * Tests Open Liberty Eclipse plugin functions.
  */
+@TestMethodOrder(MethodName.class)
 public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginSWTBotTest {
 
     /**
@@ -135,7 +140,7 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
 
         // Give the app some time to be imported (especially on Windows GHA runs)
         try {
-            Thread.sleep(Integer.parseInt(System.getProperty("io.liberty.tools.eclipse.tests.mvn.import.wait","0")));
+            Thread.sleep(Integer.parseInt(System.getProperty("io.liberty.tools.eclipse.tests.mvn.import.wait", "0")));
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
@@ -140,7 +140,7 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
 
         // Give the app some time to be imported (especially on Windows GHA runs)
         try {
-            Thread.sleep(Integer.parseInt(System.getProperty("io.liberty.tools.eclipse.tests.mvn.import.wait", "0")));
+            Thread.sleep(Integer.parseInt(System.getProperty("io.liberty.tools.eclipse.tests.app.import.wait", "0")));
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -536,8 +536,9 @@ public class SWTBotPluginOperations {
     	
         Object libertyConfigTree = getLibertyTreeItem(shell); 
 
-        go(runDebugConfigName, libertyConfigTree, Option.factory().useContains(true).widgetClass(TreeItem.class).build());
-        Object parmLabel = find("Start parameters:", libertyConfigTree, Option.factory().widgetClass(Label.class).build());
+        Object appConfigEntry = find(runDebugConfigName, libertyConfigTree, Option.factory().useContains(true).widgetClass(TreeItem.class).build());
+        go(appConfigEntry);
+        Object parmLabel = find("Start parameters:", appConfigEntry, Option.factory().widgetClass(Label.class).build());
 
         Control parmText = ControlFinder.findControlInRange(parmLabel, Text.class, Direction.EAST);
         set(parmText, customParms);


### PR DESCRIPTION
- Update LCLS to version 2.0.1
- Bump version to 23.0.9
- Create 2Q2023 target platform file
- Update peripheral scripts to use 2Q2023 target platform 