### PR TITLE
2506 prep

### DIFF
--- a/.github/workflows/run-regression-tests.yml
+++ b/.github/workflows/run-regression-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         runtime: [ linux, mac, windows ]
-        targetPlatform: [ 4Q2024 ]
+        targetPlatform: [ 1Q2025 ]
         include:
         - runtime: linux
           os: ubuntu-latest

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools Support for Language Servers
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.lsp4e;singleton:=true
-Bundle-Version: 25.0.3.qualifier
+Bundle-Version: 25.0.6.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.ls.plugin.LibertyToolsLSPlugin
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: io.openliberty.tools.eclipse.lsp4e

--- a/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
+++ b/bundles/io.openliberty.tools.eclipse.lsp4e/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.openliberty.tools.eclipse</groupId>
         <artifactId>parent</artifactId>
-        <version>25.0.3-SNAPSHOT</version>
+        <version>25.0.6-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     

--- a/bundles/io.openliberty.tools.eclipse.product/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.product/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.product;singleton:=true
-Bundle-Version: 25.0.3.qualifier
+Bundle-Version: 25.0.6.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: io.openliberty.tools.eclipse
 Bundle-ActivationPolicy: lazy

--- a/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Liberty Tools UI
 Bundle-Vendor: Open Liberty
 Bundle-SymbolicName: io.openliberty.tools.eclipse.ui;singleton:=true
-Bundle-Version: 25.0.3.qualifier
+Bundle-Version: 25.0.6.qualifier
 Bundle-Activator: io.openliberty.tools.eclipse.LibertyDevPlugin
 Export-Package: io.openliberty.tools.eclipse;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.debug;x-friends:="io.openliberty.tools.eclipse.tests",

--- a/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/io.openliberty.tools.eclipse.ui/META-INF/MANIFEST.MF
@@ -13,7 +13,9 @@ Export-Package: io.openliberty.tools.eclipse;x-friends:="io.openliberty.tools.ec
  io.openliberty.tools.eclipse.ui.launch.shortcuts;x-friends:="io.openliberty.tools.eclipse.tests",
  io.openliberty.tools.eclipse.ui.preferences;x-friends:="io.openliberty.tools.eclipse.tests"
 Require-Bundle: org.eclipse.ui,
- org.eclipse.m2e.maven.runtime
+ org.eclipse.m2e.maven.runtime,
+ org.eclipse.jdt.debug.ui;bundle-version="3.14.0",
+ org.eclipse.jdt.debug;bundle-version="3.22.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: io.openliberty.tools.eclipse.ui
 Bundle-ActivationPolicy: lazy
@@ -28,10 +30,6 @@ Import-Package: org.eclipse.cdt.launch.ui,
  org.eclipse.debug.core.commands,
  org.eclipse.debug.core.model,
  org.eclipse.debug.core.sourcelookup,
- org.eclipse.debug.internal.core.commands,
- org.eclipse.debug.internal.ui,
- org.eclipse.debug.internal.ui.actions,
- org.eclipse.debug.internal.ui.commands.actions,
  org.eclipse.debug.ui,
  org.eclipse.debug.ui.actions,
  org.eclipse.debug.ui.sourcelookup,
@@ -39,9 +37,6 @@ Import-Package: org.eclipse.cdt.launch.ui,
  org.eclipse.jdt.core,
  org.eclipse.jdt.debug.core,
  org.eclipse.jdt.debug.ui.launchConfigurations,
- org.eclipse.jdt.internal.debug.core.model,
- org.eclipse.jdt.internal.debug.ui,
- org.eclipse.jdt.internal.debug.ui.snippeteditor,
  org.eclipse.jdt.launching,
  org.eclipse.jdt.launching.sourcelookup.containers,
  org.eclipse.jem.util.emf.workbench,

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertyHotCodeReplaceErrorDialog.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertyHotCodeReplaceErrorDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2024 IBM Corporation and others.
+* Copyright (c) 2024, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -39,8 +39,8 @@ import io.openliberty.tools.eclipse.ui.launch.StartTab;
 public class LibertyHotCodeReplaceErrorDialog extends HotCodeReplaceErrorDialog {
 
     public LibertyHotCodeReplaceErrorDialog(Shell parentShell, String dialogTitle, String message, IStatus status, String preferenceKey,
-            String toggleMessage, IPreferenceStore store, IDebugTarget target) {
-        super(parentShell, dialogTitle, message, status, preferenceKey, toggleMessage, store, target);
+            String toggleMessage1, String toggleMessage2, IPreferenceStore store, IDebugTarget target) {
+        super(parentShell, dialogTitle, message, status, preferenceKey, toggleMessage1, toggleMessage2, store, target);
     }
 
     @Override

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertyHotCodeReplaceListener.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/debug/LibertyHotCodeReplaceListener.java
@@ -22,7 +22,6 @@ import org.eclipse.jdt.debug.core.IJavaDebugTarget;
 import org.eclipse.jdt.debug.core.IJavaHotCodeReplaceListener;
 import org.eclipse.jdt.internal.debug.core.model.JDIDebugTarget;
 import org.eclipse.jdt.internal.debug.ui.DebugUIMessages;
-import org.eclipse.jdt.internal.debug.ui.HotCodeReplaceErrorDialog;
 import org.eclipse.jdt.internal.debug.ui.IJDIPreferencesConstants;
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
 import org.eclipse.jdt.internal.debug.ui.snippeteditor.ScrapbookLauncher;
@@ -161,7 +160,7 @@ public class LibertyHotCodeReplaceListener implements IJavaHotCodeReplaceListene
                     return;
                 }
                 Shell shell = JDIDebugUIPlugin.getActiveWorkbenchShell();
-                HotCodeReplaceErrorDialog dialog = new HotCodeReplaceErrorDialog(shell, dialogTitle, message, status,
+                LibertyHotCodeReplaceErrorDialog dialog = new LibertyHotCodeReplaceErrorDialog(shell, dialogTitle, message, status,
                         IJDIPreferencesConstants.PREF_ALERT_OBSOLETE_METHODS, toggleMessage, toggleMessage2,
                         JDIDebugUIPlugin.getDefault().getPreferenceStore(), target);
                 dialog.setBlockOnOpen(false);

--- a/ci/jenkins/run-tests
+++ b/ci/jenkins/run-tests
@@ -38,7 +38,7 @@ pipeline {
             }
         }
         
-        stage('Test on Eclipse 4Q2024') {
+        stage('Test on Eclipse 1Q2025') {
             steps {
                 dir('liberty-tools-eclipse') {
                     script {
@@ -48,16 +48,16 @@ pipeline {
                                 sh '''
                                    MVNPATH="$(dirname $(which mvn))/.."
                                    GRADLEPATH="$(dirname $(which gradle))/.."
-                                   mvn clean verify -DmvnLogFile -DmvnPath=$MVNPATH -DgradlePath=$GRADLEPATH -Dtycho.disableP2Mirrors=true -Declipse.target=4Q2024 -Dosgi.debug=./tests/resources/ci/debug.opts -DtestAppImportWait=120000 -Dtycho.showEclipseLog -e -X
+                                   mvn clean verify -DmvnLogFile -DmvnPath=$MVNPATH -DgradlePath=$GRADLEPATH -Dtycho.disableP2Mirrors=true -Declipse.target=1Q2025 -Dosgi.debug=./tests/resources/ci/debug.opts -DtestAppImportWait=120000 -Dtycho.showEclipseLog -e -X
                                 '''
                             }
                         } finally {
                             sh "find tests -type f -name \"lte-dev-mode-output-*.log\""
                             sh "mkdir lte-dev-mode-output-logs && find tests -type f -name \"lte-dev-mode-output-*.log\" -exec cp {} lte-dev-mode-output-logs \\;"
                             sh "zip -r lte-dev-mode-output-logs.zip lte-dev-mode-output-logs"
-                            sh "cd tests/target/surefire-reports && zip -r 4Q2024-test-reports.zip ."
+                            sh "cd tests/target/surefire-reports && zip -r 1Q2025-test-reports.zip ."
                             
-                            archiveArtifacts artifacts: 'tests/target/surefire-reports/4Q2024-test-reports.zip', fingerprint: true
+                            archiveArtifacts artifacts: 'tests/target/surefire-reports/1Q2025-test-reports.zip', fingerprint: true
                             archiveArtifacts artifacts: 'lte-dev-mode-output-logs.zip', fingerprint: true
                             archiveArtifacts artifacts: 'tests/target/work/data/.metadata/.log', fingerprint: true
                         }

--- a/features/io.openliberty.tools.eclipse.feature/feature.xml
+++ b/features/io.openliberty.tools.eclipse.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="io.openliberty.tools.eclipse"
       label="%featureName"
-      version="25.0.3.qualifier"
+      version="25.0.6.qualifier"
     plugin="io.openliberty.tools.eclipse.product"
     provider-name="%providerName">
 
@@ -28,21 +28,21 @@
          id="io.openliberty.tools.eclipse.ui"
          download-size="0"
          install-size="0"
-         version="25.0.3.qualifier"
+         version="25.0.6.qualifier"
          unpack="false"/>
 
    <plugin
          id="io.openliberty.tools.eclipse.lsp4e"
          download-size="0"
          install-size="0"
-         version="25.0.3.qualifier"
+         version="25.0.6.qualifier"
          unpack="false"/>
 
    <plugin
          id="io.openliberty.tools.eclipse.product"
          download-size="0"
          install-size="0"
-         version="25.0.3.qualifier"
+         version="25.0.6.qualifier"
          unpack="false"/>
 
 </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         
         <!-- default version of the eclipse IDE to run tests against -->
         <!-- must be one of the target platform files defined in this project under releng -->
-        <eclipse.target>4Q2024</eclipse.target>
+        <eclipse.target>1Q2025</eclipse.target>
             
 	</properties>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.openliberty.tools.eclipse</groupId>
 	<artifactId>parent</artifactId>
-	<version>25.0.3-SNAPSHOT</version>
+	<version>25.0.6-SNAPSHOT</version>
 	<packaging>pom</packaging>
     <licenses>
       <license>
@@ -196,7 +196,7 @@
 						<artifact>
 							<groupId>io.openliberty.tools.eclipse</groupId>
 							<artifactId>target-platform-${eclipse.target}</artifactId>
-							<version>25.0.3-SNAPSHOT</version>
+							<version>25.0.6-SNAPSHOT</version>
 							<file>target-platform-${eclipse.target}</file>
 						</artifact>
 					</target>

--- a/releng/io.openliberty.tools.update/category.xml
+++ b/releng/io.openliberty.tools.update/category.xml
@@ -12,7 +12,7 @@
       IBM Corporation - initial implementation
 -->
 <site>
-    <feature url="features/io.openliberty.tools.eclipse_25.0.3.qualifier.liberty.jar" id="io.openliberty.tools.eclipse" version="25.0.3.qualifier">
+    <feature url="features/io.openliberty.tools.eclipse_25.0.6.qualifier.liberty.jar" id="io.openliberty.tools.eclipse" version="25.0.6.qualifier">
         <category name="io.openliberty.tools.eclipse"/>
     </feature>
 

--- a/releng/target-platform-1Q2025/.project
+++ b/releng/target-platform-1Q2025/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>target-platform-4Q2024</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/releng/target-platform-1Q2025/target-platform-1Q2025.target
+++ b/releng/target-platform-1Q2025/target-platform-1Q2025.target
@@ -30,6 +30,8 @@
             <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="1.3.9.202411190713"/>
             <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="1.3.6.202409052135"/>
             <unit id="org.eclipse.m2e.lemminx.feature.feature.group" version="2.6.0.20250208-1755"/>
+            <unit id="org.eclipse.jdt.debug.ui" version="3.14.0.v20250211-0925"/>
+            <unit id="org.eclipse.jdt.debug" version="3.22.0.v20250124-1739"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository"/>

--- a/releng/target-platform-1Q2025/target-platform-1Q2025.target
+++ b/releng/target-platform-1Q2025/target-platform-1Q2025.target
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<!--
+  Copyright (c) 2025 IBM Corporation and others.
+  
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Contributors:
+      IBM Corporation - initial implementation
+--><target includeMode="feature" name="target-platform.target" sequenceNumber="16">
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/releases/2025-03/"/>
+            <unit id="org.eclipse.jdt.feature.group" version="3.20.100.v20250228-0140"/>
+            <unit id="org.eclipse.ui.trace" version="1.3.400.v20240801-2123"/>
+            <unit id="org.eclipse.emf.sdk.feature.group" version="2.41.0.v20241204-1554"/>
+            <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.1600.v20250228-0640"/>
+            <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.6.1.20231024-1618"/>
+            <unit id="org.eclipse.sdk.feature.group" version="4.35.0.v20250228-0640"/>
+            <unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
+            <unit id="org.junit" version="4.13.2.v20240929-1000"/>
+            <unit id="junit-jupiter-api" version="5.11.4"/>
+            <unit id="junit-jupiter-engine" version="5.11.4"/>
+            <unit id="org.eclipse.lsp4e" version="0.18.17.202502012025"/>
+            <unit id="org.eclipse.lsp4e.jdt" version="0.13.4.202412191700"/>
+            <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="1.3.9.202411190713"/>
+            <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="1.3.6.202409052135"/>
+            <unit id="org.eclipse.m2e.lemminx.feature.feature.group" version="2.6.0.20250208-1755"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository"/>
+            <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
+            <unit id="ch.qos.logback.slf4j.source" version="1.2.3.v20200428-2012"/>
+            <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
+            <unit id="org.slf4j.api.source" version="1.7.30.v20200204-2150"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/technology/swtbot/releases/4.2.1"/>
+            <unit id="org.eclipse.swtbot.eclipse.feature.group" version="4.2.1.202406141605"/>
+            <unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="4.2.1.202406141605"/>
+            <unit id="org.eclipse.swtbot.feature.group" version="4.2.1.202406141605"/>
+            <unit id="org.eclipse.swtbot.forms.feature.group" version="4.2.1.202406141605"/>
+            <unit id="org.eclipse.swtbot.ide.feature.group" version="4.2.1.202406141605"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/cdt/releases/11.6"/>
+            <unit id="org.eclipse.cdt.launch" version="10.4.400.202402230238"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="http://download.eclipse.org/lsp4mp/releases/0.13.2/repository/"/>
+            <unit id="org.eclipse.lsp4mp.jdt.core" version="0.13.2.20241022-1352"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.24.0/"/>
+            <unit id="org.eclipse.lsp4j" version="0.0.0"/>
+            <unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/jdtls/milestones/1.42.0/repository/"/>
+            <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/buildship/updates/e427/releases/3.x/3.1.9.v20240115-1636/"/>
+            <unit id="org.eclipse.buildship.ui" version="3.1.9.v20240115-1636"/>
+        </location>
+	    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		    <repository location="https://download.eclipse.org/lsp4jakarta/releases/0.2.3/repository/"/>
+		    <unit id="org.eclipse.lsp4jakarta.jdt.core" version="0.2.3"/>
+	    </location>
+	    <location includeDependencyDepth="none" includeDependencyScopes="compile" missingManifest="generate" type="Maven">
+		    <dependencies>
+			    <dependency>
+				    <groupId>net.bytebuddy</groupId>
+				    <artifactId>byte-buddy-agent</artifactId>
+				    <version>1.14.18</version>
+				    <type>jar</type>
+			    </dependency>
+			    <dependency>
+				    <groupId>net.bytebuddy</groupId>
+				    <artifactId>byte-buddy</artifactId>
+				    <version>1.14.18</version>
+				    <type>jar</type>
+			    </dependency>
+			    <dependency>
+				    <groupId>org.mockito</groupId>
+				    <artifactId>mockito-core</artifactId>
+				    <version>5.12.0</version>
+				    <type>jar</type>
+			    </dependency>
+			    <dependency>
+				    <groupId>org.mockito</groupId>
+				    <artifactId>mockito-junit-jupiter</artifactId>
+				    <version>5.12.0</version>
+				    <type>jar</type>
+			    </dependency>
+			    <dependency>
+				    <groupId>org.objenesis</groupId>
+				    <artifactId>objenesis</artifactId>
+				    <version>3.4</version>
+				    <type>jar</type>
+			    </dependency>
+		    </dependencies>
+	    </location>
+    </locations>
+</target>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-Copyright: Copyright (c) 2022, 2025 IBM Corporation and others.
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: io.openliberty.tools.eclipse.tests
-Bundle-Version: 25.0.3.qualifier
+Bundle-Version: 25.0.6.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: junit-jupiter-api,
  org.eclipse.ui,

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.openliberty.tools.eclipse</groupId>
         <artifactId>parent</artifactId>
-        <version>25.0.3-SNAPSHOT</version>
+        <version>25.0.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.openliberty.tools.eclipse.tests</artifactId>

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -510,6 +510,14 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
             // Run Tests.
             launchDashboardAction(GRADLE_APP_NAME, DashboardView.APP_MENU_ACTION_RUN_TESTS);
 
+            // Sleep for a bit to allow tests to complete and not have the console tab take focus
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                // Handle interruption
+                Thread.currentThread().interrupt();
+            }
+
             // Validate that the reports were generated and the the browser editor was launched.
             LibertyPluginTestUtils.validateTestReportExists(pathToTestReport);
             if (LibertyPluginTestUtils.isInternalBrowserSupportAvailable()) {

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -385,6 +385,10 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
 
         // Doing a 'clean' first in case server was started previously and terminated abruptly
         String cmd = CommandBuilder.getGradleCommandLine(wrapperProject.toString(), "clean libertyDev", null);
+
+        if (LibertyPluginTestUtils.onWindows()) {
+            cmd = "cmd.exe /c" + cmd;
+        }
         String[] cmdParts = cmd.split(" ");
         ProcessBuilder pb = new ProcessBuilder(cmdParts).inheritIO().directory(wrapperProject.toFile()).redirectErrorStream(true);
         pb.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
@@ -514,7 +518,7 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
         } finally {
             // Stop dev mode.
             launchDashboardAction(GRADLE_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
-        	
+
             // Validate application stopped.
             LibertyPluginTestUtils.validateLibertyServerStopped(testAppPath + "/build");
 
@@ -674,11 +678,11 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
             LibertyPluginTestUtils.validateLibertyServerStopped(testAppPath + "/build");
         }
     }
-    
+
     /**
-     * Tests the Clean project option provided under liberty run configuration option. Test will check 
-     * if the application has started and also will check for the presence of project clean and dev mode commands 
-     * from the console tab 
+     * Tests the Clean project option provided under liberty run configuration option. Test will check
+     * if the application has started and also will check for the presence of project clean and dev mode commands
+     * from the console tab
      */
 
     @Test
@@ -706,9 +710,9 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
         }
 
         LibertyPluginTestUtils.validateApplicationOutcome(GRADLE_APP_NAME, true, testAppPath + "/build");
-        //Reads the text from the console output tab
-        String consoleText =LibertyPluginTestUtils.getConsoleOutput();
-        Assertions.assertTrue(consoleText.contains("clean libertyDev"),"Console text should contain 'clean libertyDev'");
+        // Reads the text from the console output tab
+        String consoleText = LibertyPluginTestUtils.getConsoleOutput();
+        Assertions.assertTrue(consoleText.contains("clean libertyDev"), "Console text should contain 'clean libertyDev'");
         // If there are issues with the workspace, close the error dialog.
         pressWorkspaceErrorDialogProceedButton(bot);
 
@@ -716,7 +720,7 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
         launchDashboardAction(GRADLE_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
 
         // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped( testAppPath + "/build");
+        LibertyPluginTestUtils.validateLibertyServerStopped(testAppPath + "/build");
 
     }
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -14,8 +14,8 @@ package io.openliberty.tools.eclipse.test.it;
 
 import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.context;
 import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.go;
-import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.checkRunInContainerCheckBox;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.checkRunCleanProjectCheckBox;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.checkRunInContainerCheckBox;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.deleteLibertyToolsRunConfigEntriesFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.enableLibertyTools;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getAppDebugAsMenu;
@@ -416,6 +416,11 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         // making it look like an "outer", actual test is failing, so we skip the tests.
         String cmd = CommandBuilder.getMavenCommandLine(projAbsolutePath.toString(),
                 "clean io.openliberty.tools:liberty-maven-plugin:dev -DskipITs=true", null);
+
+        if (LibertyPluginTestUtils.onWindows()) {
+            cmd = "cmd.exe /c" + cmd;
+        }
+
         String[] cmdParts = cmd.split(" ");
         ProcessBuilder pb = new ProcessBuilder(cmdParts).inheritIO().directory(projAbsolutePath.toFile()).redirectErrorStream(true);
         pb.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
@@ -966,9 +971,9 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
     }
 
     /**
-     * Tests the Clean project option provided under liberty run configuration option. Test will check 
-     * if the application has started and also will check for the presence of project clean and dev mode commands 
-     * from the console tab 
+     * Tests the Clean project option provided under liberty run configuration option. Test will check
+     * if the application has started and also will check for the presence of project clean and dev mode commands
+     * from the console tab
      */
 
     @Test
@@ -990,9 +995,9 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
 
         LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true, projectPath.toAbsolutePath().toString() + "/target/liberty");
-        //Reads the text from the console output tab
-        String consoleText =LibertyPluginTestUtils.getConsoleOutput();
-        Assertions.assertTrue(consoleText.contains("clean io.openliberty.tools:liberty-maven-plugin:dev"), 
+        // Reads the text from the console output tab
+        String consoleText = LibertyPluginTestUtils.getConsoleOutput();
+        Assertions.assertTrue(consoleText.contains("clean io.openliberty.tools:liberty-maven-plugin:dev"),
                 "Console text should contain 'clean io.openliberty.tools:liberty-maven-plugin:dev'");
         // If there are issues with the workspace, close the error dialog.
         pressWorkspaceErrorDialogProceedButton(bot);

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -308,6 +308,7 @@ public class SWTBotPluginOperations {
 
         Object dashboardView = MagicWidgetFinder.findGlobal(DASHBOARD_VIEW_TITLE);
         Object project = MagicWidgetFinder.find(appName, dashboardView, Option.factory().widgetClass(TableItem.class).build());
+        MagicWidgetFinder.go(project);
         MagicWidgetFinder.context(project, action);
     }
 
@@ -658,10 +659,10 @@ public class SWTBotPluginOperations {
 
         go(button);
     }
-    
 
     /**
      * Selects the project clean option under liberty in run configurations
+     * 
      * @param shell
      * @param runDebugConfigName
      */


### PR DESCRIPTION
This PR:

1. Updates the LTE version to 25.0.6
2. Creates a target platform file for Eclipse 2025-03 and sets this as the default
3. Fixes a breaking change in the HCR error dialog that we are extending.
4. Creates a hard requirement on the JDT levels moving forward to accommodate the break. If a user installs LTE 25.0.6 on an older version of Eclipse, the installation will fail. 