### PR TITLE
2503 release

### DIFF
--- a/.github/workflows/run-regression-tests.yml
+++ b/.github/workflows/run-regression-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         runtime: [ linux, mac, windows ]
-        targetPlatform: [ 3Q2024 ]
+        targetPlatform: [ 4Q2024 ]
         include:
         - runtime: linux
           os: ubuntu-latest

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
-Bundle-Copyright: Copyright (c) 2022, 2024 IBM Corporation and others.
+Bundle-Copyright: Copyright (c) 2022, 2025 IBM Corporation and others.
 Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools Support for Language Servers
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.lsp4e;singleton:=true
-Bundle-Version: 24.0.12.qualifier
+Bundle-Version: 25.0.3.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.ls.plugin.LibertyToolsLSPlugin
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: io.openliberty.tools.eclipse.lsp4e

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2022 IBM Corporation and others.
+  Copyright (c) 2022, 2025 IBM Corporation and others.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.openliberty.tools.eclipse</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.12-SNAPSHOT</version>
+        <version>25.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     

--- a/bundles/io.openliberty.tools.eclipse.product/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.product/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
-Bundle-Copyright: Copyright (c) 2022, 2024 IBM Corporation and others.
+Bundle-Copyright: Copyright (c) 2022, 2025 IBM Corporation and others.
 Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.product;singleton:=true
-Bundle-Version: 24.0.12.qualifier
+Bundle-Version: 25.0.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: io.openliberty.tools.eclipse
 Bundle-ActivationPolicy: lazy

--- a/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
-Bundle-Copyright: Copyright (c) 2022, 2024 IBM Corporation and others.
+Bundle-Copyright: Copyright (c) 2022, 2025 IBM Corporation and others.
 Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools UI
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.ui;singleton:=true
-Bundle-Version: 24.0.12.qualifier
+Bundle-Version: 25.0.3.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.LibertyDevPlugin
 Export-Package: io.openliberty.tools.eclipse;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.debug;x-friends:="io.openliberty.tools.eclipse.tests",

--- a/ci/jenkins/run-tests
+++ b/ci/jenkins/run-tests
@@ -38,7 +38,7 @@ pipeline {
             }
         }
         
-        stage('Test on Eclipse 3Q2024') {
+        stage('Test on Eclipse 4Q2024') {
             steps {
                 dir('liberty-tools-eclipse') {
                     script {
@@ -48,16 +48,16 @@ pipeline {
                                 sh '''
                                    MVNPATH="$(dirname $(which mvn))/.."
                                    GRADLEPATH="$(dirname $(which gradle))/.."
-                                   mvn clean verify -DmvnLogFile -DmvnPath=$MVNPATH -DgradlePath=$GRADLEPATH -Dtycho.disableP2Mirrors=true -Declipse.target=3Q2024 -Dosgi.debug=./tests/resources/ci/debug.opts -DtestAppImportWait=120000 -Dtycho.showEclipseLog -e -X
+                                   mvn clean verify -DmvnLogFile -DmvnPath=$MVNPATH -DgradlePath=$GRADLEPATH -Dtycho.disableP2Mirrors=true -Declipse.target=4Q2024 -Dosgi.debug=./tests/resources/ci/debug.opts -DtestAppImportWait=120000 -Dtycho.showEclipseLog -e -X
                                 '''
                             }
                         } finally {
                             sh "find tests -type f -name \"lte-dev-mode-output-*.log\""
                             sh "mkdir lte-dev-mode-output-logs && find tests -type f -name \"lte-dev-mode-output-*.log\" -exec cp {} lte-dev-mode-output-logs \\;"
                             sh "zip -r lte-dev-mode-output-logs.zip lte-dev-mode-output-logs"
-                            sh "cd tests/target/surefire-reports && zip -r 3Q2024-test-reports.zip ."
+                            sh "cd tests/target/surefire-reports && zip -r 4Q2024-test-reports.zip ."
                             
-                            archiveArtifacts artifacts: 'tests/target/surefire-reports/3Q2024-test-reports.zip', fingerprint: true
+                            archiveArtifacts artifacts: 'tests/target/surefire-reports/4Q2024-test-reports.zip', fingerprint: true
                             archiveArtifacts artifacts: 'lte-dev-mode-output-logs.zip', fingerprint: true
                             archiveArtifacts artifacts: 'tests/target/work/data/.metadata/.log', fingerprint: true
                         }

--- a/features/io.openliberty.tools.eclipse.feature/feature.xml
+++ b/features/io.openliberty.tools.eclipse.feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2022 IBM Corporation and others.
+  Copyright (c) 2022, 2025 IBM Corporation and others.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@
 <feature
       id="io.openliberty.tools.eclipse"
       label="%featureName"
-      version="24.0.12.qualifier"
+      version="25.0.3.qualifier"
     plugin="io.openliberty.tools.eclipse.product"
     provider-name="%providerName">
 
@@ -28,21 +28,21 @@
          id="io.openliberty.tools.eclipse.ui"
          download-size="0"
          install-size="0"
-         version="24.0.12.qualifier"
+         version="25.0.3.qualifier"
          unpack="false"/>
 
    <plugin
          id="io.openliberty.tools.eclipse.lsp4e"
          download-size="0"
          install-size="0"
-         version="24.0.12.qualifier"
+         version="25.0.3.qualifier"
          unpack="false"/>
 
    <plugin
          id="io.openliberty.tools.eclipse.product"
          download-size="0"
          install-size="0"
-         version="24.0.12.qualifier"
+         version="25.0.3.qualifier"
          unpack="false"/>
 
 </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2022, 2024 IBM Corporation and others.
+  Copyright (c) 2022, 2025 IBM Corporation and others.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,7 +15,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.openliberty.tools.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>24.0.12-SNAPSHOT</version>
+	<version>25.0.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
     <licenses>
       <license>
@@ -196,7 +196,7 @@
 						<artifact>
 							<groupId>io.openliberty.tools.eclipse</groupId>
 							<artifactId>target-platform-${eclipse.target}</artifactId>
-							<version>24.0.12-SNAPSHOT</version>
+							<version>25.0.3-SNAPSHOT</version>
 							<file>target-platform-${eclipse.target}</file>
 						</artifact>
 					</target>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         
         <!-- default version of the eclipse IDE to run tests against -->
         <!-- must be one of the target platform files defined in this project under releng -->
-        <eclipse.target>3Q2024</eclipse.target>
+        <eclipse.target>4Q2024</eclipse.target>
             
 	</properties>
 	

--- a/releng/io.openliberty.tools.update/category.xml
+++ b/releng/io.openliberty.tools.update/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2022, 2024 IBM Corporation and others.
+  Copyright (c) 2022, 2025 IBM Corporation and others.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,7 +12,7 @@
       IBM Corporation - initial implementation
 -->
 <site>
-    <feature url="features/io.openliberty.tools.eclipse_24.0.12.qualifier.liberty.jar" id="io.openliberty.tools.eclipse" version="24.0.12.qualifier">
+    <feature url="features/io.openliberty.tools.eclipse_25.0.3.qualifier.liberty.jar" id="io.openliberty.tools.eclipse" version="25.0.3.qualifier">
         <category name="io.openliberty.tools.eclipse"/>
     </feature>
 

--- a/releng/target-platform-4Q2024/target-platform-4Q2024.target
+++ b/releng/target-platform-4Q2024/target-platform-4Q2024.target
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<!--
+  Copyright (c) 2025 IBM Corporation and others.
+  
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Contributors:
+      IBM Corporation - initial implementation
+-->
+<target includeMode="feature" name="target-platform.target" sequenceNumber="16">
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/releases/2024-12/"/>
+            <unit id="org.eclipse.jdt.feature.group" version="3.20.0.v20241120-1800"/>
+            <unit id="org.eclipse.ui.trace" version="1.3.400.v20240801-2123"/>
+            <unit id="org.eclipse.emf.sdk.feature.group" version="2.40.0.v20241018-1213"/>
+            <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.1500.v20241112-0530"/>
+            <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.6.1.20231024-1618"/>
+            <unit id="org.eclipse.sdk.feature.group" version="4.34.0.v20241120-1800"/>
+            <unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
+            <unit id="org.junit" version="4.13.2.v20240929-1000"/>
+            <unit id="junit-jupiter-api" version="5.11.3"/>
+            <unit id="junit-jupiter-engine" version="5.11.3"/>
+            <unit id="org.eclipse.lsp4e" version="0.18.12.202408150719"/>
+            <unit id="org.eclipse.lsp4e.jdt" version="0.13.0.202402070603"/>
+            <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="1.3.9.202411190713"/>
+            <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="1.3.6.202409052135"/>
+            <unit id="org.eclipse.m2e.lemminx.feature.feature.group" version="2.0.700.20240928-0605"/>
+        </location>
+
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository"/>
+            <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
+            <unit id="ch.qos.logback.slf4j.source" version="1.2.3.v20200428-2012"/>
+            <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
+            <unit id="org.slf4j.api.source" version="1.7.30.v20200204-2150"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/technology/swtbot/releases/4.2.1"/>
+            <unit id="org.eclipse.swtbot.eclipse.feature.group" version="4.2.1.202406141605"/>
+            <unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="4.2.1.202406141605"/>
+            <unit id="org.eclipse.swtbot.feature.group" version="4.2.1.202406141605"/>
+            <unit id="org.eclipse.swtbot.forms.feature.group" version="4.2.1.202406141605"/>
+            <unit id="org.eclipse.swtbot.ide.feature.group" version="4.2.1.202406141605"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="http://download.eclipse.org/lsp4mp/releases/0.13.2/repository/"/>
+            <unit id="org.eclipse.lsp4mp.jdt.core" version="0.13.2.20241022-1352"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/lsp4jakarta/releases/0.2.2/repository/"/>
+            <unit id="org.eclipse.lsp4jakarta.jdt.core" version="0.2.2"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.23.1/"/>
+            <unit id="org.eclipse.lsp4j" version="0.0.0"/>
+            <unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/jdtls/milestones/1.42.0/repository/"/>
+            <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/buildship/updates/e427/releases/3.x/3.1.9.v20240115-1636/"/>
+            <unit id="org.eclipse.buildship.ui" version="3.1.9.v20240115-1636"/>
+        </location>
+        <location includeDependencyDepth="none" includeDependencyScopes="compile" missingManifest="generate" type="Maven">
+            <dependencies>
+                <dependency>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy-agent</artifactId>
+                    <version>1.14.18</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                    <version>1.14.18</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <version>5.12.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-junit-jupiter</artifactId>
+                    <version>5.12.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                    <version>3.4</version>
+                    <type>jar</type>
+                </dependency>
+            </dependencies>
+        </location>       
+    </locations>
+</target>

--- a/releng/target-platform-4Q2024/target-platform-4Q2024.target
+++ b/releng/target-platform-4Q2024/target-platform-4Q2024.target
@@ -32,7 +32,6 @@
             <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="1.3.6.202409052135"/>
             <unit id="org.eclipse.m2e.lemminx.feature.feature.group" version="2.0.700.20240928-0605"/>
         </location>
-
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository"/>
             <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
@@ -47,6 +46,10 @@
             <unit id="org.eclipse.swtbot.feature.group" version="4.2.1.202406141605"/>
             <unit id="org.eclipse.swtbot.forms.feature.group" version="4.2.1.202406141605"/>
             <unit id="org.eclipse.swtbot.ide.feature.group" version="4.2.1.202406141605"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/cdt/releases/11.6"/>
+            <unit id="org.eclipse.cdt.launch" version="10.4.400.202402230238"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="http://download.eclipse.org/lsp4mp/releases/0.13.2/repository/"/>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
-Bundle-Copyright: Copyright (c) 2022, 2024 IBM Corporation and others.
+Bundle-Copyright: Copyright (c) 2022, 2025 IBM Corporation and others.
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: io.openliberty.tools.eclipse.tests
-Bundle-Version: 24.0.12.qualifier
+Bundle-Version: 25.0.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: junit-jupiter-api,
  org.eclipse.ui,

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2022, 2024 IBM Corporation and others.
+  Copyright (c) 2022, 2025 IBM Corporation and others.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.openliberty.tools.eclipse</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.12-SNAPSHOT</version>
+        <version>25.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.openliberty.tools.eclipse.tests</artifactId>


### PR DESCRIPTION
- Update version to 25.0.3
- Creates new target platform for Eclipse 24.0.12 and updates the default 

No changes needed to dependencies (LCLS, LSP4MP, LSP4Jakarta, etc) - already at current