### PR TITLE
Add Common tab with test

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigTabGroup.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigTabGroup.java
@@ -13,6 +13,7 @@
 package io.openliberty.tools.eclipse.ui.launch;
 
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
+import org.eclipse.debug.ui.CommonTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
 import org.eclipse.debug.ui.sourcelookup.SourceLookupTab;
@@ -27,6 +28,6 @@ public class LaunchConfigTabGroup extends AbstractLaunchConfigurationTabGroup {
      */
     @Override
     public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-        setTabs(new ILaunchConfigurationTab[] { new StartTab(), new JRETab(), new SourceLookupTab() });
+        setTabs(new ILaunchConfigurationTab[] { new StartTab(), new JRETab(), new SourceLookupTab(), new CommonTab() });
     }
 }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -41,6 +41,7 @@ import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStopWithRunAsShortcut;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchViewITReportWithRunDebugAsShortcut;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchViewUTReportWithRunDebugAsShortcut;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.openCommonTab;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.openJRETab;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.openJavaPerspectiveViaMenu;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.openSourceTab;
@@ -897,8 +898,35 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
             go("Close", configShell);
         }
     }
-
+    
+    
     /**
+     * Tests that the Common Tab is added and can be opened
+     */
+    @Test
+    public void testDefaultCommonTab() {    	
+    	
+    	deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+
+        Shell configShell = launchRunConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
+    	
+    	try {
+        
+        TreeItem libertyConfigTree = getLibertyTreeItemNoBot(configShell);
+
+        context(libertyConfigTree, "New Configuration");
+    	
+    	openCommonTab(bot);
+    	
+    	} finally {
+           
+            go("Close", configShell);
+        }
+    	
+
+    }
+
+	/**
      * Tests that a non-Liberty project can be manually be categorized to be Liberty project. This test also tests the refresh
      * function.
      * 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -851,6 +851,20 @@ public class SWTBotPluginOperations {
         SWTBotCTabItem tabItem = shellBot.cTabItem("Source");
         tabItem.activate().setFocus();
     }
+    
+   /** 
+    * Switches the Liberty run configuration main tab to the Common Tab.  This operation will fail if tab is not
+    * successfully launched or switched to
+    * 
+    * @param bot The SWTWorkbenchBot instance.
+    */
+   public static void openCommonTab(SWTWorkbenchBot bot) {
+       SWTBotShell shell = bot.shell("Run Configurations");
+       shell.activate().setFocus();
+       SWTBot shellBot = shell.bot();
+       SWTBotCTabItem tabItem = shellBot.cTabItem("Common");
+       tabItem.activate().setFocus();
+   }
 
     /**
      * Presses the Proceed button if it exists on the error in workspace dialog.


### PR DESCRIPTION
Adds the Common tab to the Run Configurations.  Added a test to launch the tab, and validated that the test failed when the Common tab is not added.