### PR TITLE
Use custom debug model

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
@@ -7,12 +7,16 @@ Bundle-SymbolicName: io.openliberty.tools.eclipse.ui;singleton:=true
 Bundle-Version: 23.0.12.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.LibertyDevPlugin
 Export-Package: io.openliberty.tools.eclipse;x-friends:="io.openliberty.tools.eclipse.tests",
+ io.openliberty.tools.eclipse.debug;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.ui.dashboard;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.ui.launch;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.ui.launch.shortcuts;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.ui.preferences;x-friends:="io.openliberty.tools.eclipse.tests"
 Require-Bundle: org.eclipse.ui,
- org.eclipse.equinox.preferences
+ org.eclipse.equinox.preferences,
+ org.eclipse.swt,
+ org.eclipse.m2e.maven.runtime,
+ org.eclipse.m2e.core
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: io.openliberty.tools.eclipse.ui
 Bundle-ActivationPolicy: lazy
@@ -23,11 +27,18 @@ Import-Package: org.eclipse.core.commands,
  org.eclipse.core.runtime.jobs,
  org.eclipse.debug.core,
  org.eclipse.debug.core.model,
+ org.eclipse.debug.core.sourcelookup,
  org.eclipse.debug.ui,
+ org.eclipse.debug.ui.sourcelookup,
+ org.eclipse.jdi,
  org.eclipse.jdt.core,
+ org.eclipse.jdt.debug.core,
  org.eclipse.jdt.debug.ui.launchConfigurations,
  org.eclipse.jdt.launching,
+ org.eclipse.jdt.launching.sourcelookup.containers,
  org.eclipse.jem.util.emf.workbench,
+ org.eclipse.m2e.core,
+ org.eclipse.m2e.core.project,
  org.eclipse.osgi.service.debug,
  org.eclipse.osgi.util,
  org.eclipse.swt.custom,
@@ -43,4 +54,7 @@ Import-Package: org.eclipse.core.commands,
  org.eclipse.ui,
  org.eclipse.ui.handlers,
  org.eclipse.ui.plugin,
+ org.gradle.tooling,
+ org.gradle.tooling.model,
+ org.gradle.tooling.model.eclipse,
  org.osgi.framework

--- a/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
@@ -13,10 +13,7 @@ Export-Package: io.openliberty.tools.eclipse;x-friends:="io.openliberty.tools.ec
  io.openliberty.tools.eclipse.ui.launch.shortcuts;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.ui.preferences;x-friends:="io.openliberty.tools.eclipse.tests"
 Require-Bundle: org.eclipse.ui,
- org.eclipse.equinox.preferences,
- org.eclipse.swt,
- org.eclipse.m2e.maven.runtime,
- org.eclipse.m2e.core
+ org.eclipse.m2e.maven.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: io.openliberty.tools.eclipse.ui
 Bundle-ActivationPolicy: lazy
@@ -25,6 +22,7 @@ Import-Package: org.eclipse.core.commands,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.core.runtime.jobs,
+ org.eclipse.core.runtime.preferences,
  org.eclipse.debug.core,
  org.eclipse.debug.core.model,
  org.eclipse.debug.core.sourcelookup,
@@ -38,6 +36,7 @@ Import-Package: org.eclipse.core.commands,
  org.eclipse.jdt.launching.sourcelookup.containers,
  org.eclipse.jem.util.emf.workbench,
  org.eclipse.m2e.core,
+ org.eclipse.m2e.core.embedder,
  org.eclipse.m2e.core.project,
  org.eclipse.osgi.service.debug,
  org.eclipse.osgi.util,
@@ -51,9 +50,6 @@ Import-Package: org.eclipse.core.commands,
  org.eclipse.tm.terminal.view.ui.launcher,
  org.eclipse.tm.terminal.view.ui.manager,
  org.eclipse.tm.terminal.view.ui.tabs,
- org.eclipse.ui,
- org.eclipse.ui.handlers,
- org.eclipse.ui.plugin,
  org.gradle.tooling,
  org.gradle.tooling.model,
  org.gradle.tooling.model.eclipse,

--- a/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
+++ b/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
@@ -373,6 +373,21 @@
             </command>
         </menuContribution>
    </extension>
+   
+   <extension point="org.eclipse.debug.core.sourceLocators">
+	   <sourceLocator
+	       name="Liberty Source Lookup Director"
+	       class="io.openliberty.tools.eclipse.debug.LibertySourceLookupDirector"
+	       id="io.openliberty.tools.eclipse.debug.libertySourceLookupDirector">
+	   </sourceLocator>
+   </extension>
+   
+   <extension point="org.eclipse.debug.core.sourcePathComputers">
+       <sourcePathComputer
+           class="io.openliberty.tools.eclipse.debug.LibertySourcePathComputer"
+           id="io.openliberty.tools.eclipse.debug.libertySourcePathComputer">
+       </sourcePathComputer>
+   </extension>
 
   <!-- Launch configuration -->
   <extension point="org.eclipse.debug.core.launchConfigurationTypes">
@@ -380,7 +395,9 @@
           name="Liberty"
           delegate="io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher"
           modes="run, debug"
-          id="io.openliberty.tools.eclipse.launch.type">
+          id="io.openliberty.tools.eclipse.launch.type"
+          sourceLocatorId="io.openliberty.tools.eclipse.debug.libertySourceLookupDirector"
+          sourcePathComputerId="io.openliberty.tools.eclipse.debug.libertySourcePathComputer">
       </launchConfigurationType>
   </extension>
   <extension point="org.eclipse.debug.ui.launchConfigurationTypeImages">

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -15,7 +15,7 @@ package io.openliberty.tools.eclipse;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.osgi.util.NLS;
 
 import io.openliberty.tools.eclipse.logging.Trace;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -32,6 +32,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jface.viewers.ISelection;
@@ -46,6 +47,7 @@ import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
 
 import io.openliberty.tools.eclipse.CommandBuilder.CommandNotFoundException;
 import io.openliberty.tools.eclipse.Project.BuildType;
+import io.openliberty.tools.eclipse.debug.DebugModeHandler;
 import io.openliberty.tools.eclipse.logging.Logger;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.messages.Messages;
@@ -151,7 +153,7 @@ public class DevModeOperations {
      * @param javaHomePath The configuration java installation home to be set in the terminal running dev mode.
      * @param mode The configuration mode.
      */
-    public void start(IProject iProject, String parms, String javaHomePath, String mode) {
+    public void start(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode) {
 
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms, javaHomePath, mode });
@@ -232,13 +234,13 @@ public class DevModeOperations {
                         + "does not appear to be a Maven or Gradle built project.");
             }
 
-            // If there is a debugPort, start the job to attach the debugger to the Liberty server JVM.
-            if (debugPort != null) {
-                debugModeHandler.startDebugAttacher(project, debugPort);
-            }
-
             // Start a terminal and run the application in dev mode.
             startDevMode(cmd, projectName, projectPath, javaHomePath);
+
+            // If there is a debugPort, start the job to attach the debugger to the Liberty server JVM.
+            if (debugPort != null) {
+                debugModeHandler.startDebugAttacher(project, launch, debugPort);
+            }
         } catch (CommandNotFoundException e) {
             String msg = "Maven or Gradle command not found for project " + projectName;
             if (Trace.isEnabled()) {
@@ -266,7 +268,7 @@ public class DevModeOperations {
      * @param javaHomePath The configuration java installation home to be set in the terminal running dev mode.
      * @param mode The configuration mode.
      */
-    public void startInContainer(IProject iProject, String parms, String javaHomePath, String mode) {
+    public void startInContainer(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode) {
 
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms, javaHomePath, mode });
@@ -347,13 +349,13 @@ public class DevModeOperations {
                         + "does not appear to be a Maven or Gradle built project.");
             }
 
-            // If there is a debugPort, start the job to attach the debugger to the Liberty server JVM.
-            if (debugPort != null) {
-                debugModeHandler.startDebugAttacher(project, debugPort);
-            }
-
             // Start a terminal and run the application in dev mode.
             startDevMode(cmd, projectName, projectPath, javaHomePath);
+
+            // If there is a debugPort, start the job to attach the debugger to the Liberty server JVM.
+            if (debugPort != null) {
+                debugModeHandler.startDebugAttacher(project, launch, debugPort);
+            }
         } catch (Exception e) {
             String msg = "An error was detected during the start in container request on project " + projectName;
             if (Trace.isEnabled()) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/DebugModeHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/DebugModeHandler.java
@@ -10,11 +10,12 @@
 * Contributors:
 *     IBM Corporation - initial implementation
 *******************************************************************************/
-package io.openliberty.tools.eclipse;
+package io.openliberty.tools.eclipse.debug;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.IOException;
 import java.net.ConnectException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -22,29 +23,27 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
-import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationType;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.debug.core.ILaunchManager;
-import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.debug.core.model.IDebugTarget;
+import org.eclipse.jdi.Bootstrap;
+import org.eclipse.jdi.TimeoutException;
+import org.eclipse.jdt.debug.core.JDIDebugModel;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IViewPart;
@@ -53,12 +52,19 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
+import com.sun.jdi.VirtualMachine;
+import com.sun.jdi.connect.AttachingConnector;
+import com.sun.jdi.connect.Connector;
+import com.sun.jdi.connect.Connector.Argument;
+import com.sun.jdi.connect.IllegalConnectorArgumentsException;
+
+import io.openliberty.tools.eclipse.DevModeOperations;
+import io.openliberty.tools.eclipse.LibertyDevPlugin;
+import io.openliberty.tools.eclipse.Project;
 import io.openliberty.tools.eclipse.Project.BuildType;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.messages.Messages;
 import io.openliberty.tools.eclipse.ui.dashboard.DashboardView;
-import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationHelper;
-import io.openliberty.tools.eclipse.ui.launch.StartTab;
 import io.openliberty.tools.eclipse.ui.terminal.ProjectTabController;
 import io.openliberty.tools.eclipse.ui.terminal.TerminalListener;
 import io.openliberty.tools.eclipse.utils.ErrorHandler;
@@ -88,9 +94,6 @@ public class DebugModeHandler {
 
     /** Job status return code indicating that an error took place while attempting to attach the debugger to the JVM. */
     public static int JOB_STATUS_DEBUGGER_CONN_ERROR = 1;
-
-    /** Instance to this class. */
-    private LaunchConfigurationHelper launchConfigHelper = LaunchConfigurationHelper.getInstance();
 
     /** DevModeOperations instance. */
     private DevModeOperations devModeOps;
@@ -209,11 +212,12 @@ public class DebugModeHandler {
      * Starts the job that will attempt to connect the debugger with the server's JVM.
      * 
      * @param project The project for which the debugger needs to be attached.
+     * @param launch The launch to which the debug target will be added.
      * @param debugPort The debug port to use to attach the debugger to.
      * 
      * @throws Exception
      */
-    public void startDebugAttacher(Project project, String debugPort) {
+    public void startDebugAttacher(Project project, ILaunch launch, String debugPort) {
         String projectName = project.getIProject().getName();
 
         Job job = new Job("Attaching Debugger to JVM...") {
@@ -229,7 +233,13 @@ public class DebugModeHandler {
                         return Status.CANCEL_STATUS;
                     }
 
-                    createRemoteJavaAppDebugConfig(project, DEFAULT_ATTACH_HOST, portToConnect, monitor);
+                    AttachingConnector connector = getAttachingConnector();
+                    Map<String, Argument> map = connector.defaultArguments();
+                    configureConnector(map, DEFAULT_ATTACH_HOST, Integer.parseInt(portToConnect));
+                    IDebugTarget debugTarget = createRemoteJDTDebugTarget(launch, Integer.parseInt(portToConnect), DEFAULT_ATTACH_HOST,
+                            connector, map);
+
+                    launch.addDebugTarget(debugTarget);
 
                 } catch (Exception e) {
                     return new Status(IStatus.ERROR, LibertyDevPlugin.PLUGIN_ID, JOB_STATUS_DEBUGGER_CONN_ERROR,
@@ -283,6 +293,120 @@ public class DebugModeHandler {
         });
 
         job.schedule();
+    }
+
+    private AttachingConnector getAttachingConnector() {
+        List<?> connectors = Bootstrap.virtualMachineManager().attachingConnectors();
+        for (int i = 0; i < connectors.size(); i++) {
+            AttachingConnector c = (AttachingConnector) connectors.get(i);
+            if ("com.sun.jdi.SocketAttach".equals(c.name()))
+                return c;
+        }
+
+        return null;
+    }
+
+    /**
+     * Configure the connector properties.
+     *
+     * @param map argument map
+     * @param host the host name or IP address
+     * @param portNumber the port number
+     */
+    private void configureConnector(Map<String, Argument> map, String host, int portNumber) {
+        Connector.StringArgument hostArg = (Connector.StringArgument) map.get("hostname");
+        hostArg.setValue(host);
+
+        Connector.IntegerArgument portArg = (Connector.IntegerArgument) map.get("port");
+        portArg.setValue(portNumber);
+
+        // This timeout value is directly configurable from the "Launch timeout" in Eclipse Preferences.
+        // At the point when we connect, we already confirmed that we are able to connect to the socket,
+        // so this may not come into play. However, we are keeping it here just in case.
+        Connector.IntegerArgument timeoutArg = (Connector.IntegerArgument) map.get("timeout");
+        if (timeoutArg != null) {
+            int timeout = Platform.getPreferencesService().getInt(
+                    "org.eclipse.jdt.launching",
+                    JavaRuntime.PREF_CONNECT_TIMEOUT,
+                    JavaRuntime.DEF_CONNECT_TIMEOUT,
+                    null);
+            timeoutArg.setValue(timeout);
+        }
+    }
+
+    private IDebugTarget createRemoteJDTDebugTarget(ILaunch launch, int remoteDebugPortNum, String hostName,
+            AttachingConnector connector, Map<String, Argument> map) throws CoreException {
+        if (launch == null || hostName == null || hostName.length() == 0) {
+            return null;
+        }
+        VirtualMachine remoteVM = null;
+        Exception ex = null;
+        IDebugTarget debugTarget = null;
+        try {
+            remoteVM = attachJVM(hostName, remoteDebugPortNum, connector, map);
+        } catch (Exception e) {
+            ex = e;
+        }
+        if (remoteVM == null) {
+            throw new CoreException(
+                    new Status(IStatus.ERROR, this.getClass(), IJavaLaunchConfigurationConstants.ERR_CONNECTION_FAILED, "", ex));
+        }
+        debugTarget = JDIDebugModel.newDebugTarget(launch, remoteVM, hostName + ":" + remoteDebugPortNum, null, true, false, true);
+        return debugTarget;
+    }
+
+    /**
+     * Connect the debugger to the debug port of the target VM
+     * 
+     * @param hostName
+     * @param port
+     * @param connector
+     * @param map
+     * 
+     * @return
+     */
+    private VirtualMachine attachJVM(String hostName, int port, AttachingConnector connector, Map<String, Argument> map) {
+
+        // At this point, the "waitForSocketActivation" method has already been called so we know that we are able
+        // to connect to the Liberty server's debug port. However, there is still a gap here where we can get a
+        // connection refused exception when we attempt to attach the debugger. This could potentially be due to a difference in
+        // how we are writing to the socket, but whatever the reason, we have a timeout mechanism here as well to attempt the
+        // connection every 100ms for 10 seconds. Any IOExceptions like a "connection refused" will trigger a retry. Any timeout
+        // exceptions within the connector itself will not trigger a retry. We will catch that in the calling method and
+        // expose the timeout there. If we exhaust out retries we will return null and the calling method will throw a connection
+        // error.
+
+        VirtualMachine vm = null;
+        int timeOut = 10000;
+        try {
+            try {
+                vm = connector.attach(map);
+            } catch (IOException e) {
+                if (Trace.isEnabled()) {
+                    Trace.getTracer().trace(Trace.TRACE_UI,
+                            "Error occured while trying to connect to the remote virtual machine " + e.getMessage(), e);
+                }
+            } catch (TimeoutException e2) {
+                // do nothing
+            }
+
+            while (vm == null && timeOut > 0) {
+                try {
+                    Thread.sleep(100);
+                } catch (Exception e) {
+                    // do nothing
+                }
+                timeOut = timeOut - 100;
+                try {
+                    vm = connector.attach(map);
+                } catch (IOException e) {
+                    // do nothing
+                }
+            }
+        } catch (IllegalConnectorArgumentsException e) {
+            // Do nothing, return vm as null if it fails
+        }
+        return vm;
     }
 
     /**
@@ -431,91 +555,6 @@ public class DebugModeHandler {
     }
 
     /**
-     * Returns a new Remote Java Application debug configuration.
-     * 
-     * @param configuration The configuration being processed.
-     * @param host The JVM host to connect to.
-     * @param port The JVM port to connect to.
-     * @param monitor The progress monitor.
-     * 
-     * @return A new Remote Java Application debug configuration.
-     * 
-     * @throws Exception
-     */
-    private ILaunch createRemoteJavaAppDebugConfig(Project project, String host, String port, IProgressMonitor monitor) throws Exception {
-        // There are cases where some modules of a multi-module project may not be categorized as Java projects.
-        // The Remote Java Application configuration requires that the project being processed is a Java project.
-        // Given this requirement, multi-module projects that contain modules with liberty server configuration that
-        // are not considered Java projects may not be able to run debug mode.
-        // A compromise to go around this case is to obtain configuration information from a child or peer project that
-        // is considered to be Java project.
-        // Therefore, the following code obtains Java configuration information from an associated Java project and
-        // uses it on behalf of the application being processed.
-        IProject iProject = project.getIProject();
-        String projectName = iProject.getName();
-        String associatedProjectName = projectName;
-        if (!iProject.hasNature(JavaCore.NATURE_ID)) {
-            Project associatedProject = project.getAssociatedJavaProject(project);
-            if (associatedProject != null) {
-                associatedProjectName = associatedProject.getName();
-            } else {
-                throw new Exception("Project " + projectName + " is not a Java project. Associated Java projects not found.");
-            }
-        }
-
-        ILaunchManager iLaunchManager = DebugPlugin.getDefault().getLaunchManager();
-        ILaunchConfigurationType remoteJavaAppConfigType = iLaunchManager
-                .getLaunchConfigurationType(IJavaLaunchConfigurationConstants.ID_REMOTE_JAVA_APPLICATION);
-        ILaunchConfiguration[] remoteJavaAppConfigs = iLaunchManager.getLaunchConfigurations(remoteJavaAppConfigType);
-        ILaunchConfigurationWorkingCopy remoteJavaAppConfigWCopy = null;
-
-        // Find the configurations associated with the project.
-        List<ILaunchConfiguration> projectAssociatedConfigs = new ArrayList<ILaunchConfiguration>();
-        for (ILaunchConfiguration remoteJavaAppConfig : remoteJavaAppConfigs) {
-            String savedProjectName = remoteJavaAppConfig.getAttribute(StartTab.PROJECT_NAME, (String) null);
-            if (savedProjectName != null && savedProjectName.equals(projectName)) {
-                projectAssociatedConfigs.add(remoteJavaAppConfig);
-            }
-        }
-
-        // Find the configuration used last.
-        if (projectAssociatedConfigs.size() > 0) {
-            ILaunchConfiguration lastUsedConfig = launchConfigHelper.getLastRunConfiguration(projectAssociatedConfigs);
-            remoteJavaAppConfigWCopy = lastUsedConfig.getWorkingCopy();
-        }
-
-        // If an existing configuration was not found, create one.
-        if (remoteJavaAppConfigWCopy == null) {
-            String configName = launchConfigHelper.buildConfigurationName(projectName);
-            remoteJavaAppConfigWCopy = remoteJavaAppConfigType.newInstance(null, configName);
-            remoteJavaAppConfigWCopy.setAttribute(StartTab.PROJECT_NAME, projectName);
-            remoteJavaAppConfigWCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, associatedProjectName);
-            remoteJavaAppConfigWCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_CONNECTOR,
-                    IJavaLaunchConfigurationConstants.ID_SOCKET_ATTACH_VM_CONNECTOR);
-            remoteJavaAppConfigWCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_ALLOW_TERMINATE, false);
-        }
-
-        // Update the configuration with the current data.
-        Map<String, String> connectMap = new HashMap<>(2);
-        connectMap.put("port", port);
-        connectMap.put("hostname", host);
-        remoteJavaAppConfigWCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_CONNECT_MAP, connectMap);
-        remoteJavaAppConfigWCopy.setAttribute(StartTab.PROJECT_RUN_TIME, String.valueOf(System.currentTimeMillis()));
-
-        //
-        // Fixed issue: https://github.com/OpenLiberty/liberty-tools-eclipse/issues/372
-        // by launching with the return value of remoteJavaAppConfigWCopy.doSave(), rather than the
-        // object (the "working copy") itself.
-        //
-        // Debated calling launch() with the doSave() return value vs. the value of
-        // remoteJavaAppConfigWCopy.getOriginal(). Decided on the former which
-        // seemed to be the more common usage pattern, though not entirely clear which is better.
-        //
-        ILaunchConfiguration updatedConfig = remoteJavaAppConfigWCopy.doSave();
-        return updatedConfig.launch(ILaunchManager.DEBUG_MODE, monitor);
-    }
-
-    /**
      * Waits for the JDWP socket on the JVM to start listening for connections.
      * 
      * @param host The host to connect to.
@@ -527,6 +566,14 @@ public class DebugModeHandler {
      * @throws Exception
      */
     private String waitForSocketActivation(Project project, String host, String port, IProgressMonitor monitor) throws Exception {
+
+        // This is the first of several timeout mechanisms during the debugger connection. This method
+        // will attempt a write to the debug port of the target VM (Liberty server) once every second for
+        // 3 minutes. This seems like a reasonable amount of time for the debug port to become available
+        // so for now we are not making this timeout configurable. If in the future, we need to expose
+        // this timeout value, we could potentially tie it to the "Launch timeout" setting of in the
+        // Eclipse "Debug" preferences.
+
         byte[] handshakeString = "JDWP-Handshake".getBytes(StandardCharsets.US_ASCII);
         int retryLimit = 180;
         int envReadInterval = 2;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertySourceLookupDirector.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertySourceLookupDirector.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+* Copyright (c) 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial implementation
+*******************************************************************************/
+package io.openliberty.tools.eclipse.debug;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.debug.core.sourcelookup.AbstractSourceLookupDirector;
+import org.eclipse.debug.core.sourcelookup.ISourceLookupParticipant;
+import org.eclipse.jdt.launching.sourcelookup.containers.JavaSourceLookupParticipant;
+
+public class LibertySourceLookupDirector extends AbstractSourceLookupDirector {
+
+    @Override
+    public void initializeParticipants() {
+        final List<ISourceLookupParticipant> participants = new ArrayList<>();
+
+        participants.add(new JavaSourceLookupParticipant());
+
+        addParticipants(participants.toArray(new ISourceLookupParticipant[participants.size()]));
+    }
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertySourcePathComputer.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertySourcePathComputer.java
@@ -1,0 +1,204 @@
+/*******************************************************************************
+* Copyright (c) 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial implementation
+*******************************************************************************/
+package io.openliberty.tools.eclipse.debug;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.sourcelookup.ISourceContainer;
+import org.eclipse.debug.core.sourcelookup.ISourcePathComputerDelegate;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.launching.IRuntimeClasspathEntry;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+import org.gradle.tooling.model.ExternalDependency;
+import org.gradle.tooling.model.GradleModuleVersion;
+import org.gradle.tooling.model.eclipse.EclipseProject;
+
+import io.openliberty.tools.eclipse.DevModeOperations;
+import io.openliberty.tools.eclipse.Project;
+import io.openliberty.tools.eclipse.ui.launch.StartTab;
+
+public class LibertySourcePathComputer implements ISourcePathComputerDelegate {
+
+    ArrayList<IRuntimeClasspathEntry> unresolvedClasspathEntries;
+
+    @Override
+    public ISourceContainer[] computeSourceContainers(ILaunchConfiguration configuration, IProgressMonitor monitor) throws CoreException {
+
+        unresolvedClasspathEntries = new ArrayList<IRuntimeClasspathEntry>();
+
+        /*
+         * This method computes the default source lookup paths for a particular launch configuration. We are doing this in two ways:
+         * .
+         * 1. We are first computing the runtime classpath entries. This is in-line with what Remote Java Application does.
+         * .
+         * 2. We are finding any project dependencies that are also present in the current Eclipse workspace and adding those projects.
+         * . For this step we are using m2e and gradle/buildship APIs to get lists of the dependency artifacts and then checking if those
+         * . artifact coordinates map to any existing projects in the workspace. At the moment, the dependency projects must be Maven
+         * . projects. M2e offers APIs to lookup Maven projects in the workspace based on artifact coordinates,
+         * . but Gradle/Buildship does not offer similar capabilities for Gradle projects.
+         */
+
+        // Get current project
+        String projectName = configuration.getAttribute(StartTab.PROJECT_NAME, (String) null);
+
+        Project project = DevModeOperations.getInstance().getProjectModel().getProject(projectName);
+
+        // Get full list of projects (multi-mod, children, siblings, etc)
+        List<Project> baseProjects = getBaseProjects(project);
+
+        // Loop through each
+        for (Project baseProject : baseProjects) {
+
+            addRuntimeDependencies(baseProject.getIProject());
+
+            // Get project dependencies that are open in the same workspace
+            List<IProject> projectDependencies = getProjectDependencies(baseProject);
+
+            // Create the classpath entry for the project dependencies found
+            for (IProject dependencyProject : projectDependencies) {
+
+                if (dependencyProject.isNatureEnabled(JavaCore.NATURE_ID)) {
+                    IJavaProject dependencyJavaProject = JavaCore.create(dependencyProject);
+                    unresolvedClasspathEntries.add(JavaRuntime.newDefaultProjectClasspathEntry(dependencyJavaProject));
+                }
+            }
+        }
+
+        // Resolve and get final list of source containers
+        IRuntimeClasspathEntry[] resolvedClasspathDependencies = JavaRuntime.resolveSourceLookupPath(
+                unresolvedClasspathEntries.toArray(new IRuntimeClasspathEntry[unresolvedClasspathEntries.size()]), configuration);
+
+        ArrayList<ISourceContainer> containersList = new ArrayList<ISourceContainer>();
+
+        containersList.addAll(Arrays.asList(JavaRuntime.getSourceContainers(resolvedClasspathDependencies)));
+
+        ISourceContainer[] containers = new ISourceContainer[containersList.size()];
+        containersList.toArray(containers);
+
+        return containers;
+    }
+
+    private List<Project> getBaseProjects(Project project) {
+        List<Project> baseProjects = new ArrayList<Project>();
+
+        baseProjects.add(project);
+
+        baseProjects.addAll(project.getChildJavaProjects());
+        baseProjects.addAll(project.getPeerJavaProjects());
+
+        return baseProjects;
+    }
+
+    private List<IProject> getProjectDependencies(Project project) throws CoreException {
+        List<IProject> projectDependencies = new ArrayList<IProject>();
+
+        if (project.getBuildType() == Project.BuildType.MAVEN) {
+
+            MavenProject mavenModuleProject = MavenPlugin.getMavenModelManager().readMavenProject(project.getIProject().getFile("pom.xml"),
+                    new NullProgressMonitor());
+            Set<Artifact> artifacts = mavenModuleProject.getArtifacts();
+
+            for (Artifact artifact : artifacts) {
+
+                IProject localProject = getLocalProject(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+                if (localProject != null) {
+                    projectDependencies.add(localProject);
+                }
+            }
+        } else {
+            GradleConnector connector = GradleConnector.newConnector();
+            connector.forProjectDirectory(project.getIProject().getLocation().toFile());
+            ProjectConnection connection = connector.connect();
+
+            try {
+                EclipseProject eclipseProject = connection.getModel(EclipseProject.class);
+                for (ExternalDependency externalDependency : eclipseProject.getClasspath()) {
+
+                    GradleModuleVersion gradleModuleVersion = externalDependency.getGradleModuleVersion();
+
+                    IProject localProject = getLocalProject(gradleModuleVersion.getGroup(), gradleModuleVersion.getName(),
+                            gradleModuleVersion.getVersion());
+                    if (localProject != null) {
+                        projectDependencies.add(localProject);
+                    }
+                }
+            } finally {
+                connection.close();
+            }
+        }
+
+        return projectDependencies;
+    }
+
+    /**
+     * Get project if found in local workspace based on artifact coordinates
+     * 
+     * @param groupId
+     * @param artifactId
+     * @param version
+     * 
+     * @return
+     */
+    private IProject getLocalProject(String groupId, String artifactId, String version) {
+
+        // Check Maven projects
+        IMavenProjectRegistry mavenProjectRegistry = MavenPlugin.getMavenProjectRegistry();
+
+        IMavenProjectFacade mavenProjectFacade = mavenProjectRegistry.getMavenProject(groupId, artifactId, version);
+
+        if (mavenProjectFacade != null) {
+            return mavenProjectFacade.getProject();
+        }
+
+        // TODO: Check Gradle projects
+
+        return null;
+    }
+
+    /**
+     * Adds classpath entries for runtime dependencies to the unresolved classpath entries list
+     * 
+     * @param project
+     * 
+     * @throws CoreException
+     */
+    private void addRuntimeDependencies(IProject project) throws CoreException {
+
+        // If the project is a java project, get classpath entries for runtime dependencies
+        if (project.isNatureEnabled(JavaCore.NATURE_ID)) {
+            List<IRuntimeClasspathEntry> runtimeDependencies = Arrays
+                    .asList(JavaRuntime.computeUnresolvedRuntimeDependencies(JavaCore.create(project)));
+            for (IRuntimeClasspathEntry runtimeDependency : runtimeDependencies) {
+                if (!unresolvedClasspathEntries.contains(runtimeDependency)) {
+                    unresolvedClasspathEntries.add(runtimeDependency);
+                }
+            }
+        }
+    }
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertySourcePathComputer.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertySourcePathComputer.java
@@ -193,7 +193,7 @@ public class LibertySourcePathComputer implements ISourcePathComputerDelegate {
         // If the project is a java project, get classpath entries for runtime dependencies
         if (project.isNatureEnabled(JavaCore.NATURE_ID)) {
             List<IRuntimeClasspathEntry> runtimeDependencies = Arrays
-                    .asList(JavaRuntime.computeUnresolvedRuntimeDependencies(JavaCore.create(project)));
+                    .asList(JavaRuntime.computeUnresolvedRuntimeClasspath(JavaCore.create(project)));
             for (IRuntimeClasspathEntry runtimeDependency : runtimeDependencies) {
                 if (!unresolvedClasspathEntries.contains(runtimeDependency)) {
                     unresolvedClasspathEntries.add(runtimeDependency);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
@@ -248,7 +248,7 @@ public class DashboardView extends ViewPart {
             public void run() {
                 IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    StartAction.run(iProject, null, ILaunchManager.RUN_MODE);
+                    StartAction.run(iProject, ILaunchManager.RUN_MODE);
                 } catch (Exception e) {
                     String msg = "An error was detected during the " + APP_MENU_ACTION_START + " action.";
                     if (Trace.isEnabled()) {
@@ -293,7 +293,7 @@ public class DashboardView extends ViewPart {
             public void run() {
                 IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    StartInContainerAction.run(iProject, null, ILaunchManager.RUN_MODE);
+                    StartInContainerAction.run(iProject, ILaunchManager.RUN_MODE);
                 } catch (Exception e) {
                     String msg = "An error was detected during the " + APP_MENU_ACTION_START_IN_CONTAINER
                             + " action.";
@@ -315,7 +315,7 @@ public class DashboardView extends ViewPart {
             public void run() {
                 IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    StartInContainerAction.run(iProject, null, ILaunchManager.DEBUG_MODE);
+                    StartInContainerAction.run(iProject, ILaunchManager.DEBUG_MODE);
                 } catch (Exception e) {
                     String msg = "An error was detected during the " + APP_MENU_ACTION_DEBUG_IN_CONTAINER
                             + " action.";
@@ -337,7 +337,7 @@ public class DashboardView extends ViewPart {
             public void run() {
                 IProject iProject = devModeOps.getSelectedDashboardProject();
                 try {
-                    StartAction.run(iProject, null, ILaunchManager.DEBUG_MODE);
+                    StartAction.run(iProject, ILaunchManager.DEBUG_MODE);
                 } catch (Exception e) {
                     String msg = "An error was detected during the " + APP_MENU_ACTION_DEBUG + " action.";
                     if (Trace.isEnabled()) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigTabGroup.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigTabGroup.java
@@ -15,6 +15,7 @@ package io.openliberty.tools.eclipse.ui.launch;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
+import org.eclipse.debug.ui.sourcelookup.SourceLookupTab;
 
 /**
  * Creates and groups run configuration view tabs.
@@ -26,6 +27,6 @@ public class LaunchConfigTabGroup extends AbstractLaunchConfigurationTabGroup {
      */
     @Override
     public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-        setTabs(new ILaunchConfigurationTab[] { new StartTab(), new JRETab() });
+        setTabs(new ILaunchConfigurationTab[] { new StartTab(), new JRETab(), new SourceLookupTab() });
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationHelper.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationHelper.java
@@ -57,6 +57,10 @@ public class LaunchConfigurationHelper {
      * @throws Exception
      */
     public ILaunchConfiguration getLaunchConfiguration(IProject iProject, String mode, RuntimeEnv runtimeEnv) throws Exception {
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { iProject, mode, runtimeEnv });
+        }
+
         DevModeOperations devModeOps = DevModeOperations.getInstance();
         ILaunchConfiguration configuration = null;
         ILaunchManager iLaunchMgr = DebugPlugin.getDefault().getLaunchManager();
@@ -69,31 +73,35 @@ public class LaunchConfigurationHelper {
         List<ILaunchConfiguration> matchingConfigList = filterLaunchConfigurations(existingConfigs, iProject.getName(), runtimeEnv);
 
         switch (matchingConfigList.size()) {
-        case 0:
-            // Create a new configuration.
-            String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
-            ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
-            workingCopy.setAttribute(StartTab.PROJECT_NAME, iProject.getName());
-            workingCopy.setAttribute(StartTab.PROJECT_START_PARM, devModeOps.getProjectModel().getDefaultStartParameters(iProject));
-            //default to 'false', no container
-            boolean runInContainer = runtimeEnv.equals(RuntimeEnv.CONTAINER);
-            workingCopy.setAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, runInContainer);
+            case 0:
+                // Create a new configuration.
+                String newName = iLaunchMgr.generateLaunchConfigurationName(iProject.getName());
+                ILaunchConfigurationWorkingCopy workingCopy = iLaunchConfigType.newInstance(null, newName);
+                workingCopy.setAttribute(StartTab.PROJECT_NAME, iProject.getName());
+                workingCopy.setAttribute(StartTab.PROJECT_START_PARM, devModeOps.getProjectModel().getDefaultStartParameters(iProject));
+                // default to 'false', no container
+                boolean runInContainer = runtimeEnv.equals(RuntimeEnv.CONTAINER);
+                workingCopy.setAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, runInContainer);
 
-            String defaultJavaDef = JRETab.getDefaultJavaFromBuildPath(iProject);
-            if (defaultJavaDef != null) {
-                workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_JRE_CONTAINER_PATH, defaultJavaDef);
-            }
+                String defaultJavaDef = JRETab.getDefaultJavaFromBuildPath(iProject);
+                if (defaultJavaDef != null) {
+                    workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_JRE_CONTAINER_PATH, defaultJavaDef);
+                }
 
-            configuration = workingCopy.doSave();
-            break;
-        case 1:
-            // Return the found configuration.
-            configuration = matchingConfigList.get(0);
-            break;
-        default:
-            // Return the configuration that was run last.
-            configuration = getLastRunConfiguration(matchingConfigList);
-            break;
+                configuration = workingCopy.doSave();
+                break;
+            case 1:
+                // Return the found configuration.
+                configuration = matchingConfigList.get(0);
+                break;
+            default:
+                // Return the configuration that was run last.
+                configuration = getLastRunConfiguration(matchingConfigList);
+                break;
+        }
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_TOOLS, new Object[] { iProject, configuration });
         }
 
         return configuration;

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -106,7 +106,7 @@ public class StartAction implements ILaunchShortcut {
 
         // Determine what configuration to use.
         LaunchConfigurationHelper launchConfigHelper = LaunchConfigurationHelper.getInstance();
-        ILaunchConfiguration configuration = launchConfigHelper.getLaunchConfiguration(iProject, mode, RuntimeEnv.UNKNOWN);
+        ILaunchConfiguration configuration = launchConfigHelper.getLaunchConfiguration(iProject, mode, RuntimeEnv.LOCAL);
 
         DebugUITools.launch(configuration, mode);
     }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
@@ -109,7 +109,7 @@ public class StartInContainerAction implements ILaunchShortcut {
 
         // Determine what configuration to use.
         LaunchConfigurationHelper launchConfigHelper = LaunchConfigurationHelper.getInstance();
-        ILaunchConfiguration configuration = launchConfigHelper.getLaunchConfiguration(iProject, mode, RuntimeEnv.UNKNOWN);
+        ILaunchConfiguration configuration = launchConfigHelper.getLaunchConfiguration(iProject, mode, RuntimeEnv.CONTAINER);
 
         DebugUITools.launch(configuration, mode);
     }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
@@ -14,6 +14,7 @@ package io.openliberty.tools.eclipse.ui.launch.shortcuts;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.debug.ui.ILaunchShortcut;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.osgi.util.NLS;
@@ -22,11 +23,9 @@ import org.eclipse.ui.IEditorPart;
 import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.messages.Messages;
-import io.openliberty.tools.eclipse.ui.launch.JRETab;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationHelper;
-import io.openliberty.tools.eclipse.ui.launch.StartTab;
 import io.openliberty.tools.eclipse.utils.ErrorHandler;
 import io.openliberty.tools.eclipse.utils.Utils;
 
@@ -47,7 +46,7 @@ public class StartInContainerAction implements ILaunchShortcut {
         }
 
         try {
-            run(iProject, null, mode);
+            run(iProject, mode);
         } catch (Exception e) {
             String msg = "An error was detected when the \""
                     + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER + "\" launch shortcut was processed.";
@@ -76,7 +75,7 @@ public class StartInContainerAction implements ILaunchShortcut {
         }
 
         try {
-            run(iProject, null, mode);
+            run(iProject, mode);
         } catch (Exception e) {
             String msg = "An error was detected when the \""
                     + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER + "\" launch shortcut was processed.";
@@ -102,26 +101,16 @@ public class StartInContainerAction implements ILaunchShortcut {
      * 
      * @throws Exception
      */
-    public static void run(IProject iProject, ILaunchConfiguration iConfiguration, String mode) throws Exception {
-        if (iProject == null) {
-            throw new Exception("Invalid project. Be sure to select a project first.");
-        }
+    public static void run(IProject iProject, String mode) throws Exception {
 
         // Validate that the project is supported.
         DevModeOperations devModeOps = DevModeOperations.getInstance();
         devModeOps.verifyProjectSupport(iProject);
 
-        // If the configuration was not provided by the caller, determine what configuration to use.
+        // Determine what configuration to use.
         LaunchConfigurationHelper launchConfigHelper = LaunchConfigurationHelper.getInstance();
-        ILaunchConfiguration configuration = (iConfiguration != null) ? iConfiguration
-                : launchConfigHelper.getLaunchConfiguration(iProject, mode, RuntimeEnv.CONTAINER);
+        ILaunchConfiguration configuration = launchConfigHelper.getLaunchConfiguration(iProject, mode, RuntimeEnv.UNKNOWN);
 
-        // Save the time when this configuration was processed.
-        launchConfigHelper.saveConfigProcessingTime(configuration);
-
-        // Process the action.
-        String configParms = configuration.getAttribute(StartTab.PROJECT_START_PARM, (String) null);
-        String javaHomePath = JRETab.resolveJavaHome(configuration);
-        devModeOps.startInContainer(iProject, configParms, javaHomePath, mode);
+        DebugUITools.launch(configuration, mode);
     }
 }

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Require-Bundle: junit-jupiter-api;bundle-version="[5.8.0,6.0.0)",
  org.eclipse.ui,
  org.hamcrest.library;bundle-version="[1.3.0,2.2)"
 Import-Package: io.openliberty.tools.eclipse,
+ io.openliberty.tools.eclipse.debug,
  io.openliberty.tools.eclipse.ui.dashboard,
  io.openliberty.tools.eclipse.ui.launch,
  io.openliberty.tools.eclipse.ui.launch.shortcuts,

--- a/tests/resources/applications/gradle/liberty-gradle-test-app/build.gradle
+++ b/tests/resources/applications/gradle/liberty-gradle-test-app/build.gradle
@@ -31,6 +31,9 @@ dependencies {
      // test dependencies
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1' 
      testImplementation 'commons-httpclient:commons-httpclient:3.1'
+     
+     // test shared lib jar
+     implementation 'test:shared-lib:1.0-SNAPSHOT'
 
 }
 

--- a/tests/resources/applications/gradle/liberty-gradle-test-app/build.gradle
+++ b/tests/resources/applications/gradle/liberty-gradle-test-app/build.gradle
@@ -13,6 +13,7 @@ tasks.withType(JavaCompile) {
 buildscript {
     repositories {
         mavenCentral()
+        mavenLocal()
     }
     dependencies {
         classpath 'io.openliberty.tools:liberty-gradle-plugin:3.6.2'
@@ -21,6 +22,7 @@ buildscript {
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {

--- a/tests/resources/applications/maven/liberty-maven-test-app/pom.xml
+++ b/tests/resources/applications/maven/liberty-maven-test-app/pom.xml
@@ -47,6 +47,13 @@
             <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
+        
+        <!-- Shared Lib -->
+        <dependency>
+	        <groupId>test</groupId>
+		    <artifactId>shared-lib</artifactId>
+		    <version>1.0-SNAPSHOT</version>
+	    </dependency>
     </dependencies>
     
     <build>

--- a/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/webapp/META-INF/MANIFEST.MF
+++ b/tests/resources/applications/maven/maven-multi-module/typeJ/war2/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Class-Path: 
+

--- a/tests/resources/applications/maven/test-shared-lib-jar/pom.xml
+++ b/tests/resources/applications/maven/test-shared-lib-jar/pom.xml
@@ -9,6 +9,7 @@
     <groupId>test</groupId>
     <artifactId>shared-lib</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests/resources/applications/maven/test-shared-lib-jar/pom.xml
+++ b/tests/resources/applications/maven/test-shared-lib-jar/pom.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>shared-lib</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/tests/resources/applications/maven/test-shared-lib-jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
+++ b/tests/resources/applications/maven/test-shared-lib-jar/src/main/java/io/openliberty/guides/multimodules/lib/Converter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Initial implementation
+ *******************************************************************************/
+package io.openliberty.guides.multimodules.lib;
+
+public class Converter {
+
+    public static int getFeet(int cm) {
+        int feet = (int) (cm / 30.48);
+        return feet;
+    }
+
+    public static int getInches(int cm) {
+        double feet = cm / 30.48;
+        int inches = (int) (cm / 2.54) - ((int) feet * 12);
+        return inches;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+
+    public static int diff(int a, int b) {
+        return a - b;
+    }
+
+    public static int product(int a, int b) {
+        return a * b;
+    }
+
+    public static int quotient(int a, int b) {
+        return a / b;
+    }
+
+}

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -17,65 +17,43 @@ import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.go;
 import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.goGlobal;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.checkRunInContainerCheckBox;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.deleteLibertyToolsRunConfigEntriesFromAppRunAs;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.enableLibertyTools;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getAppDebugAsMenu;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getAppRunAsMenu;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getComboTextBoxWithTextPrefix;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getDashboardContent;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getDashboardItemMenuActions;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getDefaultSourceLookupTreeItemNoBot;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getLibertyTreeItem;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getLibertyTreeItemNoBot;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getRunConfigurationsShell;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchCustomDebugFromDashboard;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchCustomRunFromDashboard;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDashboardAction;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDebugConfigurationsDialogFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchRunConfigurationsDialogFromAppRunAs;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchRunTestsWithRunAsShortcut;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStartWithDebugAsShortcut;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStartWithDefaultRunConfigFromAppRunAs;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStartWithNewCustomDebugConfig;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStartWithNewCustomRunConfig;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStartWithRunAsShortcut;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStopWithRunAsShortcut;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchViewITReportWithRunDebugAsShortcut;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchViewUTReportWithRunDebugAsShortcut;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.openJRETab;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.openJavaPerspectiveViaMenu;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.openSourceTab;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.pressWorkspaceErrorDialogProceedButton;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.setBuildCmdPathInPreferences;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.unsetBuildCmdPathInPreferences;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TreeItem;
-import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotCombo;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import io.openliberty.tools.eclipse.CommandBuilder;
-import io.openliberty.tools.eclipse.CommandBuilder.CommandNotFoundException;
-import io.openliberty.tools.eclipse.test.it.utils.DisabledOnMac;
 import io.openliberty.tools.eclipse.test.it.utils.LibertyPluginTestUtils;
 import io.openliberty.tools.eclipse.ui.dashboard.DashboardView;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher;
@@ -103,7 +81,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
     /**
      * Shared lib jar project name.
      */
-    static final String MVN_SHARED_LIB_NAME = "test-shared-lib-jar";
+    static final String MVN_SHARED_LIB_NAME = "shared-lib";
 
     /**
      * Test app relative path.
@@ -155,6 +133,8 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
 
     /**
      * Setup.
+     * 
+     * @throws Exception
      */
     @BeforeAll
     public static void setup() throws Exception {
@@ -168,14 +148,26 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         projectPaths.add(sharedLibProjectPath.toString());
 
         // Maybe redundant but we really want to cleanup. We really want to
-        // avoid wasting time debugging tricky differences in behavior because of a dirty re-run
+        // avoid wasting time debugging tricky sdifferences in behavior because of a dirty re-run
         for (String p : projectPaths) {
             cleanupProject(p);
         }
 
         importMavenProjects(workspaceRoot, projectPaths);
 
-        // set the preferences
+        // Build shared lib project
+        Process process = new ProcessBuilder("mvn", "clean", "install").directory(sharedLibProjectPath.toFile()).start();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+        String line;
+        while ((line = reader.readLine()) != null) {
+            System.out.println(line);
+        }
+
+        int exitCode = process.waitFor();
+        assertEquals(0, exitCode, "Building of shared lib jar project failed with RC " + exitCode);
+
+        // Set the preferences
         setBuildCmdPathInPreferences(bot, "Maven");
         LibertyPluginTestUtils.validateLibertyToolsPreferencesSet();
 
@@ -296,630 +288,646 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         }
     }
 
-    /**
-     * Tests the start with parameters menu action on a dashboard listed application.
-     */
-    @Test
-    public void testLibertyConfigurationTabsExist() {
-
-        Shell configShell = launchRunConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
-
-        try {
-            TreeItem libertyConfigTree = getLibertyTreeItemNoBot(configShell);
-            context(libertyConfigTree, "New Configuration");
-
-            Assertions.assertTrue(bot.cTabItem("Start").isVisible(), "Liberty Start tab not visible.");
-            Assertions.assertTrue(bot.cTabItem("JRE").isVisible(), "Liberty JRE tab not visible.");
-        } finally {
-            go("Close", configShell);
-        }
-    }
-
-    @Test
-    @DisabledOnMac
-    public void testMavenCommandAssembly() throws IOException, InterruptedException, CommandNotFoundException {
-
-        IProject iProject = LibertyPluginTestUtils.getProject(MVN_APP_NAME);
-        String projPath = iProject.getLocation().toOSString();
-
-        String localMvnCmd = LibertyPluginTestUtils.onWindows() ? "mvn.cmd" : "mvn";
-        String opaqueMvnCmd = CommandBuilder.getMavenCommandLine(projPath, "io.openliberty.tools:liberty-maven-plugin:dev -f " + projPath,
-                System.getenv("PATH"), true);
-        Assertions.assertTrue(opaqueMvnCmd.contains(localMvnCmd + " io.openliberty.tools:liberty-maven-plugin:dev"),
-                "Expected cmd to contain 'mvn io.openliberty.tools...' but cmd = " + opaqueMvnCmd);
-    }
-
-    @Test
-    public void testMavenWrapperCommandAssembly() throws IOException, InterruptedException, CommandNotFoundException {
-        IProject iProject = LibertyPluginTestUtils.getProject(MVN_WRAPPER_APP_NAME);
-        String projPath = iProject.getLocation().toOSString();
-
-        String opaqueMvnwCmd = CommandBuilder.getMavenCommandLine(projPath, "io.openliberty.tools:liberty-maven-plugin:dev -f " + projPath,
-                System.getenv("PATH"), true);
-        Assertions.assertTrue(opaqueMvnwCmd.contains("mvnw"), "Expected cmd to contain 'mvnw' but cmd = " + opaqueMvnwCmd);
-    }
-
-    /**
-     * Tests the start menu action on a dashboard listed application.
-     */
-    @Test
-    public void testDashboardStartActionWithWrapper() {
-
-        // Start dev mode.
-        launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_START);
-
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_WRAPPER_APP_NAME, true,
-                wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        // Stop dev mode.
-        launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
-    }
-
-    /**
-     * Tests the start menu action on a dashboard listed application.
-     */
-    @Test
-    public void testDashboardStartAction() {
-        // Start dev mode.
-        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        // Stop dev mode.
-        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-    }
-
-    /**
-     * Tests stop of a server started outside of the current Liberty Tools Eclipse session
-     * 
-     * @throws CommandNotFoundException
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    @Test
-    public void testDashboardStopExternalServer() throws CommandNotFoundException, IOException, InterruptedException {
-
-        Path projAbsolutePath = wrapperProjectPath.toAbsolutePath();
-
-        // Doing a 'clean' first in case server was started previously and terminated abruptly. App tests may fail,
-        // making it look like an "outer", actual test is failing, so we skip the tests.
-        String cmd = CommandBuilder.getMavenCommandLine(projAbsolutePath.toString(),
-                "clean io.openliberty.tools:liberty-maven-plugin:dev -DskipITs=true", null, false);
-        String[] cmdParts = cmd.split(" ");
-        ProcessBuilder pb = new ProcessBuilder(cmdParts).inheritIO().directory(projAbsolutePath.toFile()).redirectErrorStream(true);
-        pb.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
-
-        Process p = pb.start();
-        p.waitFor(3, TimeUnit.SECONDS);
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_WRAPPER_APP_NAME, true,
-                wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // Stop dev mode.
-        launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-
-        bot.button("Yes").click();
-
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
-    }
-
-    /**
-     * Tests the start menu action on a dashboard listed application.
-     */
-    @Test
-    public void testDashboardDebugAction() {
-        // Start dev mode.
-        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_DEBUG);
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        // Stop dev mode.
-        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-    }
-
-    /**
-     * Tests the start with parameters menu action on a dashboard listed application.
-     */
-    @Test
-    public void testDashboardStartWithCustomConfigAction() {
-
-        // Delete any previously created configs.
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
-
-        // Delete the test report files before we start this test.
-        Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
-        boolean testReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
-        Assertions.assertTrue(testReportDeleted, () -> "File: " + pathToITReport + " was not be deleted.");
-
-        launchCustomRunFromDashboard(MVN_APP_NAME, "-DhotTests=true");
-
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        try {
-            // Validate that the test reports were generated.
-            LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
-        } finally {
-            // Stop dev mode.
-            launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-
-            // Validate application stopped.
-            LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-        }
-    }
-
-    /**
-     * Tests the start with parameters menu action on a dashboard listed application.
-     */
-    @Test
-    public void testDashboardDebugWithCustomConfigAction() {
-
-        // Delete any previously created configs.
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
-
-        // Delete the test report files before we start this test.
-        Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
-        boolean testReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
-        Assertions.assertTrue(testReportDeleted, () -> "File: " + pathToITReport + " was not be deleted.");
-
-        launchCustomDebugFromDashboard(MVN_APP_NAME, "-DhotTests=true");
-
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        try {
-            // Validate that the test reports were generated.
-            LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
-        } catch (Exception e) {
-            System.out.println("Caught exception: " + e);
-            throw new RuntimeException(e);
-        } finally {
-            // Stop dev mode.
-            launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-
-            // Validate application stopped.
-            LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-        }
-    }
-
-    /**
-     * Tests the start, run tests, view test report, and stop dashboard actions.
-     */
-    @Test
-    public void testDashboardActions() {
-
-        // Delete the test report files before we start this test.
-        Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
-        boolean itReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
-        Assertions.assertTrue(itReportDeleted, () -> "Test report file: " + pathToITReport + " was not be deleted.");
-
-        Path pathToUTReport = Paths.get(projectPath.toString(), "target", "site", "surefire-report.html");
-        boolean utReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
-        Assertions.assertTrue(utReportDeleted, () -> "Test report file: " + pathToITReport + " was not be deleted.");
-
-        // Start dev mode.
-        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        try {
-            // Run Tests.
-            launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_RUN_TESTS);
-
-            // Validate that the reports were generated and the the browser editor was launched.
-            LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
-            if (LibertyPluginTestUtils.isInternalBrowserSupportAvailable()) {
-                launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_VIEW_MVN_IT_REPORT);
-            }
-
-            LibertyPluginTestUtils.validateTestReportExists(pathToUTReport);
-            if (LibertyPluginTestUtils.isInternalBrowserSupportAvailable()) {
-                launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT);
-            }
-        } finally {
-            // Stop dev mode.
-            launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-
-            // Validate application stopped.
-            LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-        }
-    }
-
-    /**
-     * Tests the start action initiated through: project -> Run As -> Run Configurations -> Liberty -> New configuration (default) ->
-     * Run.
-     */
-    @Test
-    public void testStartWithDefaultRunAsConfig() {
-
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
-
-        // Start dev mode.
-        launchStartWithDefaultRunConfigFromAppRunAs(MVN_APP_NAME);
-
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        // Stop dev mode.
-        launchStopWithRunAsShortcut(MVN_APP_NAME);
-
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-    }
-
-    /**
-     * Tests the start action initiated through: project -> Run As -> Run Configurations -> Liberty -> New configuration (customized)
-     * -> Run.
-     */
-    @Test
-    public void testStartWithCustomRunAsConfig() {
-        // Delete any previously created configs.
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
-
-        // Delete the test report files before we start this test.
-        Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
-        boolean testReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
-        Assertions.assertTrue(testReportDeleted, () -> "File: " + pathToITReport + " was not be deleted.");
-
-        // Start dev mode with parms.
-        launchStartWithNewCustomRunConfig(MVN_APP_NAME, "-DhotTests=true");
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        try {
-            // Validate that the test reports were generated.
-            LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
-        } finally {
-            // Stop dev mode.
-            launchStopWithRunAsShortcut(MVN_APP_NAME);
-
-            // Validate application stopped.
-            LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-        }
-    }
-
-    /**
-     * Tests the start, run tests, view IT report, view UT report, and stop run as shortcut actions.
-     */
-    @Test
-    public void testRunAsShortcutActions() {
-
-        // Delete any previously created configs.
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
-
-        // Delete the test report files before we start this test.
-        Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
-        boolean itReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
-        Assertions.assertTrue(itReportDeleted, () -> "Test report file: " + pathToITReport + " was not be deleted.");
-
-        Path pathToUTReport = Paths.get(projectPath.toString(), "target", "site", "surefire-report.html");
-        boolean utReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
-        Assertions.assertTrue(utReportDeleted, () -> "Test report file: " + pathToITReport + " was not be deleted.");
-
-        // Start dev mode.
-        launchStartWithRunAsShortcut(MVN_APP_NAME);
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        try {
-            // Run Tests.
-            launchRunTestsWithRunAsShortcut(MVN_APP_NAME);
-
-            // Validate that the reports were generated and the the browser editor was launched.
-            LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
-            if (LibertyPluginTestUtils.isInternalBrowserSupportAvailable()) {
-                launchViewITReportWithRunDebugAsShortcut(bot, MVN_APP_NAME);
-            }
-
-            LibertyPluginTestUtils.validateTestReportExists(pathToUTReport);
-            if (LibertyPluginTestUtils.isInternalBrowserSupportAvailable()) {
-                launchViewUTReportWithRunDebugAsShortcut(bot, MVN_APP_NAME);
-            }
-        } finally {
-            // Stop dev mode.
-            launchStopWithRunAsShortcut(MVN_APP_NAME);
-
-            // Validate application stopped.
-            LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-        }
-    }
-
-    /**
-     * Tests the start action initiated through: project -> Debug As -> Debug Configurations -> Liberty -> New configuration
-     * (customized) -> Run.
-     */
-    @Test
-    public void testStartWithCustomDebugAsConfig() {
-
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
-
-        // Delete the test report files before we start this test.
-        Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
-        boolean testReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
-        Assertions.assertTrue(testReportDeleted, () -> "File: " + pathToITReport + " was not be deleted.");
-
-        // Start dev mode with parms.
-        launchStartWithNewCustomDebugConfig(MVN_APP_NAME, "-DhotTests=true");
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        try {
-            // Validate that the test reports were generated.
-            LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
-
-            // Validate that a remote java application configuration was created and is named after the application.
-            validateRemoteJavaAppCreation(MVN_APP_NAME);
-        } catch (Exception e) {
-            System.out.println("Caught exception: " + e);
-            throw new RuntimeException(e);
-        } finally {
-
-            openJavaPerspectiveViaMenu();
-
-            // Stop dev mode using the Run As stop command.
-            launchStopWithRunAsShortcut(MVN_APP_NAME);
-            // terminal.show();
-
-            // Validate application stopped.
-            LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-            // Close the terminal.
-            // terminal.close();
-        }
-    }
-
-    /**
-     * Tests the start/stop debug as shortcut actions.
-     */
-    @Test
-    public void testStartWithDebugAsShortcut() {
-
-        // Delete any previously created configs.
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
-
-        // Start dev mode.
-        launchStartWithDebugAsShortcut(MVN_APP_NAME);
-
-        goGlobal("Terminal");
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        // Validate that a remote java application configuration was created and is named after the application.
-        validateRemoteJavaAppCreation(MVN_APP_NAME);
-
-        // Switch back to Java so we can find Pkg Explorer
-        openJavaPerspectiveViaMenu();
-
-        // Stop dev mode using the Run As stop command.
-        launchStopWithRunAsShortcut(MVN_APP_NAME);
-
-        // terminal.show();
-
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // Close the terminal.
-        // terminal.close();
-    }
-
-    @Test
-    @Disabled
-    public void testStartWithNoWrapperAndNoPreferencesSet() {
-
-        // verify no wrapper present
-        String localMvnwCmd = LibertyPluginTestUtils.onWindows() ? "mvnw.cmd" : "mvnw";
-        String absoluteMvnwCmd = projectPath.toAbsolutePath().toString() + localMvnwCmd;
-        LibertyPluginTestUtils.validateWrapperInProject(false, absoluteMvnwCmd);
-
-        // Start dev mode.
-        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
-
-        // Validate application is not up and not running.
-        LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-    }
-
-    @Test
-    @DisabledOnMac
-    public void testStartWithWrapperAndNoPreferencesSet() {
-
-        unsetBuildCmdPathInPreferences(bot, "Maven");
-
-        // verify wrapper present
-        String localMvnwCmd = LibertyPluginTestUtils.onWindows() ? "mvnw.cmd" : "mvnw";
-        String absoluteMvnwCmd = wrapperProjectPath + File.separator + localMvnwCmd;
-        LibertyPluginTestUtils.validateWrapperInProject(true, absoluteMvnwCmd);
-
-        // Start dev mode.
-        launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_START);
-        SWTBotView terminal = bot.viewByTitle("Terminal");
-        terminal.show();
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_WRAPPER_APP_NAME, true,
-                wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        // Stop dev mode.
-        launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-        terminal.show();
-
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // Close the terminal.
-        terminal.close();
-
-        setBuildCmdPathInPreferences(bot, "Maven");
-    }
-
-    @Test
-    @DisabledOnMac
-    public void testStartWithNoWrapperAndPreferencesSet() {
-
-        // verify no wrapper present
-        String localMvnwCmd = LibertyPluginTestUtils.onWindows() ? "mvnw.cmd" : "mvnw";
-        String absoluteMvnwCmd = projectPath.toAbsolutePath().toString() + localMvnwCmd;
-        LibertyPluginTestUtils.validateWrapperInProject(false, absoluteMvnwCmd);
-
-        // Start dev mode.
-        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
-        SWTBotView terminal = bot.viewByTitle("Terminal");
-        terminal.show();
-
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // If there are issues with the workspace, close the error dialog.
-        pressWorkspaceErrorDialogProceedButton(bot);
-
-        // Stop dev mode.
-        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-        terminal.show();
-
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
-
-        // Close the terminal.
-        terminal.close();
-    }
-
-    /**
-     * Tests that the default JRE set in the project's java build path matches what is marked as default in the Liberty Tools
-     * configuration JRE tab.
-     */
-    @Test
-    public void testDefaultJRECompliance() {
-        // Delete any previously created configs.
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
-
-        Shell configShell = launchRunConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
-        try {
-            TreeItem libertyConfigTree = getLibertyTreeItemNoBot(configShell);
-
-            context(libertyConfigTree, "New Configuration");
-            openJRETab(bot);
-            String buildPathJRE = LibertyPluginTestUtils.getJREFromBuildpath(projectPath.toString());
-
-            Assertions.assertTrue(buildPathJRE != null,
-                    () -> "Unable to find the JRE configured in the project's build path (.classpath).");
-
-            SWTBotCombo comboJREBox = getComboTextBoxWithTextPrefix(bot, buildPathJRE);
-
-            Assertions.assertTrue(comboJREBox != null,
-                    () -> "The java installation shown on the Liberty run configurations JRE tab does not contain the Java installation configured on project's the build path (claspath):"
-                            + buildPathJRE);
-            Assertions.assertTrue(comboJREBox.isEnabled(),
-                    () -> "The JRE tab box showing Java installation \" + buildPathJRE + \" is not selected.");
-        } finally {
-            go("Apply", configShell);
-            go("Close", configShell);
-        }
-    }
-
-    /**
-     * Tests that a non-Liberty project can be manually be categorized to be Liberty project. This test also tests the refresh
-     * function.
-     * 
-     * @throws Exception
-     */
-    @Test
-    public void testAddingProjectToDashboardManually() throws Exception {
-
-        IProject iProject = LibertyPluginTestUtils.getProject(NON_DFLT_NAME);
-        String projectName = iProject.getName();
-
-        // Make sure the application is no longer listed in the dashboard.
-        List<String> projectList = getDashboardContent();
-        boolean mavenAppFound = false;
-        for (String project : projectList) {
-            if (NON_DFLT_NAME.equals(project)) {
-                mavenAppFound = true;
-                break;
-            }
-        }
-
-        Assertions.assertTrue(!mavenAppFound, () -> "Project " + projectName + " should not be listed in the dashboard.");
-
-        // Add the project nature manually.
-        enableLibertyTools(NON_DFLT_NAME);
-
-        // Make sure the application is listed in the dashboard.
-        List<String> newProjectList = getDashboardContent();
-        boolean newMavenAppFound = false;
-        for (String project : newProjectList) {
-            if (NON_DFLT_NAME.equals(project)) {
-                newMavenAppFound = true;
-                break;
-            }
-        }
-
-        Assertions.assertTrue(newMavenAppFound, () -> "The Maven project should be listed in the dashboard.");
-    }
+    // /**
+    // * Tests the start with parameters menu action on a dashboard listed application.
+    // */
+    // @Test
+    // public void testLibertyConfigurationTabsExist() {
+    //
+    // Shell configShell = launchRunConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
+    //
+    // try {
+    // TreeItem libertyConfigTree = getLibertyTreeItemNoBot(configShell);
+    // context(libertyConfigTree, "New Configuration");
+    //
+    // Assertions.assertTrue(bot.cTabItem("Start").isVisible(), "Liberty Start tab not visible.");
+    // Assertions.assertTrue(bot.cTabItem("JRE").isVisible(), "Liberty JRE tab not visible.");
+    // } finally {
+    // go("Close", configShell);
+    // }
+    // }
+    //
+    // @Test
+    // @DisabledOnMac
+    // public void testMavenCommandAssembly() throws IOException, InterruptedException, CommandNotFoundException {
+    //
+    // IProject iProject = LibertyPluginTestUtils.getProject(MVN_APP_NAME);
+    // String projPath = iProject.getLocation().toOSString();
+    //
+    // String localMvnCmd = LibertyPluginTestUtils.onWindows() ? "mvn.cmd" : "mvn";
+    // String opaqueMvnCmd = CommandBuilder.getMavenCommandLine(projPath, "io.openliberty.tools:liberty-maven-plugin:dev -f " +
+    // projPath,
+    // System.getenv("PATH"), true);
+    // Assertions.assertTrue(opaqueMvnCmd.contains(localMvnCmd + " io.openliberty.tools:liberty-maven-plugin:dev"),
+    // "Expected cmd to contain 'mvn io.openliberty.tools...' but cmd = " + opaqueMvnCmd);
+    // }
+    //
+    // @Test
+    // public void testMavenWrapperCommandAssembly() throws IOException, InterruptedException, CommandNotFoundException {
+    // IProject iProject = LibertyPluginTestUtils.getProject(MVN_WRAPPER_APP_NAME);
+    // String projPath = iProject.getLocation().toOSString();
+    //
+    // String opaqueMvnwCmd = CommandBuilder.getMavenCommandLine(projPath, "io.openliberty.tools:liberty-maven-plugin:dev -f " +
+    // projPath,
+    // System.getenv("PATH"), true);
+    // Assertions.assertTrue(opaqueMvnwCmd.contains("mvnw"), "Expected cmd to contain 'mvnw' but cmd = " + opaqueMvnwCmd);
+    // }
+    //
+    // /**
+    // * Tests the start menu action on a dashboard listed application.
+    // */
+    // @Test
+    // public void testDashboardStartActionWithWrapper() {
+    //
+    // // Start dev mode.
+    // launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_START);
+    //
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_WRAPPER_APP_NAME, true,
+    // wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // // Stop dev mode.
+    // launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    //
+    // /**
+    // * Tests the start menu action on a dashboard listed application.
+    // */
+    // @Test
+    // public void testDashboardStartAction() {
+    // // Start dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // // Stop dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    //
+    // /**
+    // * Tests stop of a server started outside of the current Liberty Tools Eclipse session
+    // *
+    // * @throws CommandNotFoundException
+    // * @throws IOException
+    // * @throws InterruptedException
+    // */
+    // @Test
+    // public void testDashboardStopExternalServer() throws CommandNotFoundException, IOException, InterruptedException {
+    //
+    // Path projAbsolutePath = wrapperProjectPath.toAbsolutePath();
+    //
+    // // Doing a 'clean' first in case server was started previously and terminated abruptly. App tests may fail,
+    // // making it look like an "outer", actual test is failing, so we skip the tests.
+    // String cmd = CommandBuilder.getMavenCommandLine(projAbsolutePath.toString(),
+    // "clean io.openliberty.tools:liberty-maven-plugin:dev -DskipITs=true", null, false);
+    // String[] cmdParts = cmd.split(" ");
+    // ProcessBuilder pb = new ProcessBuilder(cmdParts).inheritIO().directory(projAbsolutePath.toFile()).redirectErrorStream(true);
+    // pb.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
+    //
+    // Process p = pb.start();
+    // p.waitFor(3, TimeUnit.SECONDS);
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_WRAPPER_APP_NAME, true,
+    // wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
+    //
+    // // Stop dev mode.
+    // launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+    //
+    // bot.button("Yes").click();
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    //
+    // /**
+    // * Tests the start menu action on a dashboard listed application.
+    // */
+    // @Test
+    // public void testDashboardDebugAction() {
+    // // Start dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_DEBUG);
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // // Stop dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    //
+    // /**
+    // * Tests the start with parameters menu action on a dashboard listed application.
+    // */
+    // @Test
+    // public void testDashboardStartWithCustomConfigAction() {
+    //
+    // // Delete any previously created configs.
+    // deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+    //
+    // // Delete the test report files before we start this test.
+    // Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
+    // boolean testReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
+    // Assertions.assertTrue(testReportDeleted, () -> "File: " + pathToITReport + " was not be deleted.");
+    //
+    // launchCustomRunFromDashboard(MVN_APP_NAME, "-DhotTests=true");
+    //
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // try {
+    // // Validate that the test reports were generated.
+    // LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
+    // } finally {
+    // // Stop dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    // }
+    //
+    // /**
+    // * Tests the start with parameters menu action on a dashboard listed application.
+    // */
+    // @Test
+    // public void testDashboardDebugWithCustomConfigAction() {
+    //
+    // // Delete any previously created configs.
+    // deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+    //
+    // // Delete the test report files before we start this test.
+    // Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
+    // boolean testReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
+    // Assertions.assertTrue(testReportDeleted, () -> "File: " + pathToITReport + " was not be deleted.");
+    //
+    // launchCustomDebugFromDashboard(MVN_APP_NAME, "-DhotTests=true");
+    //
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // try {
+    // // Validate that the test reports were generated.
+    // LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
+    // } catch (Exception e) {
+    // System.out.println("Caught exception: " + e);
+    // throw new RuntimeException(e);
+    // } finally {
+    // // Stop dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    // }
+    //
+    // /**
+    // * Tests the start, run tests, view test report, and stop dashboard actions.
+    // */
+    // @Test
+    // public void testDashboardActions() {
+    //
+    // // Delete the test report files before we start this test.
+    // Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
+    // boolean itReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
+    // Assertions.assertTrue(itReportDeleted, () -> "Test report file: " + pathToITReport + " was not be deleted.");
+    //
+    // Path pathToUTReport = Paths.get(projectPath.toString(), "target", "site", "surefire-report.html");
+    // boolean utReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
+    // Assertions.assertTrue(utReportDeleted, () -> "Test report file: " + pathToITReport + " was not be deleted.");
+    //
+    // // Start dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // try {
+    // // Run Tests.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_RUN_TESTS);
+    //
+    // // Validate that the reports were generated and the the browser editor was launched.
+    // LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
+    // if (LibertyPluginTestUtils.isInternalBrowserSupportAvailable()) {
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_VIEW_MVN_IT_REPORT);
+    // }
+    //
+    // LibertyPluginTestUtils.validateTestReportExists(pathToUTReport);
+    // if (LibertyPluginTestUtils.isInternalBrowserSupportAvailable()) {
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT);
+    // }
+    // } finally {
+    // // Stop dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    // }
+    //
+    // /**
+    // * Tests the start action initiated through: project -> Run As -> Run Configurations -> Liberty -> New configuration (default)
+    // ->
+    // * Run.
+    // */
+    // @Test
+    // public void testStartWithDefaultRunAsConfig() {
+    //
+    // deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+    //
+    // // Start dev mode.
+    // launchStartWithDefaultRunConfigFromAppRunAs(MVN_APP_NAME);
+    //
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // // Stop dev mode.
+    // launchStopWithRunAsShortcut(MVN_APP_NAME);
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    //
+    // /**
+    // * Tests the start action initiated through: project -> Run As -> Run Configurations -> Liberty -> New configuration
+    // (customized)
+    // * -> Run.
+    // */
+    // @Test
+    // public void testStartWithCustomRunAsConfig() {
+    // // Delete any previously created configs.
+    // deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+    //
+    // // Delete the test report files before we start this test.
+    // Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
+    // boolean testReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
+    // Assertions.assertTrue(testReportDeleted, () -> "File: " + pathToITReport + " was not be deleted.");
+    //
+    // // Start dev mode with parms.
+    // launchStartWithNewCustomRunConfig(MVN_APP_NAME, "-DhotTests=true");
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // try {
+    // // Validate that the test reports were generated.
+    // LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
+    // } finally {
+    // // Stop dev mode.
+    // launchStopWithRunAsShortcut(MVN_APP_NAME);
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    // }
+    //
+    // /**
+    // * Tests the start, run tests, view IT report, view UT report, and stop run as shortcut actions.
+    // */
+    // @Test
+    // public void testRunAsShortcutActions() {
+    //
+    // // Delete any previously created configs.
+    // deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+    //
+    // // Delete the test report files before we start this test.
+    // Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
+    // boolean itReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
+    // Assertions.assertTrue(itReportDeleted, () -> "Test report file: " + pathToITReport + " was not be deleted.");
+    //
+    // Path pathToUTReport = Paths.get(projectPath.toString(), "target", "site", "surefire-report.html");
+    // boolean utReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
+    // Assertions.assertTrue(utReportDeleted, () -> "Test report file: " + pathToITReport + " was not be deleted.");
+    //
+    // // Start dev mode.
+    // launchStartWithRunAsShortcut(MVN_APP_NAME);
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // try {
+    // // Run Tests.
+    // launchRunTestsWithRunAsShortcut(MVN_APP_NAME);
+    //
+    // // Validate that the reports were generated and the the browser editor was launched.
+    // LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
+    // if (LibertyPluginTestUtils.isInternalBrowserSupportAvailable()) {
+    // launchViewITReportWithRunDebugAsShortcut(bot, MVN_APP_NAME);
+    // }
+    //
+    // LibertyPluginTestUtils.validateTestReportExists(pathToUTReport);
+    // if (LibertyPluginTestUtils.isInternalBrowserSupportAvailable()) {
+    // launchViewUTReportWithRunDebugAsShortcut(bot, MVN_APP_NAME);
+    // }
+    // } finally {
+    // // Stop dev mode.
+    // launchStopWithRunAsShortcut(MVN_APP_NAME);
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    // }
+    //
+    // /**
+    // * Tests the start action initiated through: project -> Debug As -> Debug Configurations -> Liberty -> New configuration
+    // * (customized) -> Run.
+    // */
+    // @Test
+    // public void testStartWithCustomDebugAsConfig() {
+    //
+    // deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+    //
+    // // Delete the test report files before we start this test.
+    // Path pathToITReport = Paths.get(projectPath.toString(), "target", "site", "failsafe-report.html");
+    // boolean testReportDeleted = LibertyPluginTestUtils.deleteFile(pathToITReport.toFile());
+    // Assertions.assertTrue(testReportDeleted, () -> "File: " + pathToITReport + " was not be deleted.");
+    //
+    // // Start dev mode with parms.
+    // launchStartWithNewCustomDebugConfig(MVN_APP_NAME, "-DhotTests=true");
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // try {
+    // // Validate that the test reports were generated.
+    // LibertyPluginTestUtils.validateTestReportExists(pathToITReport);
+    //
+    // // Validate that a remote java application configuration was created and is named after the application.
+    // validateRemoteJavaAppCreation(MVN_APP_NAME);
+    // } catch (Exception e) {
+    // System.out.println("Caught exception: " + e);
+    // throw new RuntimeException(e);
+    // } finally {
+    //
+    // openJavaPerspectiveViaMenu();
+    //
+    // // Stop dev mode using the Run As stop command.
+    // launchStopWithRunAsShortcut(MVN_APP_NAME);
+    // // terminal.show();
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    //
+    // // Close the terminal.
+    // // terminal.close();
+    // }
+    // }
+    //
+    // /**
+    // * Tests the start/stop debug as shortcut actions.
+    // */
+    // @Test
+    // public void testStartWithDebugAsShortcut() {
+    //
+    // // Delete any previously created configs.
+    // deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+    //
+    // // Start dev mode.
+    // launchStartWithDebugAsShortcut(MVN_APP_NAME);
+    //
+    // goGlobal("Terminal");
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // // Validate that a remote java application configuration was created and is named after the application.
+    // validateRemoteJavaAppCreation(MVN_APP_NAME);
+    //
+    // // Switch back to Java so we can find Pkg Explorer
+    // openJavaPerspectiveViaMenu();
+    //
+    // // Stop dev mode using the Run As stop command.
+    // launchStopWithRunAsShortcut(MVN_APP_NAME);
+    //
+    // // terminal.show();
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    //
+    // // Close the terminal.
+    // // terminal.close();
+    // }
+    //
+    // @Test
+    // @Disabled
+    // public void testStartWithNoWrapperAndNoPreferencesSet() {
+    //
+    // // verify no wrapper present
+    // String localMvnwCmd = LibertyPluginTestUtils.onWindows() ? "mvnw.cmd" : "mvnw";
+    // String absoluteMvnwCmd = projectPath.toAbsolutePath().toString() + localMvnwCmd;
+    // LibertyPluginTestUtils.validateWrapperInProject(false, absoluteMvnwCmd);
+    //
+    // // Start dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
+    //
+    // // Validate application is not up and not running.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    // }
+    //
+    // @Test
+    // @DisabledOnMac
+    // public void testStartWithWrapperAndNoPreferencesSet() {
+    //
+    // unsetBuildCmdPathInPreferences(bot, "Maven");
+    //
+    // // verify wrapper present
+    // String localMvnwCmd = LibertyPluginTestUtils.onWindows() ? "mvnw.cmd" : "mvnw";
+    // String absoluteMvnwCmd = wrapperProjectPath + File.separator + localMvnwCmd;
+    // LibertyPluginTestUtils.validateWrapperInProject(true, absoluteMvnwCmd);
+    //
+    // // Start dev mode.
+    // launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_START);
+    // SWTBotView terminal = bot.viewByTitle("Terminal");
+    // terminal.show();
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_WRAPPER_APP_NAME, true,
+    // wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // // Stop dev mode.
+    // launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+    // terminal.show();
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
+    //
+    // // Close the terminal.
+    // terminal.close();
+    //
+    // setBuildCmdPathInPreferences(bot, "Maven");
+    // }
+    //
+    // @Test
+    // @DisabledOnMac
+    // public void testStartWithNoWrapperAndPreferencesSet() {
+    //
+    // // verify no wrapper present
+    // String localMvnwCmd = LibertyPluginTestUtils.onWindows() ? "mvnw.cmd" : "mvnw";
+    // String absoluteMvnwCmd = projectPath.toAbsolutePath().toString() + localMvnwCmd;
+    // LibertyPluginTestUtils.validateWrapperInProject(false, absoluteMvnwCmd);
+    //
+    // // Start dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
+    // SWTBotView terminal = bot.viewByTitle("Terminal");
+    // terminal.show();
+    //
+    // // Validate application is up and running.
+    // LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() +
+    // "/target/liberty");
+    //
+    // // If there are issues with the workspace, close the error dialog.
+    // pressWorkspaceErrorDialogProceedButton(bot);
+    //
+    // // Stop dev mode.
+    // launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+    // terminal.show();
+    //
+    // // Validate application stopped.
+    // LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+    //
+    // // Close the terminal.
+    // terminal.close();
+    // }
+    //
+    // /**
+    // * Tests that the default JRE set in the project's java build path matches what is marked as default in the Liberty Tools
+    // * configuration JRE tab.
+    // */
+    // @Test
+    // public void testDefaultJRECompliance() {
+    // // Delete any previously created configs.
+    // deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+    //
+    // Shell configShell = launchRunConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
+    // try {
+    // TreeItem libertyConfigTree = getLibertyTreeItemNoBot(configShell);
+    //
+    // context(libertyConfigTree, "New Configuration");
+    // openJRETab(bot);
+    // String buildPathJRE = LibertyPluginTestUtils.getJREFromBuildpath(projectPath.toString());
+    //
+    // Assertions.assertTrue(buildPathJRE != null,
+    // () -> "Unable to find the JRE configured in the project's build path (.classpath).");
+    //
+    // SWTBotCombo comboJREBox = getComboTextBoxWithTextPrefix(bot, buildPathJRE);
+    //
+    // Assertions.assertTrue(comboJREBox != null,
+    // () -> "The java installation shown on the Liberty run configurations JRE tab does not contain the Java installation configured
+    // on project's the build path (claspath):"
+    // + buildPathJRE);
+    // Assertions.assertTrue(comboJREBox.isEnabled(),
+    // () -> "The JRE tab box showing Java installation \" + buildPathJRE + \" is not selected.");
+    // } finally {
+    // go("Apply", configShell);
+    // go("Close", configShell);
+    // }
+    // }
+    //
+    // /**
+    // * Tests that a non-Liberty project can be manually be categorized to be Liberty project. This test also tests the refresh
+    // * function.
+    // *
+    // * @throws Exception
+    // */
+    // @Test
+    // public void testAddingProjectToDashboardManually() throws Exception {
+    //
+    // IProject iProject = LibertyPluginTestUtils.getProject(NON_DFLT_NAME);
+    // String projectName = iProject.getName();
+    //
+    // // Make sure the application is no longer listed in the dashboard.
+    // List<String> projectList = getDashboardContent();
+    // boolean mavenAppFound = false;
+    // for (String project : projectList) {
+    // if (NON_DFLT_NAME.equals(project)) {
+    // mavenAppFound = true;
+    // break;
+    // }
+    // }
+    //
+    // Assertions.assertTrue(!mavenAppFound, () -> "Project " + projectName + " should not be listed in the dashboard.");
+    //
+    // // Add the project nature manually.
+    // enableLibertyTools(NON_DFLT_NAME);
+    //
+    // // Make sure the application is listed in the dashboard.
+    // List<String> newProjectList = getDashboardContent();
+    // boolean newMavenAppFound = false;
+    // for (String project : newProjectList) {
+    // if (NON_DFLT_NAME.equals(project)) {
+    // newMavenAppFound = true;
+    // break;
+    // }
+    // }
+    //
+    // Assertions.assertTrue(newMavenAppFound, () -> "The Maven project should be listed in the dashboard.");
+    // }
 
     /**
      * Tests that the correct launch configuration is chosen depending on "start" vs "start in container"
@@ -967,6 +975,8 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
      */
     @Test
     public void testDebugSourceLookupContent() {
+
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
 
         Shell configShell = launchDebugConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
@@ -67,6 +67,11 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
     static final String MVN_APP_NAME = "guide-maven-multimodules-pom";
 
     /**
+     * Parent name.
+     */
+    static final String MVN_PARENT_NAME = "guide-maven-multimodules";
+
+    /**
      * Jar sub-module name.
      */
     static final String MVN_JAR_NAME = "guide-maven-multimodules-jar";
@@ -295,11 +300,12 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
      * Tests that the correct dependency projects are added to the debug source lookup list
      */
     @Test
-    public void testDebugSourceLookupContent() {
+    public void testDebugSourceLookupContentSiblingModule() {
 
-        Shell configShell = launchDebugConfigurationsDialogFromAppRunAs(MVN_WAR_NAME);
+        Shell configShell = launchDebugConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
 
-        boolean entryFound = false;
+        boolean jarEntryFound = false;
+        boolean warEntryFound = false;
 
         try {
             Object libertyConfigTree = getLibertyTreeItemNoBot(configShell);
@@ -312,19 +318,28 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
 
             try {
                 defaultSourceLookupTree.getNode(MVN_JAR_NAME);
-                entryFound = true;
+                jarEntryFound = true;
             } catch (WidgetNotFoundException wnfe) {
                 // Jar project was not found in source lookup list.
             }
 
+            // Lookup war project
+            try {
+                defaultSourceLookupTree.getNode(MVN_WAR_NAME);
+                warEntryFound = true;
+            } catch (WidgetNotFoundException wnfe) {
+                // War project was not found in source lookup list.
+            }
+
         } finally {
             go("Close", configShell);
-            deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_WAR_NAME);
         }
 
-        // Validate dependency project is in source lookup list
-        Assertions.assertTrue(entryFound,
-                "The " + MVN_JAR_NAME + " project was not listed in the source lookup list for project " + MVN_WAR_NAME);
+        // Validate dependency projects are in source lookup list
+        Assertions.assertTrue(jarEntryFound,
+                "The sibling module project, " + MVN_JAR_NAME + ", was not listed in the source lookup list for project " + MVN_APP_NAME);
+        Assertions.assertTrue(warEntryFound,
+                "The sibling module project, " + MVN_WAR_NAME + ", was not listed in the source lookup list for project " + MVN_APP_NAME);
 
     }
 
@@ -334,7 +349,7 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
     @Test
     public void testDebugSourceLookupContentParentModule() {
 
-        Shell configShell = launchDebugConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
+        Shell configShell = launchDebugConfigurationsDialogFromAppRunAs(MVN_PARENT_NAME);
 
         boolean jarEntryFound = false;
         boolean warEntryFound = false;
@@ -370,9 +385,9 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
 
         // Validate dependency projects are in source lookup list
         Assertions.assertTrue(jarEntryFound,
-                "The child module projects, " + MVN_JAR_NAME + ", was not listed in the source lookup list for project " + MVN_APP_NAME);
+                "The child module project, " + MVN_JAR_NAME + ", was not listed in the source lookup list for project " + MVN_PARENT_NAME);
         Assertions.assertTrue(warEntryFound,
-                "The child module projects, " + MVN_WAR_NAME + ", was not listed in the source lookup list for project " + MVN_APP_NAME);
+                "The child module project, " + MVN_WAR_NAME + ", was not listed in the source lookup list for project " + MVN_PARENT_NAME);
 
     }
 }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
@@ -12,15 +12,19 @@
  *******************************************************************************/
 package io.openliberty.tools.eclipse.test.it;
 
+import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.context;
 import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.go;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.deleteLibertyToolsRunConfigEntriesFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getDashboardContent;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getDashboardItemMenuActions;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getDefaultSourceLookupTreeItemNoBot;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getLibertyTreeItem;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getLibertyTreeItemNoBot;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDebugConfigurationsDialogFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchRunConfigurationsDialogFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStartWithDefaultRunConfigFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStopWithRunAsShortcut;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.openSourceTab;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.pressWorkspaceErrorDialogProceedButton;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.setBuildCmdPathInPreferences;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.unsetBuildCmdPathInPreferences;
@@ -34,7 +38,9 @@ import java.util.List;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.junit.jupiter.api.AfterAll;
@@ -59,6 +65,16 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
      * Application name.
      */
     static final String MVN_APP_NAME = "guide-maven-multimodules-pom";
+
+    /**
+     * Jar sub-module name.
+     */
+    static final String MVN_JAR_NAME = "guide-maven-multimodules-jar";
+
+    /**
+     * War sub-module name
+     */
+    static final String MVN_WAR_NAME = "guide-maven-multimodules-war1";
 
     /**
      * Path to import from, in this case the multi-module root
@@ -273,5 +289,90 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
 
         // Close the terminal.
         terminal.close();
+    }
+
+    /**
+     * Tests that the correct dependency projects are added to the debug source lookup list
+     */
+    @Test
+    public void testDebugSourceLookupContent() {
+
+        Shell configShell = launchDebugConfigurationsDialogFromAppRunAs(MVN_WAR_NAME);
+
+        boolean entryFound = false;
+
+        try {
+            Object libertyConfigTree = getLibertyTreeItemNoBot(configShell);
+
+            context(libertyConfigTree, "New Configuration");
+
+            openSourceTab(bot);
+
+            SWTBotTreeItem defaultSourceLookupTree = new SWTBotTreeItem((TreeItem) getDefaultSourceLookupTreeItemNoBot(configShell));
+
+            try {
+                defaultSourceLookupTree.getNode(MVN_JAR_NAME);
+                entryFound = true;
+            } catch (WidgetNotFoundException wnfe) {
+                // Jar project was not found in source lookup list.
+            }
+
+        } finally {
+            go("Close", configShell);
+            deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_WAR_NAME);
+        }
+
+        // Validate dependency project is in source lookup list
+        Assertions.assertTrue(entryFound,
+                "The " + MVN_JAR_NAME + " project was not listed in the source lookup list for project " + MVN_WAR_NAME);
+
+    }
+
+    /**
+     * Tests that the correct dependency projects are added to the debug source lookup list when starting the parent module
+     */
+    @Test
+    public void testDebugSourceLookupContentParentModule() {
+
+        Shell configShell = launchDebugConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
+
+        boolean jarEntryFound = false;
+        boolean warEntryFound = false;
+
+        try {
+            Object libertyConfigTree = getLibertyTreeItemNoBot(configShell);
+
+            context(libertyConfigTree, "New Configuration");
+
+            openSourceTab(bot);
+
+            SWTBotTreeItem defaultSourceLookupTree = new SWTBotTreeItem((TreeItem) getDefaultSourceLookupTreeItemNoBot(configShell));
+
+            // Lookup jar project
+            try {
+                defaultSourceLookupTree.getNode(MVN_JAR_NAME);
+                jarEntryFound = true;
+            } catch (WidgetNotFoundException wnfe) {
+                // Jar project was not found in source lookup list.
+            }
+
+            // Lookup war project
+            try {
+                defaultSourceLookupTree.getNode(MVN_WAR_NAME);
+                warEntryFound = true;
+            } catch (WidgetNotFoundException wnfe) {
+                // War project was not found in source lookup list.
+            }
+
+        } finally {
+            go("Close", configShell);
+        }
+
+        // Validate dependency projects are in source lookup list
+        Assertions.assertTrue(jarEntryFound,
+                "The child module projects, " + MVN_JAR_NAME + ", was not listed in the source lookup list for project " + MVN_APP_NAME);
+        Assertions.assertTrue(warEntryFound,
+                "The child module projects, " + MVN_WAR_NAME + ", was not listed in the source lookup list for project " + MVN_APP_NAME);
+
     }
 }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -48,6 +48,7 @@ import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory;
 import org.eclipse.swtbot.swt.finder.utils.SWTUtils;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCTabItem;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCombo;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotRootMenu;
@@ -550,6 +551,19 @@ public class SWTBotPluginOperations {
 
         Control parmText = ControlFinder.findControlInRange(parmLabel, Text.class, Direction.EAST);
         set(parmText, customParms);
+    }
+
+    public static void checkRunInContainerCheckBox(Shell shell, String runDebugConfigName) {
+
+        Object libertyConfigTree = getLibertyTreeItem(shell);
+
+        Object appConfigEntry = find(runDebugConfigName, libertyConfigTree,
+                Option.factory().useContains(true).widgetClass(TreeItem.class).build());
+        go(appConfigEntry);
+        Object parmLabel = find("Run in container", appConfigEntry, Option.factory().widgetClass(Label.class).build());
+
+        Control checkBox = ControlFinder.findControlInRange(parmLabel, SWTBotCheckBox.class, Direction.WEST);
+        go(checkBox);
     }
 
     public static Object getAppInPackageExplorerTree(String appName) {

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -124,24 +124,25 @@ public class SWTBotPluginOperations {
 
     public static void openJavaPerspectiveViaMenu() {
         Object windowMenu = findGlobal("Window", Option.factory().widgetClass(MenuItem.class).build());
-        
+
         if (new SWTWorkbenchBot().activePerspective().getLabel().equals("Java")) {
-        	// Won't be an option to switch to if already active
+            // Won't be an option to switch to if already active
             return;
         } else {
             goMenuItem(windowMenu, "Perspective", "Open Perspective", "Java");
         }
     }
-    
+
     public static SWTBotTable getDashboardTable() {
         openDashboardUsingToolbar();
         Object dashboardView = findGlobal(DASHBOARD_VIEW_TITLE, Option.factory().widgetClass(ViewPart.class).build());
-        Table table = ((DashboardView)dashboardView).getTable();
+        Table table = ((DashboardView) dashboardView).getTable();
         return new SWTBotTable(table);
     }
 
     /**
      * Returns a list of entries on the Open Liberty dashboard.
+     * 
      * @return A list of entries on the Open Liberty dashboard.
      */
     public static List<String> getDashboardContent() {
@@ -194,6 +195,7 @@ public class SWTBotPluginOperations {
 
     /**
      * Launches a dashboard action for the specified application name.
+     * 
      * @param appName The application name to select.
      * @param action The action to select
      */
@@ -292,7 +294,7 @@ public class SWTBotPluginOperations {
 
         String finalMvnExecutableLoc = null;
         String finalGradleExecutableLoc = null;
-        Object locationLabel = null; 
+        Object locationLabel = null;
         Object locationText = null;
 
         finalMvnExecutableLoc = System.getProperty("io.liberty.tools.eclipse.tests.mvnexecutable.path");
@@ -314,7 +316,7 @@ public class SWTBotPluginOperations {
         }
 
         goGlobal("Apply and Close");
-   }
+    }
 
     public static void unsetBuildCmdPathInPreferences(SWTWorkbenchBot bot, String buildTool) {
 
@@ -324,12 +326,12 @@ public class SWTBotPluginOperations {
         if (Platform.getOS().equals(Platform.OS_MACOSX)) {
             return;
         }
-        
+
         Object windowMenu = findGlobal("Window", Option.factory().widgetClass(MenuItem.class).build());
         goMenuItem(windowMenu, "Preferences");
 
         findGlobal("Liberty", Option.factory().widgetClass(TreeItem.class).build());
-  
+
         goGlobal("Restore Defaults");
         goGlobal("Apply and Close");
     }
@@ -342,13 +344,13 @@ public class SWTBotPluginOperations {
     public static Shell launchRunConfigurationsDialogFromAppRunAs(String appName) {
 
         Object project = getAppInPackageExplorerTree(appName);
-        
+
         MagicWidgetFinder.context(project, "Run As", "Run Configurations...");
 
         // Return the newly launched configurations shell
         return (Shell) findGlobal("Run Configurations", Option.factory().widgetClass(Shell.class).build());
     }
-    
+
     /**
      * Launches the run configuration dialog.
      * 
@@ -357,7 +359,7 @@ public class SWTBotPluginOperations {
     public static Shell launchDebugConfigurationsDialogFromAppRunAs(String appName) {
 
         Object project = getAppInPackageExplorerTree(appName);
-        
+
         MagicWidgetFinder.context(project, "Debug As", "Debug Configurations...");
 
         // Return the newly launched configurations shell
@@ -387,13 +389,19 @@ public class SWTBotPluginOperations {
     }
 
     public static TreeItem getLibertyTreeItemNoBot(Shell shell) {
-        TreeItem ti = (TreeItem)find(LAUNCH_CONFIG_LIBERTY_MENU_NAME, shell);
+        TreeItem ti = (TreeItem) find(LAUNCH_CONFIG_LIBERTY_MENU_NAME, shell);
         expandTreeItem(ti);
         return ti;
     }
-    
+
+    public static TreeItem getDefaultSourceLookupTreeItemNoBot(Shell shell) {
+        TreeItem ti = (TreeItem) find("Default", shell);
+        expandTreeItem(ti);
+        return ti;
+    }
+
     public static SWTBotTreeItem getRemoteJavaAppConfigMenuItem(Shell shell) {
-        return new SWTBotTreeItem((TreeItem)find(LAUNCH_CONFIG_REMOTE_JAVA_APP, shell));
+        return new SWTBotTreeItem((TreeItem) find(LAUNCH_CONFIG_REMOTE_JAVA_APP, shell));
     }
 
     /**
@@ -408,7 +416,7 @@ public class SWTBotPluginOperations {
 
         try {
             SWTBotTreeItem libertyToolsEntry = getLibertyTreeItem(configShell);
-            
+
             Assertions.assertTrue((libertyToolsEntry != null), () -> "The Liberty entry was not found in run Configurations dialog.");
 
             List<String> configs = libertyToolsEntry.getNodes();
@@ -441,7 +449,7 @@ public class SWTBotPluginOperations {
             }
 
             // Delete debug mode Remote Java Application configurations
-            SWTBotTreeItem remoteJavaAppEntry = getRemoteJavaAppConfigMenuItem(configShell);           
+            SWTBotTreeItem remoteJavaAppEntry = getRemoteJavaAppConfigMenuItem(configShell);
             Assertions.assertTrue((remoteJavaAppEntry != null),
                     () -> "The " + LAUNCH_CONFIG_REMOTE_JAVA_APP + " entry was not found in run Configurations dialog.");
 
@@ -453,7 +461,7 @@ public class SWTBotPluginOperations {
             MagicWidgetFinder.go("Close", configShell);
         }
     }
-    
+
     private static void deleteRunDebugConfigEntry(SWTBotTreeItem parentTree, String configName) {
         go(configName, parentTree);
         goGlobal("Delete selected launch configuration(s)", Option.factory().widgetClass(ToolItem.class).useContains(true).build());
@@ -468,9 +476,9 @@ public class SWTBotPluginOperations {
     public static void launchStartWithDefaultRunConfigFromAppRunAs(String appName) {
 
         Object project = getAppInPackageExplorerTree(appName);
-        context(project, "Run As", 
+        context(project, "Run As",
                 WidgetMatcherFactory.withRegex(".*" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START + ".*"));
- 
+
     }
 
     /**
@@ -489,7 +497,7 @@ public class SWTBotPluginOperations {
     /**
      * Launches dev mode with parms using a new Liberty configuration: project -> Debug As -> Debug Configurations -> Liberty -> New
      * configuration (default) -> update parms -> Debug. Note that the changes are not saved.
-     *     
+     * 
      * @param appName The application name.
      * @param customParms The parameter(s) to pass to the dev mode start action.
      */
@@ -498,7 +506,7 @@ public class SWTBotPluginOperations {
         createAndSetNewCustomConfig(shell, customParms);
         go("Debug", shell);
     }
-    
+
     public static void createAndSetNewCustomConfig(Shell shell, String customParms) {
 
         Object libertyConfigTree = find(LAUNCH_CONFIG_LIBERTY_MENU_NAME, shell);
@@ -508,35 +516,35 @@ public class SWTBotPluginOperations {
         Control parmText = ControlFinder.findControlInRange(parmLabel, Text.class, Direction.EAST);
         set(parmText, customParms);
     }
-    
+
     public static Shell getDebugConfigurationsShell() {
-    	return (Shell) findGlobal("Debug Configurations", Option.factory().widgetClass(Shell.class).build());
+        return (Shell) findGlobal("Debug Configurations", Option.factory().widgetClass(Shell.class).build());
     }
-    
+
     public static Shell getRunConfigurationsShell() {
-    	return (Shell) findGlobal("Run Configurations", Option.factory().widgetClass(Shell.class).build());
+        return (Shell) findGlobal("Run Configurations", Option.factory().widgetClass(Shell.class).build());
     }
-    
+
     public static void launchCustomDebugFromDashboard(String appName, String customParms) {
-    	launchDashboardAction(appName, DashboardView.APP_MENU_ACTION_DEBUG_CONFIG);
+        launchDashboardAction(appName, DashboardView.APP_MENU_ACTION_DEBUG_CONFIG);
         Shell shell = getDebugConfigurationsShell();
         setCustomStartParmsFromShell(shell, appName, customParms);
         go("Debug", shell);
     }
 
     public static void launchCustomRunFromDashboard(String appName, String customParms) {
-    	launchDashboardAction(appName, DashboardView.APP_MENU_ACTION_START_CONFIG);
+        launchDashboardAction(appName, DashboardView.APP_MENU_ACTION_START_CONFIG);
         Shell shell = getRunConfigurationsShell();
         setCustomStartParmsFromShell(shell, appName, customParms);
         go("Run", shell);
     }
 
-    
     public static void setCustomStartParmsFromShell(Shell shell, String runDebugConfigName, String customParms) {
-    	
-        Object libertyConfigTree = getLibertyTreeItem(shell); 
 
-        Object appConfigEntry = find(runDebugConfigName, libertyConfigTree, Option.factory().useContains(true).widgetClass(TreeItem.class).build());
+        Object libertyConfigTree = getLibertyTreeItem(shell);
+
+        Object appConfigEntry = find(runDebugConfigName, libertyConfigTree,
+                Option.factory().useContains(true).widgetClass(TreeItem.class).build());
         go(appConfigEntry);
         Object parmLabel = find("Start parameters:", appConfigEntry, Option.factory().widgetClass(Label.class).build());
 
@@ -549,7 +557,7 @@ public class SWTBotPluginOperations {
         Object windowMenu = findGlobal("Window", Option.factory().widgetClass(MenuItem.class).build());
         goMenuItem(windowMenu, "Show View", "Package Explorer");
         Object peView = MagicWidgetFinder.findGlobal("Package Explorer");
-        
+
         Object project = MagicWidgetFinder.find(appName, peView, Option.factory().useContains(true).widgetClass(TreeItem.class).build());
         go(project);
         return project;
@@ -589,7 +597,6 @@ public class SWTBotPluginOperations {
         MagicWidgetFinder.context(project, "Run As",
                 WidgetMatcherFactory.withRegex(".*" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_STOP + ".*"));
     }
-
 
     /**
      * Launches the run tests action using the run as configuration shortcut.
@@ -673,7 +680,7 @@ public class SWTBotPluginOperations {
 
         Object project = getAppInPackageExplorerTree(appName);
 
-        context(project, "Configure", 
+        context(project, "Configure",
                 WidgetMatcherFactory.withRegex(".*" + EXPLORER_CONFIGURE_MENU_ENABLE_LIBERTY_TOOLS + ".*"));
     }
 
@@ -828,6 +835,20 @@ public class SWTBotPluginOperations {
     }
 
     /**
+     * Switches the Liberty run configuration main tab to the Source Tab. A Liberty configuration must be opened prior to calling this
+     * method.
+     * 
+     * @param bot The SWTWorkbenchBot instance.
+     */
+    public static void openSourceTab(SWTWorkbenchBot bot) {
+        SWTBotShell shell = bot.shell("Debug Configurations");
+        shell.activate().setFocus();
+        SWTBot shellBot = shell.bot();
+        SWTBotCTabItem tabItem = shellBot.cTabItem("Source");
+        tabItem.activate().setFocus();
+    }
+
+    /**
      * Presses the Proceed button if it exists on the error in workspace dialog.
      * 
      * @param bot The SWTWorkbenchBot instance.
@@ -836,7 +857,7 @@ public class SWTBotPluginOperations {
         try {
             bot.button("Proceed").click();
         } catch (Exception e) {
-            // Not a problem if error wasn't generated.  Continue...
+            // Not a problem if error wasn't generated. Continue...
         }
     }
 
@@ -922,6 +943,5 @@ public class SWTBotPluginOperations {
             return matchFound;
         }
     }
-
 
 }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -48,7 +49,6 @@ import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory;
 import org.eclipse.swtbot.swt.finder.utils.SWTUtils;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCTabItem;
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCombo;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotRootMenu;
@@ -560,10 +560,9 @@ public class SWTBotPluginOperations {
         Object appConfigEntry = find(runDebugConfigName, libertyConfigTree,
                 Option.factory().useContains(true).widgetClass(TreeItem.class).build());
         go(appConfigEntry);
-        Object parmLabel = find("Run in container", appConfigEntry, Option.factory().widgetClass(Label.class).build());
+        Object button = find("Run in Container", appConfigEntry, Option.factory().widgetClass(Button.class).build());
 
-        Control checkBox = ControlFinder.findControlInRange(parmLabel, SWTBotCheckBox.class, Direction.WEST);
-        go(checkBox);
+        go(button);
     }
 
     public static Object getAppInPackageExplorerTree(String appName) {

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/ut/LibertyPluginUnitTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/ut/LibertyPluginUnitTest.java
@@ -36,8 +36,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import io.openliberty.tools.eclipse.DebugModeHandler;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
+import io.openliberty.tools.eclipse.debug.DebugModeHandler;
 import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationHelper;
 import io.openliberty.tools.eclipse.ui.launch.StartTab;
 


### PR DESCRIPTION
This PR creates and uses a new custom debug configuration rather than using the Remote Java Application configuration. The main advantages to this are:
1. Our debug configuration is now integrated within our custom Liberty launch configuration. This includes a "Source" tab on our launch configuration dialog where source paths can be added to the source lookup list. 
2. We proactively look for project dependencies that are open projects in the same workspace and automatically add them to the default source lookup list. 
3. We can directly control the timeout when trying to attach the debugger to the running JVM.  This is useful if we need to tune things to allow larger applications to start. The timeout is set to 60 seconds for now. 

Some notable changes:

1. The custom debugger requires an ILaunch object to which the debug target is attached. We currently only have an ILaunch object when we run a "Start..." or "Debug..." action. This is because a "launch" is created when we click "Run" or "Debug" from the dialog.  That launch is then routed to our `LaunchConfigurationDelegateLauncher`.  In order to get this to work, we need to "launch" a configuration on each action. To do this, I refactored our action launch classes (e.g. `StartAction`) to lookup the configuration for the project and run `DebugUITools.launch(configuration, mode)` instead of starting dev mode directly. As a consequence, all actions create an ILaunch object which then gets routed to our `LaunchConfigurationDelegateLauncher`. The "start dev mode" logic has now been moved over to the delegate. "

This change does not change any external behavior and if anything, it keeps our action flow consistent. We now always "launch" a configuration which always routes to the delegate which is the single location for our "start dev mode" logic. 

2. We have two new classes that are associated with the behavior of our new debug launcher. These classes are added to our plugin.xml as extension points.

a. LibertySourcePathComputer - This class contains the logic to create the default source lookup path list. It first uses eclipse JDT APIs to get classpath entries for the project. It then uses m2e for maven projects and gradle tooling for gradle projects to get a list of project dependencies and then checks to see if the dependency exists in the workspace using the artifact coordinates.  

b. LibertySourceLookupDirector - This class may not be necessary for what we are doing, but the logic is trivial... it creates a "director" that gathers a list of source lookup "participants" which I believe determine what type of source lookups to create. We are only using the basic JavaSourceLookupParticipant which is for Java code. 

3. One test has been added to the multi mod tests that will start the war module project and make sure the jar project is in the source lookup list. 


NOTE: The source lookup only works ATM for dependencies that are Maven projects... in other words we properly get the list of dependencies for both Maven and Gradle projects, BUT only m2e has APIs that will look up projects in the workspace based on artifact coordinates.... and of course, it only looks up maven projects.... So a gradle app with a dependency that is a maven project will work just fine. but if the dependency project is a gradle app, that dependency app will not be added to the source lookup list.