### PR TITLE
Rework debugger config to default to suspend=n

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/jakarta/languageserver/JakartaLSConnection.java
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/jakarta/languageserver/JakartaLSConnection.java
@@ -34,6 +34,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 
 import io.openliberty.tools.eclipse.ls.plugin.LibertyToolsLSPlugin;
+import io.openliberty.tools.eclipse.lsclient.DebugUtil;
 
 public class JakartaLSConnection extends ProcessStreamConnectionProvider {
 
@@ -41,9 +42,9 @@ public class JakartaLSConnection extends ProcessStreamConnectionProvider {
 
         List<String> commands = new ArrayList<>();
         commands.add(computeJavaPath());
-        String debugPortString = System.getProperty(getClass().getName() + ".debugPort");
-        if (debugPortString != null) {
-            commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + debugPortString);
+        String debugArg = DebugUtil.getDebugJVMArg(getClass().getName());
+        if (debugArg.length() > 0) {
+            commands.add(debugArg);
         }
         commands.add("-classpath");
         try {

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/liberty/languageserver/LibertyLSConnection.java
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/liberty/languageserver/LibertyLSConnection.java
@@ -30,20 +30,19 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 
 import io.openliberty.tools.eclipse.ls.plugin.LibertyToolsLSPlugin;
+import io.openliberty.tools.eclipse.lsclient.DebugUtil;
 
 public class LibertyLSConnection extends ProcessStreamConnectionProvider {
 
     public LibertyLSConnection() {
-        String className = getClass().getName();
         List<String> commands = new ArrayList<>();
         commands.add(computeJavaPath());
-        String debugPortString = System.getProperty(className + ".debugPort");
-        if (debugPortString != null) {
-            commands.add(
-                    "-agentlib:jdwp=transport=dt_socket,server=y,suspend=" + getDebugSuspend(className) + ",address=" + debugPortString);
-        }
-        commands.add("-classpath");
         try {
+            String debugArg = DebugUtil.getDebugJVMArg(getClass().getName());
+            if (debugArg.length() > 0) {
+                commands.add(debugArg);
+            }
+            commands.add("-classpath");
             commands.add(computeClasspath());
             commands.add("io.openliberty.tools.langserver.LibertyLanguageServerLauncher");
             setCommands(commands);
@@ -64,18 +63,6 @@ public class LibertyLSConnection extends ProcessStreamConnectionProvider {
     private String computeJavaPath() {
         File f = new File(System.getProperty("java.home"), "bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : ""));
         return f.getAbsolutePath();
-    }
-
-    private String getDebugSuspend(String className) {
-        String debugSuspend = System.getProperty(className + ".debugSuspend", "false");
-
-        if (Boolean.parseBoolean(debugSuspend)) {
-            return "y";
-        } else if (debugSuspend.equalsIgnoreCase("y")) {
-            return "y";
-        } else {
-            return "n";
-        }
     }
 
     @Override

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/lsclient/DebugUtil.java
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/lsclient/DebugUtil.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
+package io.openliberty.tools.eclipse.lsclient;
+
+public class DebugUtil {
+
+    /**
+     * @param className
+     * 
+     * @return JVM arg if debug is enabled, otherwise returns emptry string
+     */
+    public static String getDebugJVMArg(String className) {
+        String debugPortString = System.getProperty(className + ".debugPort");
+        if (debugPortString != null) {
+            return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=" + getDebugSuspend(className) + ",address=" + debugPortString;
+        } else {
+            return "";
+        }
+    }
+
+    private static String getDebugSuspend(String className) {
+        String debugSuspend = System.getProperty(className + ".debugSuspend", "false");
+
+        if (Boolean.parseBoolean(debugSuspend)) {
+            return "y";
+        } else if (debugSuspend.equalsIgnoreCase("y")) {
+            return "y";
+        } else {
+            return "n";
+        }
+    }
+
+}

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/mpls/LibertyMPLSConnection.java
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/mpls/LibertyMPLSConnection.java
@@ -21,15 +21,11 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IStatus;
@@ -38,72 +34,72 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 
 import io.openliberty.tools.eclipse.ls.plugin.LibertyToolsLSPlugin;
+import io.openliberty.tools.eclipse.lsclient.DebugUtil;
 
 public class LibertyMPLSConnection extends ProcessStreamConnectionProvider {
 
-	public LibertyMPLSConnection() {
-		List<String> commands = new ArrayList<>();
-		commands.add(computeJavaPath());
-		String debugPortString = System.getProperty(getClass().getName() + ".debugPort");
-		if (debugPortString != null) {
-			commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + debugPortString);
-		}
-		commands.add("-classpath");
-		try {
-			commands.add(computeClasspath());
-			commands.add("org.eclipse.lsp4mp.ls.MicroProfileServerLauncher");
-			setCommands(commands);
-			setWorkingDirectory(System.getProperty("user.dir"));			
-		} catch (IOException e) {
-			LibertyToolsLSPlugin.getDefault().getLog().log(new Status(IStatus.ERROR,
-					LibertyToolsLSPlugin.getDefault().getBundle().getSymbolicName(), e.getMessage(), e));
-		}
-	}
+    public LibertyMPLSConnection() {
+        List<String> commands = new ArrayList<>();
+        commands.add(computeJavaPath());
+        String debugArg = DebugUtil.getDebugJVMArg(getClass().getName());
+        if (debugArg.length() > 0) {
+            commands.add(debugArg);
+        }
+        commands.add("-classpath");
+        try {
+            commands.add(computeClasspath());
+            commands.add("org.eclipse.lsp4mp.ls.MicroProfileServerLauncher");
+            setCommands(commands);
+            setWorkingDirectory(System.getProperty("user.dir"));
+        } catch (IOException e) {
+            LibertyToolsLSPlugin.getDefault().getLog()
+                    .log(new Status(IStatus.ERROR, LibertyToolsLSPlugin.getDefault().getBundle().getSymbolicName(), e.getMessage(), e));
+        }
+    }
 
-	private String computeClasspath() throws IOException {
-		StringBuilder builder = new StringBuilder();
-		URL url = FileLocator.toFileURL(getClass().getResource("/server/mp-langserver/org.eclipse.lsp4mp.ls.jar"));
-		builder.append(new java.io.File(url.getPath()).getAbsolutePath());
-		return builder.toString();
-	}
-	
-	private String computeJavaPath() {
-		File f = new File(System.getProperty("java.home"),
-				"bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : ""));
-		return f.getAbsolutePath();
-	}
+    private String computeClasspath() throws IOException {
+        StringBuilder builder = new StringBuilder();
+        URL url = FileLocator.toFileURL(getClass().getResource("/server/mp-langserver/org.eclipse.lsp4mp.ls.jar"));
+        builder.append(new java.io.File(url.getPath()).getAbsolutePath());
+        return builder.toString();
+    }
 
-	@Override
-	public Object getInitializationOptions(URI rootUri) {
-	
-		Map<String, Object> root = new HashMap<>();
-		Map<String, Object> settings = new HashMap<>();
-		Map<String, Object> microprofile = new HashMap<>();
-		Map<String, Object> tools = new HashMap<>();
-		Map<String, Object> trace = new HashMap<>();
-		trace.put("server", "verbose");
-		tools.put("trace", trace);
-		Map<String, Object> codeLens = new HashMap<>();
-		codeLens.put("urlCodeLensEnabled", "true");
-		tools.put("codeLens", codeLens);
-		microprofile.put("tools", tools);
-		settings.put("microprofile", microprofile);
-		root.put("settings", settings);
-		Map<String, Object> extendedClientCapabilities = new HashMap<>();
-		Map<String, Object> commands = new HashMap<>();
-		Map<String, Object> commandsKind = new HashMap<>();
-		commandsKind.put("valueSet", Arrays.asList("microprofile.command.configuration.update", "microprofile.command.open.uri"));
-		commands.put("commandsKind", commandsKind);
-		extendedClientCapabilities.put("commands", commands);
+    private String computeJavaPath() {
+        File f = new File(System.getProperty("java.home"), "bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : ""));
+        return f.getAbsolutePath();
+    }
+
+    @Override
+    public Object getInitializationOptions(URI rootUri) {
+
+        Map<String, Object> root = new HashMap<>();
+        Map<String, Object> settings = new HashMap<>();
+        Map<String, Object> microprofile = new HashMap<>();
+        Map<String, Object> tools = new HashMap<>();
+        Map<String, Object> trace = new HashMap<>();
+        trace.put("server", "verbose");
+        tools.put("trace", trace);
+        Map<String, Object> codeLens = new HashMap<>();
+        codeLens.put("urlCodeLensEnabled", "true");
+        tools.put("codeLens", codeLens);
+        microprofile.put("tools", tools);
+        settings.put("microprofile", microprofile);
+        root.put("settings", settings);
+        Map<String, Object> extendedClientCapabilities = new HashMap<>();
+        Map<String, Object> commands = new HashMap<>();
+        Map<String, Object> commandsKind = new HashMap<>();
+        commandsKind.put("valueSet", Arrays.asList("microprofile.command.configuration.update", "microprofile.command.open.uri"));
+        commands.put("commandsKind", commandsKind);
+        extendedClientCapabilities.put("commands", commands);
         extendedClientCapabilities.put("completion", new HashMap<>());
         extendedClientCapabilities.put("shouldLanguageServerExitOnShutdown", Boolean.TRUE);
-		root.put("extendedClientCapabilities", extendedClientCapabilities);
-		return root;
-	}
+        root.put("extendedClientCapabilities", extendedClientCapabilities);
+        return root;
+    }
 
-	@Override
-	public String toString() {
-		return "Liberty MP Language Server: " + super.toString();
-	}
+    @Override
+    public String toString() {
+        return "Liberty MP Language Server: " + super.toString();
+    }
 
 }


### PR DESCRIPTION
As noted on the [wiki](https://github.com/OpenLiberty/liberty-tools-eclipse/wiki/Debug-Options#suspend)


By default the JVM will launch but not be suspended, when the debug port is set.

To start the JVM in a suspended state while the debugger is attached, use, e.g:

> -Dio.openliberty.tools.eclipse.mpls.LibertyMPLSConnection.debugSuspend=y

(use the corresponding property for each LS based on the classnames above) 