### PR TITLE
SVT issue - Removing the next line character after 'r' command.

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -1134,7 +1134,7 @@ public class DevModeOperations {
     }
 
     public void restartServer(String projectName) {
-    	String restartCommand = "r" + System.lineSeparator();
+    	String restartCommand = "r";
     	try {
     		processController.writeToProcessStream(projectName, restartCommand);
     	} catch (Exception e) {


### PR DESCRIPTION
Removing the next line character after 'r' command, because it is running the unit tests automatically.