### PR TITLE
Update what the Run As and dashboard menu show based on project state.

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
+++ b/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
@@ -374,6 +374,17 @@
         </menuContribution>
    </extension>
    
+   <!-- Liberty project property tester -->
+   <extension point="org.eclipse.core.expressions.propertyTesters">
+      <propertyTester
+            id="io.openliberty.tools.eclipse.ui.launch.libertyProjectPropertyTester"
+            type="org.eclipse.core.resources.IProject"
+            namespace="io.openliberty.tools.eclipse.ui.launch"
+            properties="aggregateStateActive,aggregateStateInactive"
+            class="io.openliberty.tools.eclipse.ui.launch.LibertyProjectPropertyTester">
+      </propertyTester>
+   </extension>
+
    <extension point="org.eclipse.debug.core.sourceLocators">
 	   <sourceLocator
 	       name="Liberty Source Lookup Director"
@@ -400,6 +411,7 @@
           sourcePathComputerId="io.openliberty.tools.eclipse.debug.libertySourcePathComputer">
       </launchConfigurationType>
   </extension>
+
   <extension point="org.eclipse.debug.ui.launchConfigurationTypeImages">
       <launchConfigurationTypeImage
           id="io.openliberty.tools.eclipse.launch.type.image"
@@ -431,6 +443,7 @@
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
                               <test forcePluginActivation="true" property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test forcePluginActivation="true" property="io.openliberty.tools.eclipse.ui.launch.aggregateStateActive" value="false"/>
                           </and>
                       </iterate>
                   </with>
@@ -453,6 +466,7 @@
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
                               <test forcePluginActivation="true" property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test forcePluginActivation="true" property="io.openliberty.tools.eclipse.ui.launch.aggregateStateActive" value="false"/>
                           </and>
                       </iterate>
                   </with>
@@ -475,6 +489,7 @@
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
                               <test forcePluginActivation="true" property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test forcePluginActivation="true" property="io.openliberty.tools.eclipse.ui.launch.aggregateStateActive" value="false"/>
                           </and>
                       </iterate>
                   </with>
@@ -497,6 +512,7 @@
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
                               <test forcePluginActivation="true" property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test forcePluginActivation="true" property="io.openliberty.tools.eclipse.ui.launch.aggregateStateActive" value="false"/>
                           </and>
                       </iterate>
                   </with>
@@ -519,6 +535,7 @@
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
                               <test forcePluginActivation="true" property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test forcePluginActivation="true" property="io.openliberty.tools.eclipse.ui.launch.aggregateStateActive" value="false"/>
                           </and>
                       </iterate>
                   </with>
@@ -541,6 +558,7 @@
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
                               <test forcePluginActivation="true" property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test forcePluginActivation="true" property="io.openliberty.tools.eclipse.ui.launch.aggregateStateActive" value="false"/>
                           </and>
                       </iterate>
                   </with>
@@ -563,6 +581,7 @@
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
                               <test forcePluginActivation="true" property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test forcePluginActivation="true" property="io.openliberty.tools.eclipse.ui.launch.aggregateStateInactive" value="false"/>
                           </and>
                       </iterate>
                   </with>
@@ -585,6 +604,7 @@
                           <and>
                               <instanceof value="org.eclipse.core.runtime.IAdaptable"/>
                               <test forcePluginActivation="true" property="org.eclipse.debug.ui.projectNature" value="io.openliberty.tools.eclipse.ui.libertyNature"/>
+                              <test forcePluginActivation="true" property="io.openliberty.tools.eclipse.ui.launch.aggregateStateInactive" value="false"/>
                           </and>
                       </iterate>
                   </with>

--- a/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
+++ b/bundles/io.openliberty.tools.eclipse.ui/plugin.xml
@@ -378,7 +378,7 @@
    <extension point="org.eclipse.core.expressions.propertyTesters">
       <propertyTester
             id="io.openliberty.tools.eclipse.ui.launch.libertyProjectPropertyTester"
-            type="org.eclipse.core.resources.IProject"
+            type="org.eclipse.core.runtime.IAdaptable"
             namespace="io.openliberty.tools.eclipse.ui.launch"
             properties="aggregateStateActive,aggregateStateInactive"
             class="io.openliberty.tools.eclipse.ui.launch.LibertyProjectPropertyTester">

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -74,6 +74,26 @@ import io.openliberty.tools.eclipse.utils.Utils;
 public class DevModeOperations {
 
     /**
+     * Liberty module state filter options. Used to resolve modules
+     * based on their state (active/started or inactive/stopped).
+     */
+    public enum ModuleStateFilter {
+        ALL,
+        ACTIVE,
+        INACTIVE
+    }
+
+    /**
+     * Represents the combined active/inactive/mixed state of all modules associated
+     * with a project.
+     */
+    public enum ProjectAggregatedState {
+        ACTIVE,
+        INACTIVE,
+        MIXED
+    }
+
+    /**
      * Supported actions types.
      */
     public static enum DashboardAction {
@@ -116,10 +136,6 @@ public class DevModeOperations {
     /**
      * Constants.
      */
-    public static final String ACTION_MVN_IT_REPORT_NAME = "View integration test report";
-    public static final String ACTION_MVN_UT_REPORT_NAME = "View unit test report";
-    public static final String ACTION_GDLTEST_REPORT_NAME = "View test report";
-
     public static final String DEVMODE_START_PARMS_DIALOG_TITLE = Messages.getMessage("devmode_start_dialog_title");
     public static final String DEVMODE_START_PARMS_DIALOG_MSG = Messages.getMessage("devmode_start_dialog_msg");
 
@@ -1137,51 +1153,40 @@ public class DevModeOperations {
     }
 
     /**
-     * Server filter mode for resolving command targets in multi-module projects.
-     * Used to filter Liberty modules based on their server state (running or stopped).
-     */
-    public enum ServerFilterMode {
-        /** Show all Liberty projects regardless of server state. */
-        ALL,
-        /** Show only Liberty projects with active (running) servers. */
-        ACTIVE_ONLY,
-        /** Show only Liberty projects with inactive (stopped) servers. */
-        INACTIVE_ONLY
-    }
-
-    /**
      * Resolve the target project for a given action command.
      *
-     * @param projectModel The project to resolve.
-     * @param commandName  The command name for display purposes.
-     * @param filterMode   The server filter mode to apply.
+     * @param projectModel        The project to resolve.
+     * @param commandName         The command name for display purposes.
+     * @param expectedModuleState The expected module state to filter on.
      *
      * @return The target project to execute or null if the user did not select one from a list options.
      *
-     * @throws Exception if input the project is not Liberty configured, or it does not have a liberty configured module.
+     * @throws Exception if the input project is not Liberty configured, or it does not have a liberty configured module.
      */
-    public ProjectModel resolveCommandTarget(ProjectModel projectModel, DashboardAction action, ServerFilterMode filterMode) throws Exception {
+    public ProjectModel resolveCommandTarget(ProjectModel projectModel, DashboardAction action, ModuleStateFilter expectedModuleState) throws Exception {
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, new Object[] { projectModel, action.toString() });
         }
 
         final ProjectModel[] targetProject = new ProjectModel[1];
 
-        // If the project is an aggregator
+        // If the module is an aggregator, gather the list of child modules associated with it.
         if (projectModel.getBuildConfigMetadata().isAggregator()) {
             List<ProjectModel> allLibertyChildren = workspaceModel.findLibertyDescendants(projectModel);
 
-            // Filter by server state based on filter mode
-            final List<ProjectModel> libertyChildren;
-            if (filterMode == ServerFilterMode.ACTIVE_ONLY) {
+            // Filter the list by the current module state based on expected module state.
+            // For example, if the action is "Start", the expected module state is INACTIVE. That is
+            // because only modules that are not active can be started.
+            final List<ProjectModel> childModules;
+            if (expectedModuleState == ModuleStateFilter.ACTIVE) {
                 List<ProjectModel> activeChildren = new ArrayList<>();
                 for (ProjectModel child : allLibertyChildren) {
                     if (isProjectStarted(child)) {
                         activeChildren.add(child);
                     }
                 }
-                libertyChildren = activeChildren;
-            } else if (filterMode == ServerFilterMode.INACTIVE_ONLY) {
+                childModules = activeChildren;
+            } else if (expectedModuleState == ModuleStateFilter.INACTIVE) {
                 List<ProjectModel> inactiveChildren = new ArrayList<>();
                 for (ProjectModel child : allLibertyChildren) {
                     if (!isProjectStarted(child)) {
@@ -1189,36 +1194,32 @@ public class DevModeOperations {
                     }
                 }
 
-                if (!allLibertyChildren.isEmpty() && inactiveChildren.size() == 0 &&
-                    (action == DashboardAction.START || action == DashboardAction.START_CFG ||
-                     action == DashboardAction.START_CTR || action == DashboardAction.DEBUG ||
-                     action == DashboardAction.DEBUG_CFG || action == DashboardAction.DEBUG_CTR)) {
+                if (!allLibertyChildren.isEmpty() && inactiveChildren.isEmpty()) {
                     throw new Exception(Messages.getMessage("no_inactive_liberty_modules_found"));
                 }
 
-                libertyChildren = inactiveChildren;
+                childModules = inactiveChildren;
             } else {
-                libertyChildren = allLibertyChildren;
+                childModules = allLibertyChildren;
             }
 
             // There should never be the case that there are no children found because a parent without
             // child Liberty modules should not be shown in the dashboard, and the user should not be given
             // the option to select an action through the explorers. If this case is encountered, it is
-            // an internal error an it should be reported as such.
-            if (libertyChildren.isEmpty()) {
+            // an internal error and it should be reported as such.
+            if (childModules.isEmpty()) {
                 String msg = Messages.getMessage("no_liberty_modules_found", projectModel.getName());
                 throw new Exception(msg);
             }
 
-            // If this parent project has a single child, return it as the target.
-            if (libertyChildren.size() == 1) {
+            // If this parent project has a single child module, return it as the target.
+            if (childModules.size() == 1) {
                 if (Trace.isEnabled()) {
-                    Trace.getTracer().traceExit(Trace.TRACE_TOOLS, libertyChildren.get(0));
+                    Trace.getTracer().traceExit(Trace.TRACE_TOOLS, childModules.get(0));
                 }
-                targetProject[0] = libertyChildren.get(0);
+                targetProject[0] = childModules.get(0);
             } else {
-
-                // If this parent project has multiple projects, ask the user to pick one,
+                // If this parent project has multiple child modules, ask the user to pick one,
                 // and return it as the target.
                 Display.getDefault().syncExec(new Runnable() {
                     @Override
@@ -1249,25 +1250,22 @@ public class DevModeOperations {
                             // Set size to show up to 10 items, then scrollbar appears
                             dialog.setSize(60, 10);
 
-                            // Customize dialog title and message based on filter mode
-                            String dialogTitle;
-                            String dialogMessage;
+                            // Customize dialog message based on the expected module state filter.
                             String actionName = getTranslatedActionCommand(action);
-                            if (filterMode == ServerFilterMode.ACTIVE_ONLY) {
-                                dialogTitle = Messages.getMessage("select_module_title");
+                            String dialogMessage;
+                            if (expectedModuleState == ModuleStateFilter.ACTIVE) {
                                 dialogMessage = Messages.getMessage("select_active_module_for_command_description", actionName);
-                            } else if (filterMode == ServerFilterMode.INACTIVE_ONLY) {
-                                dialogTitle = Messages.getMessage("select_module_title");
+                            } else if (expectedModuleState == ModuleStateFilter.INACTIVE) {
                                 dialogMessage = Messages.getMessage("select_inactive_module_for_command_description", actionName);
                             } else {
-                                dialogTitle = Messages.getMessage("select_module_title");
                                 dialogMessage = Messages.getMessage("select_module_for_command_description", actionName);
                             }
+                            String dialogTitle = Messages.getMessage("select_module_title");
 
                             dialog.setTitle(dialogTitle);
                             dialog.setMessage(dialogMessage);
-                            dialog.setElements(libertyChildren.toArray());
-                            dialog.setInitialSelections(new Object[] { libertyChildren.get(0) });
+                            dialog.setElements(childModules.toArray());
+                            dialog.setInitialSelections(new Object[] { childModules.get(0) });
                             dialog.setHelpAvailable(false);
 
                             if (dialog.open() == Window.OK) {
@@ -1492,5 +1490,39 @@ public class DevModeOperations {
 
         Process process = builder.start();
         process.waitFor();
+    }
+
+    /**
+     * Determines whether all, none, or only some of the Liberty modules associated with
+     * the given project are currently active.
+     *
+     * @param projectModel The project to evaluate.
+     * 
+     * @return The aggregated state for the input project.
+     */
+    public ProjectAggregatedState computeProjectAggregateState(ProjectModel projectModel) {
+        List<ProjectModel> modules;
+
+        if (projectModel.getBuildConfigMetadata() != null && projectModel.getBuildConfigMetadata().isAggregator()) {
+            modules = workspaceModel.findLibertyDescendants(projectModel);
+        } else {
+            modules = new ArrayList<>();
+            modules.add(projectModel);
+        }
+
+        int activeCount = 0;
+        for (ProjectModel module : modules) {
+            if (isProjectStarted(module)) {
+                activeCount++;
+            }
+        }
+
+        if (activeCount == 0) {
+            return ProjectAggregatedState.INACTIVE;
+        } else if (activeCount == modules.size()) {
+            return ProjectAggregatedState.ACTIVE;
+        } else {
+            return ProjectAggregatedState.MIXED;
+        }
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardView.java
@@ -50,6 +50,7 @@ import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.part.ViewPart;
 
 import io.openliberty.tools.eclipse.DevModeOperations;
+import io.openliberty.tools.eclipse.DevModeOperations.ProjectAggregatedState;
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.messages.Messages;
 import io.openliberty.tools.eclipse.model.ProjectModel;
@@ -371,17 +372,64 @@ public class DashboardView extends ViewPart {
     private void addActionsToContextMenu(IMenuManager mgr) {
         IProject iProject = Utils.getActiveProject();
 
-        // If no project is selected (e.g., selection was cleared for non-Liberty project), don't show menu
+        // If no project is selected just return.
         if (iProject == null) {
             return;
         }
 
         String projectLocation = iProject.getLocation().toOSString();
         ProjectModel projectModel = devModeOps.getWorkspaceModel().getProjectByLocation(projectLocation);
-        String projectName = projectModel.getName();
 
-        // Only show the context menu if the project has been configured to run on Liberty.
+
+        // Only show the context menu if the project has been configured to run in Liberty.
         if (projectModel != null && projectModel.hasLibertyNature()) {
+            String projectName = projectModel.getName();
+            
+            // Determine which actions should be enabled or disabled based on the aggregated
+            // project state.
+            boolean isChildModule = (projectModel.getParentProjectModel() != null);
+            ProjectAggregatedState aggregatedState = devModeOps.computeProjectAggregateState(projectModel);
+
+            
+            // Enable action group: Start* and Debug* if the project aggregate state is inactive.
+            // Enable action group: Stop and Run Tests if the project's aggregate state is active.
+            // All groups are enabled if the state is mixed.
+            boolean enableProjInactiveGroup;
+            boolean enableProjActiveGroup;
+            if (isChildModule) {
+                // Child module: enable start group when inactive, stop group when active.
+                enableProjInactiveGroup = (aggregatedState == ProjectAggregatedState.INACTIVE);
+                enableProjActiveGroup  = (aggregatedState == ProjectAggregatedState.ACTIVE);
+            } else {
+                // Parent or standalone project.
+                switch (aggregatedState) {
+                    case INACTIVE:
+                        enableProjInactiveGroup = true;
+                        enableProjActiveGroup  = false;
+                        break;
+                    case ACTIVE:
+                        enableProjInactiveGroup = false;
+                        enableProjActiveGroup  = true;
+                        break;
+                    case MIXED:
+                    default:
+                        // Some modules running – expose the full set of actions.
+                        enableProjInactiveGroup = true;
+                        enableProjActiveGroup  = true;
+                        break;
+                }
+            }
+
+            startAction.setEnabled(enableProjInactiveGroup);
+            startConfigDialogAction.setEnabled(enableProjInactiveGroup);
+            startInContainerAction.setEnabled(enableProjInactiveGroup);
+            debugAction.setEnabled(enableProjInactiveGroup);
+            debugConfigDialogAction.setEnabled(enableProjInactiveGroup);
+            debugInContainerAction.setEnabled(enableProjInactiveGroup);
+            
+            stopAction.setEnabled(enableProjActiveGroup);
+            runTestAction.setEnabled(enableProjActiveGroup);
+
             mgr.add(startAction);
             mgr.add(startInContainerAction);
             mgr.add(startConfigDialogAction);
@@ -391,6 +439,7 @@ public class DashboardView extends ViewPart {
             mgr.add(stopAction);
             mgr.add(runTestAction);
 
+            // Viewing test report actions are always enabled.
             if (projectModel.getBuildType() == ProjectModel.BuildType.Maven) {
                 mgr.add(viewMavenITestReportsAction);
                 mgr.add(viewMavenUTestReportsAction);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LibertyProjectPropertyTester.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LibertyProjectPropertyTester.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
+package io.openliberty.tools.eclipse.ui.launch;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdaptable;
+
+import io.openliberty.tools.eclipse.DevModeOperations;
+import io.openliberty.tools.eclipse.DevModeOperations.ProjectAggregatedState;
+import io.openliberty.tools.eclipse.logging.Trace;
+import io.openliberty.tools.eclipse.model.ProjectModel;
+
+/**
+ * Eclipse property tester used to enable or disable Liberty Tools launch shortcuts 
+ * based on the current aggregate running state of the selected project.
+ */
+public class LibertyProjectPropertyTester extends PropertyTester {
+
+    /** Property name: true when every Liberty module associated with the project is running. */
+    public static final String PROP_AGGREGATE_STATE_ACTIVE = "aggregateStateActive";
+
+    /** Property name: true when no Liberty module associated with the project is running. */
+    public static final String PROP_AGGREGATE_STATE_INACTIVE = "aggregateStateInactive";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { receiver, property, expectedValue });
+        }
+
+        // Resolve the IProject from the receiver.
+        IProject iProject = null;
+        if (receiver instanceof IProject) {
+            iProject = (IProject) receiver;
+        } else if (receiver instanceof IAdaptable) {
+            iProject = ((IAdaptable) receiver).getAdapter(IProject.class);
+        }
+
+        if (iProject == null) {
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_UI, "Receiver object is not of the expected type. Receiver: "+ receiver);
+            }
+            return false;
+        }
+
+        // Look up the project model and compute the module state.
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
+        ProjectModel projectModel = devModeOps.getWorkspaceModel().getProjectByLocation(iProject.getLocation().toOSString());
+
+        if (projectModel == null) {
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_UI, "Project: " + iProject.getName() + " is unknown because it is not a Liberty configured project.");
+            }
+            return false;
+        }
+
+        ProjectAggregatedState state = devModeOps.computeProjectAggregateState(projectModel);
+        boolean result;
+
+        if (PROP_AGGREGATE_STATE_ACTIVE.equals(property)) {
+            result = (state == ProjectAggregatedState.ACTIVE);
+        } else if (PROP_AGGREGATE_STATE_INACTIVE.equals(property)) {
+            result = (state == ProjectAggregatedState.INACTIVE);
+        } else {
+            if (Trace.isEnabled()) {
+                Trace.getTracer().trace(Trace.TRACE_UI, "Unknown property: " + property + ". Returning false.");
+            }
+            return false;
+        }
+
+        // If the caller supplied an explicit expected value in the XML, compare against it.
+        if (expectedValue instanceof Boolean) {
+            result = result == (Boolean) expectedValue;
+        } else if (expectedValue instanceof String) {
+            result = Boolean.toString(result).equals(expectedValue);
+        }
+
+        if (Trace.isEnabled()) {
+            Trace.getTracer().traceExit(Trace.TRACE_UI, result);
+        }
+
+        return result;
+    }
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LibertyProjectPropertyTester.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/LibertyProjectPropertyTester.java
@@ -39,7 +39,7 @@ public class LibertyProjectPropertyTester extends PropertyTester {
     @Override
     public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
         if (Trace.isEnabled()) {
-            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { receiver, property, expectedValue });
+            Trace.getTracer().traceEntry(Trace.TRACE_UI, new Object[] { property, args, expectedValue });
         }
 
         // Resolve the IProject from the receiver.

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenGradleTestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenGradleTestReportAction.java
@@ -116,7 +116,7 @@ public class OpenGradleTestReportAction implements ILaunchShortcut {
         }
 
         // Resolve the target project taking into account only those that are actively running.
-        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.OPEN_GRADLE_TEST_REPORT, DevModeOperations.ServerFilterMode.ACTIVE_ONLY);
+        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.OPEN_GRADLE_TEST_REPORT, DevModeOperations.ModuleStateFilter.ALL);
         if (targetProjectModel == null) {
             return;
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenITestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenITestReportAction.java
@@ -118,7 +118,7 @@ public class OpenMavenITestReportAction implements ILaunchShortcut {
         // Resolve the target project taking into account only those that are actively running.
         ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel,
                                                                           DashboardAction.OPEN_MVN_IT_TEST_REPORT,
-                                                                          DevModeOperations.ServerFilterMode.ACTIVE_ONLY);
+                                                                          DevModeOperations.ModuleStateFilter.ALL);
         if (targetProjectModel == null) {
             return;
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenUTestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenUTestReportAction.java
@@ -117,7 +117,7 @@ public class OpenMavenUTestReportAction implements ILaunchShortcut {
 
         // Resolve the target project taking into account only those that are actively running.
         ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.OPEN_MVN_UT_TEST_REPORT,
-                                                                          DevModeOperations.ServerFilterMode.ACTIVE_ONLY);
+                                                                          DevModeOperations.ModuleStateFilter.ALL);
         if (targetProjectModel == null) {
             return;
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/RunTestsAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/RunTestsAction.java
@@ -114,7 +114,7 @@ public class RunTestsAction implements ILaunchShortcut {
         }
         
         // Resolve the target project taking into account only those that are actively running.
-        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.RUNTESTS, DevModeOperations.ServerFilterMode.ACTIVE_ONLY);
+        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.RUNTESTS, DevModeOperations.ModuleStateFilter.ACTIVE);
         if (targetProjectModel == null) {
             return;
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -115,7 +115,7 @@ public class StartAction implements ILaunchShortcut {
         }
 
         // Resolve the target project taking into account only those that are not actively running.
-        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.START, DevModeOperations.ServerFilterMode.INACTIVE_ONLY);
+        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.START, DevModeOperations.ModuleStateFilter.INACTIVE);
         if (targetProjectModel == null) {
             return;
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartConfigurationDialogAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartConfigurationDialogAction.java
@@ -134,7 +134,7 @@ public class StartConfigurationDialogAction implements ILaunchShortcut {
             }
 
             // Resolve the target project taking into account only those that are not actively running.
-            targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.START_CFG, DevModeOperations.ServerFilterMode.INACTIVE_ONLY);
+            targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.START_CFG, DevModeOperations.ModuleStateFilter.INACTIVE);
             if (targetProjectModel == null) {
                 return;
             }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
@@ -120,7 +120,7 @@ public class StartInContainerAction implements ILaunchShortcut {
         }
 
         // Resolve the target project taking into account only those that are not actively running.
-        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.START_CTR, DevModeOperations.ServerFilterMode.INACTIVE_ONLY);
+        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.START_CTR, DevModeOperations.ModuleStateFilter.INACTIVE);
         if (targetProjectModel == null) {
             return;
         }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StopAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StopAction.java
@@ -117,7 +117,7 @@ public class StopAction implements ILaunchShortcut {
         }
 
         // Resolve the target project taking into account only those that are actively running.
-        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.STOP, DevModeOperations.ServerFilterMode.ACTIVE_ONLY);
+        ProjectModel targetProjectModel = devModeOps.resolveCommandTarget(selectedProjectModel, DashboardAction.STOP, DevModeOperations.ModuleStateFilter.ACTIVE);
         if (targetProjectModel == null) {
             return;
         }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -134,12 +134,12 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
                                                      DashboardView.APP_MENU_ACTION_VIEW_GRADLE_TEST_REPORT };
 
     /**
-     * Run As configuration menu items.
+     * Run As configuration menu items for an inactive project. Actions such
+     * as "Stop" and "Run Tests" are only present when the project is active.
      */
     static String[] runAsShortcuts = new String[] { LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONFIG,
-                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER, LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_STOP,
-                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_RUN_TESTS,
+                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_GRADLE_VIEW_TEST_REPORT };
 
     /**

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -146,12 +146,12 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
                                                   DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT };
 
     /**
-     * Run As configuration menu items.
+     * Run As configuration menu items for an inactive project. Actions such 
+     * as "Stop" and "Run Tests" are only present when the project is active.
      */
     static String[] runAsShortcuts = new String[] { LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONFIG,
-                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER, LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_STOP,
-                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_RUN_TESTS,
+                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER, 
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT, };
 
@@ -278,7 +278,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
         Assertions.assertTrue(foundItems == runAsShortcuts.length,
                               "The runAs menu associated with project: " + MVN_APP_NAME
                                                                    + " does not contain one or more expected entries. Expected number of entries: " + runAsShortcuts.length
-                                                                   + "Found entry count: " + foundItems + ". Found menu entries: " + runAsMenuItems);
+                                                                   + ". Found menu entries count: " + foundItems + ". Found menu entries: " + runAsMenuItems);
 
         // Check that the Debug As menu contains the expected shortcut
         SWTBotMenu debugAsMenu = getAppDebugAsMenu(bot, MVN_APP_NAME);
@@ -301,7 +301,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
                               "The debugAs menu associated with project: " + MVN_APP_NAME
                                                                             + " does not contain one or more expected entries. Expected number of entries: "
                                                                             + debugAsShortcuts.length
-                                                                            + "Found entry count: " + foundDebugAsItems + ". Found menu entries: " + debugAsMenuItems);
+                                                                            + ". Found menu entries count: " + foundDebugAsItems + ". Found menu entries: " + debugAsMenuItems);
 
         // Check that the Run As -> Run Configurations... contains the Liberty entry in the menu.
         Shell configShell = launchRunConfigurationsDialogFromAppRunAs(MVN_APP_NAME);

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -146,12 +146,12 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
                                                   DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT };
 
     /**
-     * Run As configuration menu items for an inactive project. Actions such 
+     * Run As configuration menu items for an inactive project. Actions such
      * as "Stop" and "Run Tests" are only present when the project is active.
      */
     static String[] runAsShortcuts = new String[] { LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONFIG,
-                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER, 
+                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT, };
 
@@ -419,6 +419,7 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
      * @throws InterruptedException
      */
     @Test
+    @Disabled("Until the option to stop an externally start module is added. The stop action is no longer enabled if LT did not start dev mode.")
     public void testDashboardStopExternalServer() throws CommandNotFoundException, IOException, InterruptedException {
 
         Path projAbsolutePath = wrapperProjectPath.toAbsolutePath();

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiModMavenTest.java
@@ -102,13 +102,12 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
                                                   DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT };
 
     /**
-     * Run As configuration menu items.
+     * Run As configuration menu items with the project inactive. Actions such 
+     * as "Stop" and "Run Tests" are only present when the project is active.
      */
     static String[] runAsShortcuts = new String[] { LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONFIG,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER,
-                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_STOP,
-                                                    LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_RUN_TESTS,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT,
                                                     LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT, };
 
@@ -210,7 +209,7 @@ public class LibertyPluginSWTBotMultiModMavenTest extends AbstractLibertyPluginS
         Assertions.assertTrue(foundItems == runAsShortcuts.length,
                               "The runAs menu associated with project: " + MVN_APP_NAME
                                                                    + " does not contain one or more expected entries. Expected number of entries: " + runAsShortcuts.length
-                                                                   + "Found entry count: " + foundItems + ". Found menu entries: " + runAsMenuItems);
+                                                                   + ". Found menu entries count: " + foundItems + ". Found menu entries: " + runAsMenuItems);
 
         // Check that the Run As -> Run Configurations... contains the Liberty entry in the menu.
         Shell configShell = launchRunConfigurationsDialogFromAppRunAs(MVN_APP_NAME);


### PR DESCRIPTION
This PR:
- Update what the Run As and dashboard menu show based on project state. For example, if a project is inactive, the action to stop the server should not be shown.
- Update tests.