### PR TITLE
Added mvn clean option under liberty in run configurations 

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -82,16 +82,6 @@ public class CommandBuilder {
     }
 
 
-    public static String getMvnCleanCommand(String projectPath, String pathEnv) throws CommandBuilder.CommandNotFoundException{
-    	try {
-    		CommandBuilder builder = new CommandBuilder(projectPath, pathEnv, true);
-			return builder.getCommand()+" clean && ";
-		} catch (CommandNotFoundException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return "";
-    }
     private String getCommand() throws CommandBuilder.CommandNotFoundException {
         String cmd = getCommandFromWrapper();
         if (cmd == null) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -81,7 +81,6 @@ public class CommandBuilder {
         return cmdLine;
     }
 
-
     private String getCommand() throws CommandBuilder.CommandNotFoundException {
         String cmd = getCommandFromWrapper();
         if (cmd == null) {
@@ -247,5 +246,5 @@ public class CommandBuilder {
             super(cause);
         }
 
-    }    
+    }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -257,6 +257,5 @@ public class CommandBuilder {
             super(cause);
         }
 
-    }
-    
+    }    
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/CommandBuilder.java
@@ -81,6 +81,17 @@ public class CommandBuilder {
         return cmdLine;
     }
 
+
+    public static String getMvnCleanCommand(String projectPath, String pathEnv) throws CommandBuilder.CommandNotFoundException{
+    	try {
+    		CommandBuilder builder = new CommandBuilder(projectPath, pathEnv, true);
+			return builder.getCommand()+" clean && ";
+		} catch (CommandNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return "";
+    }
     private String getCommand() throws CommandBuilder.CommandNotFoundException {
         String cmd = getCommandFromWrapper();
         if (cmd == null) {
@@ -247,4 +258,5 @@ public class CommandBuilder {
         }
 
     }
+    
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -166,7 +166,7 @@ public class DevModeOperations {
      * @param launch The launch associated with this run.
      * @param mode The configuration mode.
      */
-    public void start(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode, boolean runMvnClean) {
+    public void start(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode, boolean runProjectClean) {
 
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms, javaHomePath, mode });
@@ -230,19 +230,15 @@ public class DevModeOperations {
             String cmd = "";
 
             if (buildType == Project.BuildType.MAVEN) {
-                cmd = CommandBuilder.getMavenCommandLine(projectPath, "io.openliberty.tools:liberty-maven-plugin:dev " + startParms,
+                cmd = CommandBuilder.getMavenCommandLine(projectPath, (runProjectClean == true ? " clean " : "" ) + "io.openliberty.tools:liberty-maven-plugin:dev " + startParms,
                         pathEnv);
             } else if (buildType == Project.BuildType.GRADLE) {
-                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDev " + startParms, pathEnv);
+                cmd = CommandBuilder.getGradleCommandLine(projectPath, (runProjectClean == true ? " clean " : "" ) + "libertyDev " + startParms, pathEnv);
             } else {
                 throw new Exception("Unexpected project build type: " + buildType + ". Project " + projectName
                         + "does not appear to be a Maven or Gradle built project.");
             }
 
-           //Modify the command to include 'mvn clean' if run maven clean option is selected
-           if(runMvnClean) {
-        	   cmd = CommandBuilder.getMvnCleanCommand(projectPath,pathEnv) + cmd;
-           }
            // Run the application in dev mode.
             startDevMode(cmd, projectName, projectPath, javaHomePath, launch);
 
@@ -278,7 +274,7 @@ public class DevModeOperations {
      * @param launch The launch associated with this run.
      * @param mode The configuration mode.
      */
-    public void startInContainer(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode , boolean runMvnClean) {
+    public void startInContainer(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode , boolean runProjectClean) {
 
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms, javaHomePath, mode });
@@ -341,19 +337,15 @@ public class DevModeOperations {
             // Prepare the Liberty plugin container dev mode command.
             String cmd = "";
             if (buildType == Project.BuildType.MAVEN) {
-                cmd = CommandBuilder.getMavenCommandLine(projectPath, "io.openliberty.tools:liberty-maven-plugin:devc " + startParms,
+                cmd = CommandBuilder.getMavenCommandLine(projectPath,(runProjectClean == true ? " clean " : "") + "io.openliberty.tools:liberty-maven-plugin:devc " + startParms,
                         pathEnv);
             } else if (buildType == Project.BuildType.GRADLE) {
-                cmd = CommandBuilder.getGradleCommandLine(projectPath, "libertyDevc " + startParms, pathEnv);
+                cmd = CommandBuilder.getGradleCommandLine(projectPath, (runProjectClean == true ? " clean " : "" ) + "libertyDevc " + startParms, pathEnv);
             } else {
                 throw new Exception("Unexpected project build type: " + buildType + ". Project " + projectName
                         + "does not appear to be a Maven or Gradle built project.");
             }
             
-            //Modify the command to include 'mvn clean' if run maven clean option is selected
-            if(runMvnClean) {
-         	   cmd = CommandBuilder.getMvnCleanCommand(projectPath,pathEnv) + cmd;
-            }
             // Run the application in dev mode.
             startDevMode(cmd, projectName, projectPath, javaHomePath, launch);
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -166,7 +166,7 @@ public class DevModeOperations {
      * @param launch The launch associated with this run.
      * @param mode The configuration mode.
      */
-    public void start(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode) {
+    public void start(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode, boolean runMvnClean) {
 
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms, javaHomePath, mode });
@@ -239,7 +239,11 @@ public class DevModeOperations {
                         + "does not appear to be a Maven or Gradle built project.");
             }
 
-            // Run the application in dev mode.
+           //Modify the command to include 'mvn clean' if run maven clean option is selected
+           if(runMvnClean) {
+        	   cmd = CommandBuilder.getMvnCleanCommand(projectPath,pathEnv) + cmd;
+           }
+           // Run the application in dev mode.
             startDevMode(cmd, projectName, projectPath, javaHomePath, launch);
 
             // If there is a debugPort, start the job to attach the debugger to the Liberty server JVM.
@@ -274,7 +278,7 @@ public class DevModeOperations {
      * @param launch The launch associated with this run.
      * @param mode The configuration mode.
      */
-    public void startInContainer(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode) {
+    public void startInContainer(IProject iProject, String parms, String javaHomePath, ILaunch launch, String mode , boolean runMvnClean) {
 
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { iProject, parms, javaHomePath, mode });
@@ -345,7 +349,11 @@ public class DevModeOperations {
                 throw new Exception("Unexpected project build type: " + buildType + ". Project " + projectName
                         + "does not appear to be a Maven or Gradle built project.");
             }
-
+            
+            //Modify the command to include 'mvn clean' if run maven clean option is selected
+            if(runMvnClean) {
+         	   cmd = CommandBuilder.getMvnCleanCommand(projectPath,pathEnv) + cmd;
+            }
             // Run the application in dev mode.
             startDevMode(cmd, projectName, projectPath, javaHomePath, launch);
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -239,7 +239,7 @@ public class DevModeOperations {
                         + "does not appear to be a Maven or Gradle built project.");
             }
 
-           // Run the application in dev mode.
+            // Run the application in dev mode.
             startDevMode(cmd, projectName, projectPath, javaHomePath, launch);
 
             // If there is a debugPort, start the job to attach the debugger to the Liberty server JVM.
@@ -345,7 +345,7 @@ public class DevModeOperations {
                 throw new Exception("Unexpected project build type: " + buildType + ". Project " + projectName
                         + "does not appear to be a Maven or Gradle built project.");
             }
-            
+
             // Run the application in dev mode.
             startDevMode(cmd, projectName, projectPath, javaHomePath, launch);
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
@@ -153,15 +153,15 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
 
         // Retrieve configuration data.
         boolean runInContainer = configuration.getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false);
-        boolean runMvnClean = configuration.getAttribute(StartTab.PROJECT_MVN_CLEAN, false);
+        boolean runProjectClean = configuration.getAttribute(StartTab.PROJECT_CLEAN, false);
         String configParms = configuration.getAttribute(StartTab.PROJECT_START_PARM, (String) null);
         String javaHomePath = JRETab.resolveJavaHome(configuration);
 
         // Process the action.
         if (runInContainer) {
-            devModeOps.startInContainer(iProject, configParms, javaHomePath, launch, mode, runMvnClean);
+            devModeOps.startInContainer(iProject, configParms, javaHomePath, launch, mode, runProjectClean);
         } else {
-            devModeOps.start(iProject, configParms, javaHomePath, launch, mode, runMvnClean);
+            devModeOps.start(iProject, configParms, javaHomePath, launch, mode, runProjectClean);
         }
 
         if (Trace.isEnabled()) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LaunchConfigurationDelegateLauncher.java
@@ -153,14 +153,15 @@ public class LaunchConfigurationDelegateLauncher extends LaunchConfigurationDele
 
         // Retrieve configuration data.
         boolean runInContainer = configuration.getAttribute(StartTab.PROJECT_RUN_IN_CONTAINER, false);
+        boolean runMvnClean = configuration.getAttribute(StartTab.PROJECT_MVN_CLEAN, false);
         String configParms = configuration.getAttribute(StartTab.PROJECT_START_PARM, (String) null);
         String javaHomePath = JRETab.resolveJavaHome(configuration);
 
         // Process the action.
         if (runInContainer) {
-            devModeOps.startInContainer(iProject, configParms, javaHomePath, launch, mode);
+            devModeOps.startInContainer(iProject, configParms, javaHomePath, launch, mode, runMvnClean);
         } else {
-            devModeOps.start(iProject, configParms, javaHomePath, launch, mode);
+            devModeOps.start(iProject, configParms, javaHomePath, launch, mode, runMvnClean);
         }
 
         if (Trace.isEnabled()) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -428,27 +428,27 @@ public class StartTab extends AbstractLaunchConfigurationTab {
      * 
      * @param parent The parent composite.
      */
-    private void createMvnCleanButton(Composite parent) {
-        mvnCleanCheckBox = new Button(parent, SWT.CHECK);
-        mvnCleanCheckBox.setText("Run maven clean");
-        mvnCleanCheckBox.setSelection(false);
-        mvnCleanCheckBox.setFont(font);
-        mvnCleanCheckBox.addSelectionListener(new SelectionAdapter() {
+	private void createMvnCleanButton(Composite parent) {
+		mvnCleanCheckBox = new Button(parent, SWT.CHECK);
+		mvnCleanCheckBox.setText("Run maven clean");
+		mvnCleanCheckBox.setSelection(false);
+		mvnCleanCheckBox.setFont(font);
+		mvnCleanCheckBox.addSelectionListener(new SelectionAdapter() {
 
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public void widgetSelected(SelectionEvent event) {
-                setDirty(true);
-                updateLaunchConfigurationDialog();
-            }
-        });
-        GridDataFactory.swtDefaults().applyTo(mvnCleanCheckBox);
+			/**
+			 * {@inheritDoc}
+			 */
+			@Override
+			public void widgetSelected(SelectionEvent event) {
+				setDirty(true);
+				updateLaunchConfigurationDialog();
+			}
+		});
+		GridDataFactory.swtDefaults().applyTo(mvnCleanCheckBox);
 
-        Label emptyColumnLabel = new Label(parent, SWT.NONE);
-        GridDataFactory.swtDefaults().applyTo(emptyColumnLabel);
-    }
+		Label emptyColumnLabel = new Label(parent, SWT.NONE);
+		GridDataFactory.swtDefaults().applyTo(emptyColumnLabel);
+	}
 
     /**
      * Returns the default start parameters.

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -63,7 +63,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     public static final String PROJECT_RUN_IN_CONTAINER = "io.openliberty.tools.eclipse.launch.project.container.run";
 
     /** Configuration map key with a value stating whether or not the associated project ran with maven clean option. */
-    public static final String PROJECT_MVN_CLEAN = "io.openliberty.tools.eclipse.launch.project.mvn.clean";
+    public static final String PROJECT_CLEAN = "io.openliberty.tools.eclipse.launch.project.clean";
     
     /** Main preference page ID. */
     public static final String MAIN_PREFERENCE_PAGE_ID = "io.openliberty.tools.eclipse.ui.preferences.page";
@@ -167,7 +167,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
             boolean runInContainer = configuration.getAttribute(PROJECT_RUN_IN_CONTAINER, false);
             runInContainerCheckBox.setSelection(runInContainer);
             
-            boolean mvnClean = configuration.getAttribute(PROJECT_MVN_CLEAN, false);
+            boolean mvnClean = configuration.getAttribute(PROJECT_CLEAN, false);
             mvnCleanCheckBox.setSelection(mvnClean);
 
             String projectName = configuration.getAttribute(PROJECT_NAME, (String) null);
@@ -263,7 +263,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
 
         configuration.setAttribute(PROJECT_RUN_IN_CONTAINER, runInContainerBool);
         
-        configuration.setAttribute(PROJECT_MVN_CLEAN, mvnCleanBool);
+        configuration.setAttribute(PROJECT_CLEAN, mvnCleanBool);
 
         configuration.setAttribute(PROJECT_START_PARM, startParamStr);
 
@@ -430,7 +430,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
      */
 	private void createMvnCleanButton(Composite parent) {
 		mvnCleanCheckBox = new Button(parent, SWT.CHECK);
-		mvnCleanCheckBox.setText("Run maven clean");
+		mvnCleanCheckBox.setText("Clean project");
 		mvnCleanCheckBox.setSelection(false);
 		mvnCleanCheckBox.setFont(font);
 		mvnCleanCheckBox.addSelectionListener(new SelectionAdapter() {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -62,7 +62,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     /** Configuration map key with a value stating whether or not the associated project ran in a container. */
     public static final String PROJECT_RUN_IN_CONTAINER = "io.openliberty.tools.eclipse.launch.project.container.run";
 
-    /** Configuration map key with a value stating whether or not the associated project ran with maven clean option. */
+    /** Configuration map key with a value stating whether or not the associated project ran with clean option. */
     public static final String PROJECT_CLEAN = "io.openliberty.tools.eclipse.launch.project.clean";
     
     /** Main preference page ID. */

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -62,6 +62,9 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     /** Configuration map key with a value stating whether or not the associated project ran in a container. */
     public static final String PROJECT_RUN_IN_CONTAINER = "io.openliberty.tools.eclipse.launch.project.container.run";
 
+    /** Configuration map key with a value stating whether or not the associated project ran with maven clean option. */
+    public static final String PROJECT_MVN_CLEAN = "io.openliberty.tools.eclipse.launch.project.mvn.clean";
+    
     /** Main preference page ID. */
     public static final String MAIN_PREFERENCE_PAGE_ID = "io.openliberty.tools.eclipse.ui.preferences.page";
 
@@ -84,6 +87,9 @@ public class StartTab extends AbstractLaunchConfigurationTab {
 
     /** Holds the run in container check box. */
     private Button runInContainerCheckBox;
+    
+    /** Holds the Maven clean check box. */
+    private Button mvnCleanCheckBox;
 
     /** DevModeOperations instance. */
     private DevModeOperations devModeOps = DevModeOperations.getInstance();
@@ -112,6 +118,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
         Composite parmsGroupComposite = createGroupComposite(mainComposite, "", 2);
         createInputParmText(parmsGroupComposite);
         createRunInContainerButton(parmsGroupComposite);
+        createMvnCleanButton(parmsGroupComposite);
 
         createLabelWithPreferenceLink(mainComposite);
     }
@@ -159,6 +166,9 @@ public class StartTab extends AbstractLaunchConfigurationTab {
 
             boolean runInContainer = configuration.getAttribute(PROJECT_RUN_IN_CONTAINER, false);
             runInContainerCheckBox.setSelection(runInContainer);
+            
+            boolean mvnClean = configuration.getAttribute(PROJECT_MVN_CLEAN, false);
+            mvnCleanCheckBox.setSelection(mvnClean);
 
             String projectName = configuration.getAttribute(PROJECT_NAME, (String) null);
             if (projectName == null) {
@@ -248,8 +258,12 @@ public class StartTab extends AbstractLaunchConfigurationTab {
         String startParamStr = startParmText.getText();
 
         boolean runInContainerBool = runInContainerCheckBox.getSelection();
+        
+        boolean mvnCleanBool = mvnCleanCheckBox.getSelection();
 
         configuration.setAttribute(PROJECT_RUN_IN_CONTAINER, runInContainerBool);
+        
+        configuration.setAttribute(PROJECT_MVN_CLEAN, mvnCleanBool);
 
         configuration.setAttribute(PROJECT_START_PARM, startParamStr);
 
@@ -404,6 +418,33 @@ public class StartTab extends AbstractLaunchConfigurationTab {
             }
         });
         GridDataFactory.swtDefaults().applyTo(runInContainerCheckBox);
+
+        Label emptyColumnLabel = new Label(parent, SWT.NONE);
+        GridDataFactory.swtDefaults().applyTo(emptyColumnLabel);
+    }
+
+    /**
+     * Creates the button entry that indicates whether or not the project should run with maven clean command.
+     * 
+     * @param parent The parent composite.
+     */
+    private void createMvnCleanButton(Composite parent) {
+        mvnCleanCheckBox = new Button(parent, SWT.CHECK);
+        mvnCleanCheckBox.setText("Run maven clean");
+        mvnCleanCheckBox.setSelection(false);
+        mvnCleanCheckBox.setFont(font);
+        mvnCleanCheckBox.addSelectionListener(new SelectionAdapter() {
+
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public void widgetSelected(SelectionEvent event) {
+                setDirty(true);
+                updateLaunchConfigurationDialog();
+            }
+        });
+        GridDataFactory.swtDefaults().applyTo(mvnCleanCheckBox);
 
         Label emptyColumnLabel = new Label(parent, SWT.NONE);
         GridDataFactory.swtDefaults().applyTo(emptyColumnLabel);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -89,7 +89,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     private Button runInContainerCheckBox;
     
     /** Holds the Maven clean check box. */
-    private Button mvnCleanCheckBox;
+    private Button projectCleanCheckBox;
 
     /** DevModeOperations instance. */
     private DevModeOperations devModeOps = DevModeOperations.getInstance();
@@ -118,7 +118,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
         Composite parmsGroupComposite = createGroupComposite(mainComposite, "", 2);
         createInputParmText(parmsGroupComposite);
         createRunInContainerButton(parmsGroupComposite);
-        createMvnCleanButton(parmsGroupComposite);
+        createProjectCleanButton(parmsGroupComposite);
 
         createLabelWithPreferenceLink(mainComposite);
     }
@@ -167,8 +167,8 @@ public class StartTab extends AbstractLaunchConfigurationTab {
             boolean runInContainer = configuration.getAttribute(PROJECT_RUN_IN_CONTAINER, false);
             runInContainerCheckBox.setSelection(runInContainer);
             
-            boolean mvnClean = configuration.getAttribute(PROJECT_CLEAN, false);
-            mvnCleanCheckBox.setSelection(mvnClean);
+            boolean projectClean = configuration.getAttribute(PROJECT_CLEAN, false);
+            projectCleanCheckBox.setSelection(projectClean);
 
             String projectName = configuration.getAttribute(PROJECT_NAME, (String) null);
             if (projectName == null) {
@@ -259,11 +259,11 @@ public class StartTab extends AbstractLaunchConfigurationTab {
 
         boolean runInContainerBool = runInContainerCheckBox.getSelection();
         
-        boolean mvnCleanBool = mvnCleanCheckBox.getSelection();
+        boolean projectCleanBool = projectCleanCheckBox.getSelection();
 
         configuration.setAttribute(PROJECT_RUN_IN_CONTAINER, runInContainerBool);
         
-        configuration.setAttribute(PROJECT_CLEAN, mvnCleanBool);
+        configuration.setAttribute(PROJECT_CLEAN, projectCleanBool);
 
         configuration.setAttribute(PROJECT_START_PARM, startParamStr);
 
@@ -428,12 +428,12 @@ public class StartTab extends AbstractLaunchConfigurationTab {
      * 
      * @param parent The parent composite.
      */
-	private void createMvnCleanButton(Composite parent) {
-		mvnCleanCheckBox = new Button(parent, SWT.CHECK);
-		mvnCleanCheckBox.setText("Clean project");
-		mvnCleanCheckBox.setSelection(false);
-		mvnCleanCheckBox.setFont(font);
-		mvnCleanCheckBox.addSelectionListener(new SelectionAdapter() {
+	private void createProjectCleanButton(Composite parent) {
+		projectCleanCheckBox = new Button(parent, SWT.CHECK);
+		projectCleanCheckBox.setText("Clean project");
+		projectCleanCheckBox.setSelection(false);
+		projectCleanCheckBox.setFont(font);
+		projectCleanCheckBox.addSelectionListener(new SelectionAdapter() {
 
 			/**
 			 * {@inheritDoc}
@@ -444,7 +444,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
 				updateLaunchConfigurationDialog();
 			}
 		});
-		GridDataFactory.swtDefaults().applyTo(mvnCleanCheckBox);
+		GridDataFactory.swtDefaults().applyTo(projectCleanCheckBox);
 
 		Label emptyColumnLabel = new Label(parent, SWT.NONE);
 		GridDataFactory.swtDefaults().applyTo(emptyColumnLabel);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -88,7 +88,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     /** Holds the run in container check box. */
     private Button runInContainerCheckBox;
     
-    /** Holds the Maven clean check box. */
+    /** Holds the project clean check box. */
     private Button projectCleanCheckBox;
 
     /** DevModeOperations instance. */
@@ -424,7 +424,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
     }
 
     /**
-     * Creates the button entry that indicates whether or not the project should run with maven clean command.
+     * Creates the button entry that indicates whether or not the project should run with project clean command.
      * 
      * @param parent The parent composite.
      */

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -7,7 +7,9 @@ Bundle-Version: 25.0.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: junit-jupiter-api,
  org.eclipse.ui,
- org.hamcrest.library
+ org.hamcrest.library,
+ org.eclipse.ui.console,
+ org.eclipse.text
 Import-Package: io.openliberty.tools.eclipse,
  io.openliberty.tools.eclipse.debug,
  io.openliberty.tools.eclipse.ui.dashboard,

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -697,7 +697,7 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
         LibertyPluginTestUtils.validateApplicationOutcome(GRADLE_APP_NAME, true, testAppPath + "/build");
         //Reads the text from the console output tab
         String consoleText =LibertyPluginTestUtils.getConsoleOutput();
-        //Assert.isTrue(consoleText.contains("clean libertyDev"));//checks if the consoleText contains the maven clean command 
+        Assert.isTrue(consoleText.contains("clean libertyDev"));//checks if the consoleText contains the clean libertyDev command 
         // If there are issues with the workspace, close the error dialog.
         pressWorkspaceErrorDialogProceedButton(bot);
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -672,7 +672,7 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
     
     /**
      * Tests the Clean project option provided under liberty run configuration option. Test will check 
-     * if the application has started and also will check for the presence of mvn clean and dev mode commands 
+     * if the application has started and also will check for the presence of project clean and dev mode commands 
      * from the console tab 
      */
     

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -62,7 +62,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.swt.widgets.Shell;
@@ -697,7 +696,7 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
         LibertyPluginTestUtils.validateApplicationOutcome(GRADLE_APP_NAME, true, testAppPath + "/build");
         //Reads the text from the console output tab
         String consoleText =LibertyPluginTestUtils.getConsoleOutput();
-        Assert.isTrue(consoleText.contains("clean libertyDev"));//checks if the consoleText contains the clean libertyDev command 
+        Assertions.assertTrue(consoleText.contains("clean libertyDev"),"Console text should contain 'clean libertyDev'");
         // If there are issues with the workspace, close the error dialog.
         pressWorkspaceErrorDialogProceedButton(bot);
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -15,6 +15,7 @@ package io.openliberty.tools.eclipse.test.it;
 import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.context;
 import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.go;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.checkRunInContainerCheckBox;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.checkRunMavenCleanCheckBox;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.deleteLibertyToolsRunConfigEntriesFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.enableLibertyTools;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getAppDebugAsMenu;
@@ -62,6 +63,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TreeItem;
@@ -954,6 +956,46 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         // ok for now.
         LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
 
+        // If there are issues with the workspace, close the error dialog.
+        pressWorkspaceErrorDialogProceedButton(bot);
+
+        // Stop dev mode.
+        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+
+        // Validate application stopped.
+        LibertyPluginTestUtils.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+
+    }
+    
+    /**
+     * Tests the Run maven clean option provided under liberty run configuration option. Test will check 
+     * if the application has started and also will check for the presence of mvn clean and dev mode commands 
+     * from the console tab 
+     */
+    
+    @Test
+    public void testRunMavenCleanCheckbox() {
+
+        // Delete any previously created configs.
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+
+        // Launch "Run Configurations" window and check "Run maven clean"
+        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START_CONFIG);
+        Shell shell = getRunConfigurationsShell();
+        checkRunMavenCleanCheckBox(shell, MVN_APP_NAME);
+
+        // No need to run here. Just Apply and Close.
+        go("Apply", shell);
+        go("Close", shell);
+
+        // Start dev mode. This should start locally.
+        launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
+
+        LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
+        //Reads the text from the console output tab
+        String consoleText =LibertyPluginTestUtils.getConsoleOutput();
+        Assert.isTrue(consoleText.contains("/mvn clean"));//checks if the consoleText contains the maven clean command 
+        Assert.isTrue(consoleText.contains("mvn io.openliberty.tools:liberty-maven-plugin:dev -Dstyle.color=always"));//checks if the consoleText contains dev mode command 
         // If there are issues with the workspace, close the error dialog.
         pressWorkspaceErrorDialogProceedButton(bot);
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -969,7 +969,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
     
     /**
      * Tests the Clean project option provided under liberty run configuration option. Test will check 
-     * if the application has started and also will check for the presence of mvn clean and dev mode commands 
+     * if the application has started and also will check for the presence of project clean and dev mode commands 
      * from the console tab 
      */
     

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -63,7 +63,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TreeItem;
@@ -994,7 +993,8 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
         //Reads the text from the console output tab
         String consoleText =LibertyPluginTestUtils.getConsoleOutput();
-        Assert.isTrue(consoleText.contains("clean io.openliberty.tools:liberty-maven-plugin:dev"));//checks if the consoleText contains the maven clean command 
+        Assertions.assertTrue(consoleText.contains("clean io.openliberty.tools:liberty-maven-plugin:dev"), 
+                "Console text should contain 'clean io.openliberty.tools:liberty-maven-plugin:dev'");
         // If there are issues with the workspace, close the error dialog.
         pressWorkspaceErrorDialogProceedButton(bot);
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -15,7 +15,7 @@ package io.openliberty.tools.eclipse.test.it;
 import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.context;
 import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.go;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.checkRunInContainerCheckBox;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.checkRunMavenCleanCheckBox;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.checkRunCleanProjectCheckBox;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.deleteLibertyToolsRunConfigEntriesFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.enableLibertyTools;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getAppDebugAsMenu;
@@ -968,21 +968,21 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
     }
     
     /**
-     * Tests the Run maven clean option provided under liberty run configuration option. Test will check 
+     * Tests the Clean project option provided under liberty run configuration option. Test will check 
      * if the application has started and also will check for the presence of mvn clean and dev mode commands 
      * from the console tab 
      */
     
     @Test
-    public void testRunMavenCleanCheckbox() {
+    public void testRunCleanProjectCheckbox() {
 
         // Delete any previously created configs.
         deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
 
-        // Launch "Run Configurations" window and check "Run maven clean"
+        // Launch "Run Configurations" window and check "Clean project"
         launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START_CONFIG);
         Shell shell = getRunConfigurationsShell();
-        checkRunMavenCleanCheckBox(shell, MVN_APP_NAME);
+        checkRunCleanProjectCheckBox(shell, MVN_APP_NAME);
 
         // No need to run here. Just Apply and Close.
         go("Apply", shell);
@@ -994,8 +994,8 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
         //Reads the text from the console output tab
         String consoleText =LibertyPluginTestUtils.getConsoleOutput();
-        Assert.isTrue(consoleText.contains("/mvn clean"));//checks if the consoleText contains the maven clean command 
-        Assert.isTrue(consoleText.contains("mvn io.openliberty.tools:liberty-maven-plugin:dev -Dstyle.color=always"));//checks if the consoleText contains dev mode command 
+        Assert.isTrue(consoleText.contains("clean io.openliberty.tools:liberty-maven-plugin:dev -Dstyle.color=always"));//checks if the consoleText contains the maven clean command 
+       // Assert.isTrue(consoleText.contains("mvn io.openliberty.tools:liberty-maven-plugin:dev -Dstyle.color=always"));//checks if the consoleText contains dev mode command 
         // If there are issues with the workspace, close the error dialog.
         pressWorkspaceErrorDialogProceedButton(bot);
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -994,8 +994,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
         //Reads the text from the console output tab
         String consoleText =LibertyPluginTestUtils.getConsoleOutput();
-        Assert.isTrue(consoleText.contains("clean io.openliberty.tools:liberty-maven-plugin:dev -Dstyle.color=always"));//checks if the consoleText contains the maven clean command 
-       // Assert.isTrue(consoleText.contains("mvn io.openliberty.tools:liberty-maven-plugin:dev -Dstyle.color=always"));//checks if the consoleText contains dev mode command 
+        Assert.isTrue(consoleText.contains("clean io.openliberty.tools:liberty-maven-plugin:dev"));//checks if the consoleText contains the maven clean command 
         // If there are issues with the workspace, close the error dialog.
         pressWorkspaceErrorDialogProceedButton(bot);
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
@@ -14,6 +14,11 @@ package io.openliberty.tools.eclipse.test.it.utils;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.eclipse.ui.console.ConsolePlugin;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IConsoleManager;
+import org.eclipse.ui.console.TextConsole;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -265,6 +270,23 @@ public class LibertyPluginTestUtils {
         if (preferences == null) {
             assertNotNull(preferences, "preferences file not found for Liberty Tools");
         }
+    }
+    
+    /**
+     * Reads and returns the text from the console output tab 
+     * @return
+     */
+    public static String getConsoleOutput() {
+        IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+        IConsole[] consoles = consoleManager.getConsoles();
+
+        for (IConsole console : consoles) {
+            if (console instanceof TextConsole) {
+                TextConsole textConsole = (TextConsole) console;
+                return textConsole.getDocument().get();
+            }
+        }
+        return "";
     }
 
     /**

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
@@ -279,14 +279,19 @@ public class LibertyPluginTestUtils {
     public static String getConsoleOutput() {
         IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
         IConsole[] consoles = consoleManager.getConsoles();
-
+        StringBuilder result = new StringBuilder();
+        
+        // Iterate through each console
         for (IConsole console : consoles) {
             if (console instanceof TextConsole) {
                 TextConsole textConsole = (TextConsole) console;
-                return textConsole.getDocument().get();
+                // Append the console output to the result
+                result.append(textConsole.getDocument().get());
             }
         }
-        return "";
+        
+        // Return the concatenated result from all text consoles
+        return result.toString();
     }
 
     /**

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -664,14 +664,14 @@ public class SWTBotPluginOperations {
      * @param shell
      * @param runDebugConfigName
      */
-    public static void checkRunMavenCleanCheckBox(Shell shell, String runDebugConfigName) {
+    public static void checkRunCleanProjectCheckBox(Shell shell, String runDebugConfigName) {
 
         Object libertyConfigTree = getLibertyTreeItem(shell);
 
         Object appConfigEntry = find(runDebugConfigName, libertyConfigTree,
                 Option.factory().useContains(true).widgetClass(TreeItem.class).build());
         go(appConfigEntry);
-        Object button = find("Run maven clean", appConfigEntry, Option.factory().widgetClass(Button.class).build());
+        Object button = find("Clean project", appConfigEntry, Option.factory().widgetClass(Button.class).build());
 
         go(button);
     }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -660,7 +660,7 @@ public class SWTBotPluginOperations {
     }
     
     /**
-     * Selects the Run Maven clean option under liberty in run configurations
+     * Selects the project clean option under liberty in run configurations
      * @param shell
      * @param runDebugConfigName
      */

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -658,6 +658,23 @@ public class SWTBotPluginOperations {
 
         go(button);
     }
+    
+    /**
+     * Selects the Run Maven clean option under liberty in run configurations
+     * @param shell
+     * @param runDebugConfigName
+     */
+    public static void checkRunMavenCleanCheckBox(Shell shell, String runDebugConfigName) {
+
+        Object libertyConfigTree = getLibertyTreeItem(shell);
+
+        Object appConfigEntry = find(runDebugConfigName, libertyConfigTree,
+                Option.factory().useContains(true).widgetClass(TreeItem.class).build());
+        go(appConfigEntry);
+        Object button = find("Run maven clean", appConfigEntry, Option.factory().widgetClass(Button.class).build());
+
+        go(button);
+    }
 
     public static Object getAppInPackageExplorerTree(String appName) {
         openJavaPerspectiveViaMenu();


### PR DESCRIPTION
Fixes #239 

changes includes : 
Adding a new check box to enable project clean option under liberty in run configurations .
Test cases for the new Run project clean check box added for both Gradle and maven projects
