### PR TITLE
Added Test case for enhanced debug mode

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -1059,7 +1059,7 @@ public class DevModeOperations {
 
         return path;
     }
-    
+
     /**
      * Returns the project instance associated with the currently selected view object in the workspace.
      *

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -1060,6 +1060,22 @@ public class DevModeOperations {
         return path;
     }
 
+	/**
+	 * Returns the path of the xml file containing app monitoring configuration.
+	 *
+	 * @param projectPath The project's path.
+	 *
+	 * @return The custom path of the xml file containing the config to
+	 *         enable/disable app monitoring.
+	 */
+	public static Path getMavenXmlFilePathInOverridesDirectory(String projectPath) {
+
+		Path path = Paths.get(projectPath, "target", "liberty", "wlp", "usr", "servers", "defaultServer",
+				"configDropins", "overrides", "disableApplicationMonitor.xml");
+
+		return path;
+	}
+    
     /**
      * Returns the project instance associated with the currently selected view object in the workspace.
      *

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -1059,22 +1059,6 @@ public class DevModeOperations {
 
         return path;
     }
-
-	/**
-	 * Returns the path of the xml file containing app monitoring configuration.
-	 *
-	 * @param projectPath The project's path.
-	 *
-	 * @return The custom path of the xml file containing the config to
-	 *         enable/disable app monitoring.
-	 */
-	public static Path getMavenXmlFilePathInOverridesDirectory(String projectPath) {
-
-		Path path = Paths.get(projectPath, "target", "liberty", "wlp", "usr", "servers", "defaultServer",
-				"configDropins", "overrides", "disableApplicationMonitor.xml");
-
-		return path;
-	}
     
     /**
      * Returns the project instance associated with the currently selected view object in the workspace.

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDebuggerTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDebuggerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import io.openliberty.tools.eclipse.DevModeOperations;
 import io.openliberty.tools.eclipse.test.it.utils.LibertyPluginTestUtils;
 import io.openliberty.tools.eclipse.ui.dashboard.DashboardView;
 
@@ -188,5 +189,128 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
 
         // Validate button enabled
         Assertions.assertTrue(getDebuggerConnectMenuForDebugObject(launch).isEnabled());
+    }
+    
+    /**
+     * Tests the "Enhanced debug monitoring", that the XML file is added in the
+     * overrides directory during the debug mode.
+     * 
+     */
+    @Test
+    public void testEnhancedDebugMode_configXmlFilePresentOnDebugMode() {
+    	// Start dev mode.
+    	launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_DEBUG);
+
+    	// Validate application is up and running.
+    	LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true,
+    			projectPath.toAbsolutePath().toString() + "/target/liberty");
+
+    	// If there are issues with the workspace, close the error dialog.
+    	pressWorkspaceErrorDialogProceedButton(bot);
+
+    	// Validate app monitoring is disabled by checking the xml file is present in
+    	// the overrides directory.
+    	Path pathToXmlFile = DevModeOperations.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
+    	boolean isDisabled = LibertyPluginTestUtils.validateXmlFilePresentInOverridesDirectory(pathToXmlFile);
+
+    	if (!isDisabled) {
+    		Assertions.fail("Xml file not found on " + pathToXmlFile + ".");
+    	}
+    	// Stop dev mode.
+    	launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+
+    	// Validate application stopped.
+    	LibertyPluginTestUtils
+    	.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+
+    }
+
+    /**
+     * Tests the "Enhanced debug monitoring", that the XML file is added in the
+     * overrides directory during the debug mode.
+     * 
+     */
+    @Test
+    public void testEnhancedDebugMode_onStopRemoveXmlFile() {
+    	boolean isDisabled = false;
+    	// Start dev mode.
+    	launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_DEBUG);
+
+    	// Validate application is up and running.
+    	LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true,
+    			projectPath.toAbsolutePath().toString() + "/target/liberty");
+
+    	// If there are issues with the workspace, close the error dialog.
+    	pressWorkspaceErrorDialogProceedButton(bot);
+
+    	// Validate app monitoring is disabled by checking the xml file is present in
+    	// the overrides directory.
+    	Path pathToXmlFile = DevModeOperations.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
+    	isDisabled = LibertyPluginTestUtils.validateXmlFilePresentInOverridesDirectory(pathToXmlFile);
+
+    	if (!isDisabled) {
+    		Assertions.fail("Xml file not found on " + pathToXmlFile + ".");
+    	}
+    	// Stop dev mode.
+    	launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+
+    	// Validate application stopped.
+    	LibertyPluginTestUtils
+    	.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+
+    	isDisabled = LibertyPluginTestUtils.validateXmlFileNotPresentInOverridesDirectory(pathToXmlFile);
+    	if (!isDisabled) {
+    		Assertions.fail("Xml file " + pathToXmlFile
+    				+ " is not removed from overrides directory on disconnecting debugger.");
+    	}
+    }
+
+    /**
+     * Tests that the XML file is removed from the overrides directory when the
+     * debugger is disconnected.
+     */
+    @Test
+    public void testEnhancedDebugMode_disconnectDebuggerRemoveXmlFile() {
+    	boolean isDisabled = false;
+
+    	// Start dev mode.
+    	launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_DEBUG);
+
+    	// Validate application is up and running.
+    	LibertyPluginTestUtils.validateApplicationOutcome(MVN_APP_NAME, true,
+    			projectPath.toAbsolutePath().toString() + "/target/liberty");
+
+    	// If there are issues with the workspace, close the error dialog.
+    	pressWorkspaceErrorDialogProceedButton(bot);
+
+    	// Validate app monitoring is disabled by checking the xml file is present in
+    	// the overrides directory.
+    	Path pathToXmlFile = DevModeOperations.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
+    	isDisabled = LibertyPluginTestUtils.validateXmlFilePresentInOverridesDirectory(pathToXmlFile);
+    	if (!isDisabled) {
+    		Assertions.fail("Xml file not found on " + pathToXmlFile + ".");
+    	}
+
+    	// Verify button is disabled
+    	Object launch = getObjectInDebugView(MVN_APP_NAME + " [Liberty]");
+    	SWTBotMenu connectDebuggerMenu = getDebuggerConnectMenuForDebugObject(launch);
+    	Assertions.assertFalse(connectDebuggerMenu.isEnabled());
+
+    	// Disconnected Debugger
+    	Object debugTarget = getObjectInDebugView("Liberty Application Debug");
+    	disconnectDebugTarget(debugTarget);
+
+    	isDisabled = LibertyPluginTestUtils.validateXmlFileNotPresentInOverridesDirectory(pathToXmlFile);
+    	if (!isDisabled) {
+    		Assertions.fail("Xml file " + pathToXmlFile
+    				+ " is not removed from overrides directory on disconnecting debugger.");
+    	}
+    	// Stop dev mode.
+    	launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+
+    	// Validate application stopped.
+    	LibertyPluginTestUtils
+    	.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
+
     }
 }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDebuggerTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDebuggerTest.java
@@ -210,7 +210,7 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
 
     	// Validate app monitoring is disabled by checking the xml file is present in
     	// the overrides directory.
-    	Path pathToXmlFile = DevModeOperations.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
+    	Path pathToXmlFile = LibertyPluginTestUtils.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
     	boolean isDisabled = LibertyPluginTestUtils.validateXmlFilePresentInOverridesDirectory(pathToXmlFile);
 
     	if (!isDisabled) {
@@ -245,7 +245,7 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
 
     	// Validate app monitoring is disabled by checking the xml file is present in
     	// the overrides directory.
-    	Path pathToXmlFile = DevModeOperations.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
+    	Path pathToXmlFile = LibertyPluginTestUtils.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
     	isDisabled = LibertyPluginTestUtils.validateXmlFilePresentInOverridesDirectory(pathToXmlFile);
 
     	if (!isDisabled) {
@@ -285,7 +285,7 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
 
     	// Validate app monitoring is disabled by checking the xml file is present in
     	// the overrides directory.
-    	Path pathToXmlFile = DevModeOperations.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
+    	Path pathToXmlFile = LibertyPluginTestUtils.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
     	isDisabled = LibertyPluginTestUtils.validateXmlFilePresentInOverridesDirectory(pathToXmlFile);
     	if (!isDisabled) {
     		Assertions.fail("Xml file not found on " + pathToXmlFile + ".");

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDebuggerTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotDebuggerTest.java
@@ -211,9 +211,9 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
     	// Validate app monitoring is disabled by checking the xml file is present in
     	// the overrides directory.
     	Path pathToXmlFile = LibertyPluginTestUtils.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
-    	boolean isDisabled = LibertyPluginTestUtils.validateXmlFilePresentInOverridesDirectory(pathToXmlFile);
+    	boolean isExist = LibertyPluginTestUtils.appMonitorDisabledXmlExists(pathToXmlFile);
 
-    	if (!isDisabled) {
+    	if (!isExist) {
     		Assertions.fail("Xml file not found on " + pathToXmlFile + ".");
     	}
     	// Stop dev mode.
@@ -232,7 +232,7 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
      */
     @Test
     public void testEnhancedDebugMode_onStopRemoveXmlFile() {
-    	boolean isDisabled = false;
+    	boolean isExist = false;
     	// Start dev mode.
     	launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_DEBUG);
 
@@ -246,9 +246,9 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
     	// Validate app monitoring is disabled by checking the xml file is present in
     	// the overrides directory.
     	Path pathToXmlFile = LibertyPluginTestUtils.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
-    	isDisabled = LibertyPluginTestUtils.validateXmlFilePresentInOverridesDirectory(pathToXmlFile);
+    	isExist = LibertyPluginTestUtils.appMonitorDisabledXmlExists(pathToXmlFile);
 
-    	if (!isDisabled) {
+    	if (!isExist) {
     		Assertions.fail("Xml file not found on " + pathToXmlFile + ".");
     	}
     	// Stop dev mode.
@@ -258,8 +258,8 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
     	LibertyPluginTestUtils
     	.validateLibertyServerStopped(projectPath.toAbsolutePath().toString() + "/target/liberty");
 
-    	isDisabled = LibertyPluginTestUtils.validateXmlFileNotPresentInOverridesDirectory(pathToXmlFile);
-    	if (!isDisabled) {
+    	isExist = LibertyPluginTestUtils.appMonitorDisabledXmlExists(pathToXmlFile);
+    	if (isExist) {
     		Assertions.fail("Xml file " + pathToXmlFile
     				+ " is not removed from overrides directory on disconnecting debugger.");
     	}
@@ -271,7 +271,7 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
      */
     @Test
     public void testEnhancedDebugMode_disconnectDebuggerRemoveXmlFile() {
-    	boolean isDisabled = false;
+    	boolean isExist = false;
 
     	// Start dev mode.
     	launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_DEBUG);
@@ -286,8 +286,8 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
     	// Validate app monitoring is disabled by checking the xml file is present in
     	// the overrides directory.
     	Path pathToXmlFile = LibertyPluginTestUtils.getMavenXmlFilePathInOverridesDirectory(projectPath.toString());
-    	isDisabled = LibertyPluginTestUtils.validateXmlFilePresentInOverridesDirectory(pathToXmlFile);
-    	if (!isDisabled) {
+    	isExist = LibertyPluginTestUtils.appMonitorDisabledXmlExists(pathToXmlFile);
+    	if (!isExist) {
     		Assertions.fail("Xml file not found on " + pathToXmlFile + ".");
     	}
 
@@ -300,8 +300,8 @@ public class LibertyPluginSWTBotDebuggerTest extends AbstractLibertyPluginSWTBot
     	Object debugTarget = getObjectInDebugView("Liberty Application Debug");
     	disconnectDebugTarget(debugTarget);
 
-    	isDisabled = LibertyPluginTestUtils.validateXmlFileNotPresentInOverridesDirectory(pathToXmlFile);
-    	if (!isDisabled) {
+    	isExist = LibertyPluginTestUtils.appMonitorDisabledXmlExists(pathToXmlFile);
+    	if (isExist) {
     		Assertions.fail("Xml file " + pathToXmlFile
     				+ " is not removed from overrides directory on disconnecting debugger.");
     	}

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -241,6 +241,66 @@ public class LibertyPluginTestUtils {
         }
 
         throw new IllegalStateException("Timed out waiting for test report: " + pathToTestReport + " file to be created.");
+    }
+
+    /**
+     * Validates the xml file with config for disabling app monitoring exsist in 'configDropins/overrides' folder.
+     *
+     * @param pathToTestReport The path to the report.
+     */
+    public static boolean validateXmlFilePresentInOverridesDirectory(Path xmlFilePath) {
+        int retryCountLimit = 100;
+        int reryIntervalSecs = 1;
+        int retryCount = 0;
+
+        while (retryCount < retryCountLimit) {
+            retryCount++;
+
+            boolean fileExists = fileExists(xmlFilePath.toAbsolutePath());
+            if (!fileExists) {
+                try {
+                    Thread.sleep(reryIntervalSecs * 1000);
+                } catch (Exception e) {
+                    e.printStackTrace(System.out);
+                    continue;
+                }
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Validates the xml file with config for disabling app monitoring not exsist in 'configDropins/overrides' folder.
+     *
+     * @param pathToTestReport The path to the report.
+     */
+    public static boolean validateXmlFileNotPresentInOverridesDirectory(Path xmlFilePath) {
+        int retryCountLimit = 10;
+        int reryIntervalSecs = 1;
+        int retryCount = 0;
+
+        while (retryCount < retryCountLimit) {
+            retryCount++;
+
+            boolean fileExists = fileExists(xmlFilePath.toAbsolutePath());
+            if (fileExists) {
+                try {
+                    Thread.sleep(reryIntervalSecs * 1000);
+                } catch (Exception e) {
+                    e.printStackTrace(System.out);
+                    continue;
+                }
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
@@ -248,8 +248,8 @@ public class LibertyPluginTestUtils {
      *
      * @param pathToTestReport The path to the report.
      */
-    public static boolean validateXmlFilePresentInOverridesDirectory(Path xmlFilePath) {
-        int retryCountLimit = 100;
+    public static boolean appMonitorDisabledXmlExists(Path xmlFilePath) {
+        int retryCountLimit = 20;
         int reryIntervalSecs = 1;
         int retryCount = 0;
 
@@ -258,36 +258,6 @@ public class LibertyPluginTestUtils {
 
             boolean fileExists = fileExists(xmlFilePath.toAbsolutePath());
             if (!fileExists) {
-                try {
-                    Thread.sleep(reryIntervalSecs * 1000);
-                } catch (Exception e) {
-                    e.printStackTrace(System.out);
-                    continue;
-                }
-                continue;
-            }
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Validates the xml file with config for disabling app monitoring not exsist in 'configDropins/overrides' folder.
-     *
-     * @param pathToTestReport The path to the report.
-     */
-    public static boolean validateXmlFileNotPresentInOverridesDirectory(Path xmlFilePath) {
-        int retryCountLimit = 10;
-        int reryIntervalSecs = 1;
-        int retryCount = 0;
-
-        while (retryCount < retryCountLimit) {
-            retryCount++;
-
-            boolean fileExists = fileExists(xmlFilePath.toAbsolutePath());
-            if (fileExists) {
                 try {
                     Thread.sleep(reryIntervalSecs * 1000);
                 } catch (Exception e) {

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
@@ -558,4 +558,20 @@ public class LibertyPluginTestUtils {
 
         return jre;
     }
+
+	/**
+	 * Returns the path of the xml file containing app monitoring configuration.
+	 *
+	 * @param projectPath The project's path.
+	 *
+	 * @return The custom path of the xml file containing the config to
+	 *         enable/disable app monitoring.
+	 */
+	public static Path getMavenXmlFilePathInOverridesDirectory(String projectPath) {
+
+		Path path = Paths.get(projectPath, "target", "liberty", "wlp", "usr", "servers", "defaultServer",
+				"configDropins", "overrides", "disableApplicationMonitor.xml");
+
+		return path;
+	}
 }


### PR DESCRIPTION
part of #562 
Test cases for enhanced debug mode.

- Validate xml file with app monitoring configuration is present in 'configDropins/overrides' directory when dev mode starts in debug mode.
- Validate xml file with app monitoring configuration is removed from 'configDropins/overrides' directory when debugger disconnects from the dev mode.
- Validate xml file with app monitoring configuration is removed from 'configDropins/overrides' directory when dev mode stops