### PR TITLE
Fixes #527

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022, 2023 IBM Corporation and others.
+* Copyright (c) 2022, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -147,9 +147,17 @@ public class CommandBuilder {
 
     private String getCommandFromPreferences() throws IllegalStateException {
 
-        File tempCmdFile = new File(getInstallLocationPreferenceString() + File.separator + "bin" + File.separator + getExecBaseName());
+        String installLocPref = getInstallLocationPreferenceString();
+        if (installLocPref == null || installLocPref.isBlank() || installLocPref.isEmpty()) {
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_TOOLS, "The mvn/gradle preference path: " + installLocPref + " was null, blank, or empty");
+            }
+            return null;
+        }        
+        
+        File tempCmdFile = new File(installLocPref + File.separator + "bin" + File.separator + getExecBaseName());
         String cmdPathStr = tempCmdFile.getPath();
-
+        
         if (tempCmdFile.exists()) {
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_TOOLS, "Found mvn/gradle from preference at path: " + cmdPathStr);
@@ -179,9 +187,9 @@ public class CommandBuilder {
 
         String[] pathMembers = pathEnv.split(File.pathSeparator);
         for (String member : pathMembers) {
-        	if (member.isBlank() || member.isEmpty()) {
-        		continue;
-        	}
+            if (member.isBlank() || member.isEmpty()) {
+                continue;
+            }
             File tempFile = new File(member + File.separator + executableBaseName);
             if (tempFile.exists()) {
                 foundCmd = tempFile.getPath();

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -179,6 +179,9 @@ public class CommandBuilder {
 
         String[] pathMembers = pathEnv.split(File.pathSeparator);
         for (String member : pathMembers) {
+        	if (member.isBlank() || member.isEmpty()) {
+        		continue;
+        	}
             File tempFile = new File(member + File.separator + executableBaseName);
             if (tempFile.exists()) {
                 foundCmd = tempFile.getPath();

--- a/tests/resources/execs/mvn
+++ b/tests/resources/execs/mvn
@@ -1,0 +1,1 @@
+echo "This is a dummy file just so file exists for test"

--- a/tests/resources/execs/mvn.cmd
+++ b/tests/resources/execs/mvn.cmd
@@ -1,0 +1,2 @@
+@echo off
+echo This is a dummy file just so file exists for test

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/ut/CommandBuilderTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/ut/CommandBuilderTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright (c) 2025 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial implementation
+*******************************************************************************/
+
+package io.openliberty.tools.eclipse.test.ut;
+
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.unsetBuildCmdPathInPreferences;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.junit.jupiter.api.Test;
+
+import io.openliberty.tools.eclipse.CommandBuilder;
+
+public class CommandBuilderTest {
+
+	
+
+	/**
+	 * Tests the CommandBuilder builds a mvn invocation using the mvnw wrapper found in the project, even when the preference
+	 * is unset
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testCmdBuilderMvnWrapper() throws Exception {
+		// This allows the test to prove the wrapper is in use even when the preference is unset, since an empty string preference would
+		// resolve to "" + "/bin/mvn" = "/bin/mvn" and would typically be an actual path on Unix/Mac
+        unsetBuildCmdPathInPreferences(new SWTWorkbenchBot(), "Maven");
+		Path projectPath = Paths.get("resources", "applications", "maven", "liberty-maven-test-wrapper-app");
+		String retVal = CommandBuilder.getMavenCommandLine(projectPath.toString(), "-a 123", obfuscatedPath(), false);
+		assertEquals(projectPath.resolve(mvnwName()) + " -a 123", retVal, "Wrong cmd line");
+	}
+
+	/**
+	 * Tests the CommandBuilder builds a mvn invocation using the mvn found in the path, even when there is an empty path element
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testCmdBuilderMvn() throws Exception {
+		Path projectPath = Paths.get("resources", "applications", "maven", "liberty-maven-test-app");
+		Path mvnPath = Paths.get("resources", "execs");
+		String pathEnv= obfuscatedPath() + File.pathSeparator + mvnPath.toAbsolutePath().toString();
+		String retVal = CommandBuilder.getMavenCommandLine(projectPath.toString(), "-a 123", pathEnv, false);
+		assertEquals(mvnPath.toAbsolutePath().resolve(mvnName()) + " -a 123", retVal, "Wrong cmd line");
+	}
+
+	/**
+	 * @return 	A platform-dependent path very unlikely to be used, with an empty element
+	 */
+	private String obfuscatedPath() {
+		if (System.getProperty("os.name").contains("Windows")) {
+			return "C:\\abc\\xyz\\123\456;;C:\\xyz\\abc\\456\\123";
+		} else {
+			return "/a/b/c/d1/e/f/g::/x/ya/b2/saa/";
+		}
+	}
+
+	
+	private String mvnName() {
+		if (System.getProperty("os.name").contains("Windows")) {
+			return "mvn.cmd";
+		} else {
+			return "mvn";
+		}
+	}
+
+	private String mvnwName() {
+		if (System.getProperty("os.name").contains("Windows")) {
+			return "mvnw.cmd";
+		} else {
+			return "mvnw";
+		}
+	}
+
+}


### PR DESCRIPTION
It seems that the "blank" preference will sometimes allow /bin/mvn to resolve.  OTOH, this would typically resolve as part of the PATH, so removing it might be cleaner.

Still it's not exactly zero side effects, so let's review.