### PR TITLE
Add LCLS change listener

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -24,7 +24,8 @@ Require-Bundle: com.google.gson,
  org.eclipse.jdt.core,
  org.eclipse.jdt.ui,
  org.eclipse.jdt.ls.core,
- org.eclipse.ui.workbench
+ org.eclipse.ui.workbench,
+ org.eclipse.core.resources
 Bundle-ClassPath: .,
  server/mp-langserver/org.eclipse.lsp4mp.ls.jar,
  server/liberty-langserver/liberty-langserver.jar,

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/plugin.xml
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/plugin.xml
@@ -114,7 +114,6 @@
             editorId="org.eclipse.ui.genericeditor.GenericEditor">
       </editorContentTypeBinding>
    </extension>   
-  
 
    <extension
          point="org.eclipse.lsp4e.languageServer">
@@ -135,11 +134,12 @@
             contentType="org.eclipse.jdt.core.javaSource"
             id="io.openliberty.tools.eclipse.org.microprofile.mpserver">
       </contentTypeMapping>
-      
+            
       <!-- Liberty Config LS config -->
       <server
             class="io.openliberty.tools.eclipse.liberty.languageserver.LibertyLSConnection"
             id="io.openliberty.tools.eclipse.org.liberty.languageserver"
+            clientImpl="io.openliberty.tools.eclipse.liberty.languageserver.LibertyLSClientImpl"
             label="Liberty Config Language Server"
             singleton="true">
       </server>

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     
     <properties>
-        <liberty.ls.version>2.1.1</liberty.ls.version>
+        <liberty.ls.version>2.1.2</liberty.ls.version>
         <jakarta.ls.version>0.2.1</jakarta.ls.version>
         <mp.ls.version>0.10.0</mp.ls.version>
     </properties>

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/liberty/languageserver/LibertyLSClientImpl.java
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/src/io/openliberty/tools/eclipse/liberty/languageserver/LibertyLSClientImpl.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+* Copyright (c) 2024 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial implementation
+*******************************************************************************/
+package io.openliberty.tools.eclipse.liberty.languageserver;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.lsp4e.LanguageClientImpl;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.swt.widgets.Display;
+
+import io.openliberty.tools.eclipse.ls.plugin.LibertyToolsLSPlugin;
+
+/**
+ * Liberty Config language client.
+ * 
+ * @author
+ */
+public class LibertyLSClientImpl extends LanguageClientImpl {
+
+    public LibertyLSClientImpl() {
+        super();
+        IWorkspace iWorkspace = ResourcesPlugin.getWorkspace();
+        LCLSListener resourceChangeListener = new LCLSListener();
+        iWorkspace.addResourceChangeListener(resourceChangeListener, IResourceChangeEvent.POST_BUILD);
+
+    }
+
+    public void fireUpdate(List<String> uris) {
+        List<FileEvent> fileEvents = new ArrayList<FileEvent>();
+        for (String uri : uris) {
+            fileEvents.add(new FileEvent(uri, FileChangeType.Changed));
+        }
+        DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams();
+        params.setChanges(fileEvents);
+
+        getLanguageServer().getWorkspaceService().didChangeWatchedFiles(params);
+    }
+
+    public class LCLSListener implements IResourceChangeListener {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void resourceChanged(IResourceChangeEvent event) {
+            Display.getDefault().syncExec(new Runnable() {
+
+                @Override
+                public void run() {
+
+                    IResourceDelta delta = event.getDelta();
+                    if (delta == null) {
+                        return;
+                    }
+
+                    final ArrayList<String> changed = new ArrayList<String>();
+
+                    IResourceDeltaVisitor visitor = new IResourceDeltaVisitor() {
+                        public boolean visit(IResourceDelta delta) {
+                            IResource resource = delta.getResource();
+                            if (resource.getType() == IResource.FILE) {
+
+                                // Look for changes to liberty-plugin-config.xml, *.properties, and *.env
+                                if ("liberty-plugin-config.xml".equalsIgnoreCase(resource.getName())
+                                        || "properties".equalsIgnoreCase(resource.getFileExtension())
+                                        || "env".equalsIgnoreCase(resource.getFileExtension())) {
+                                    changed.add(resource.getLocationURI().toString());
+                                }
+                            }
+                            return true;
+                        }
+                    };
+
+                    try {
+                        delta.accept(visitor);
+                    } catch (CoreException e) {
+                        LibertyToolsLSPlugin.logException(e.getLocalizedMessage(), e);
+                    }
+
+                    if (!changed.isEmpty()) {
+                        fireUpdate(changed);
+                    }
+
+                }
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
Add a resource changed listener to send "didChangedWatchedFiles" events to the Liberty Config LS on any changes to liberty-plugin-config.xml and all *.properties and *.env files.

Resolves issue #461 

Addresses required changes in LCLS PR https://github.com/OpenLiberty/liberty-language-server/pull/212 