### PR TITLE
Handle external dev mode process

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -146,7 +146,6 @@ public class DevModeOperations {
     public static final String BROWSER_MVN_IT_REPORT_NAME_SUFFIX = "failsafe report";
     public static final String BROWSER_MVN_UT_REPORT_NAME_SUFFIX = "surefire report";
     public static final String BROWSER_GRADLE_TEST_REPORT_NAME_SUFFIX = "test report";
-    public static final String MVN_RUN_APP_LOG_FILE = "io.openliberty.tools.eclipse.mvnlogfilename";
 
     private static final String ANSI_SUPPORT_QUALIFIER = "org.eclipse.ui.console";
     private static final String ANSI_SUPPORT_KEY = "ANSI_support_enabled";
@@ -734,16 +733,6 @@ public class DevModeOperations {
         // The value for JAVA_HOME comes from the underlying configuration. The configuration allows
         // the java installation to be custom defined, execution environment defined, or workspace defined.
         envs.add("JAVA_HOME=" + javaInstallPath);
-        String logFileName = System.getProperty(MVN_RUN_APP_LOG_FILE);
-        if (logFileName != null && !logFileName.isEmpty()) {
-            // TODO - could abort if either of these env variables is already set but by guarding with sysprop no risk
-            // of accidental usage.
-
-            // mvn
-            envs.add("MAVEN_ARGS=--log-file " + logFileName);
-            // mvnw
-            envs.add("MAVEN_CONFIG=--log-file " + logFileName);
-        }
 
         processController.runProcess(projectName, projectPath, cmd, envs, true, launch);
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -61,6 +61,8 @@ import io.openliberty.tools.eclipse.messages.Messages;
 import io.openliberty.tools.eclipse.model.ProjectModel;
 import io.openliberty.tools.eclipse.model.ProjectModel.BuildType;
 import io.openliberty.tools.eclipse.model.WorkspaceModel;
+import io.openliberty.tools.eclipse.process.ConsoleOutputInterceptor;
+import io.openliberty.tools.eclipse.process.DevModeStateHandler;
 import io.openliberty.tools.eclipse.process.ProcessController;
 import io.openliberty.tools.eclipse.ui.ElementListSelectionDialogWrapper;
 import io.openliberty.tools.eclipse.ui.dashboard.DashboardView;
@@ -302,7 +304,7 @@ public class DevModeOperations {
             }
 
             // Run the application in dev mode.
-            startDevMode(cmd, targetProjectName, targetProjectExecPath, javaHomePath, launch);
+            startDevMode(cmd, targetProjectModel, targetProjectExecPath, javaHomePath, launch, mode);
 
             // If there is a debugPort, start the job to attach the debugger to the Liberty server JVM.
             if (debugPort != null) {
@@ -406,7 +408,7 @@ public class DevModeOperations {
             }
 
             // Run the application in dev mode.
-            startDevMode(cmd, targetProjectName, targetProjectExecPath, javaHomePath, launch);
+            startDevMode(cmd, targetProjectModel, targetProjectExecPath, javaHomePath, launch, mode);
 
             // If there is a debugPort, start the job to attach the debugger to the Liberty server JVM.
             if (debugPort != null) {
@@ -443,22 +445,19 @@ public class DevModeOperations {
             // Check if the stop action has already been issued or if a start action was never issued before.
             if (!isProjectStarted(targetProjectModel)) {
                 String msg = Messages.getMessage("stop_already_issued", targetProjectName);
-                handleStopActionError(targetProjectName, msg);
-
+                ErrorHandler.processErrorMessage(msg, true);
                 return;
             }
-
+            
             // Issue the command to the process.
             processController.writeToProcessStream(targetProjectName, DEVMODE_COMMAND_EXIT);
 
             // Cleanup internal objects.
             cleanupProcess(targetProjectName);
-
         } catch (Exception e) {
             String projectName = (targetProjectName == null) ? targetProjectModel.getName() : targetProjectName;
             String msg = Messages.getMessage("stop_general_error", projectName);
-            handleStopActionError(projectName, msg);
-
+            ErrorHandler.processErrorMessage(msg, true);
             return;
         }
 
@@ -473,7 +472,9 @@ public class DevModeOperations {
      * @param projectName The name of the project whose process should be cleaned up.
      */
     public void cleanupProcess(String projectName) {
-        processController.cleanup(projectName);
+        ProjectModel projectModel = workspaceModel.getProjectByName(projectName);
+        String projectPath = (projectModel != null) ? projectModel.getPath() : null;
+        processController.cleanup(projectName, projectPath);
     }
 
     /**
@@ -717,13 +718,16 @@ public class DevModeOperations {
     /**
      * Runs the specified command.
      *
-     * @param cmd         The command to run.
-     * @param projectName The name of the project currently being processed.
-     * @param projectPath The project's path.
+     * @param cmd          The command to run.
+     * @param projectModel The model of the project currently being processed.
+     * @param projectPath  The project's path.
+     * @param mode         The Eclipse launch mode used to start dev mode.
      *
      * @throws Exception If an error occurs while running the specified command.
      */
-    public void startDevMode(String cmd, String projectName, String projectPath, String javaInstallPath, ILaunch launch) throws Exception {
+    public void startDevMode(String cmd, ProjectModel projectModel, String projectPath, String javaInstallPath, ILaunch launch, String mode) throws Exception {
+        String projectName = projectModel.getName();
+
         // Determine the environment properties to be set in the process running dev mode.
         List<String> envs = new ArrayList<String>(1);
 
@@ -742,30 +746,23 @@ public class DevModeOperations {
         }
 
         processController.runProcess(projectName, projectPath, cmd, envs, true, launch);
-    }
 
-    /**
-     * Informs the user of the error and prompts them to choose whether or not to allow the Liberty plugin stop command to be issued
-     * for the specified project.
-     *
-     * @param projectName The name of the project for which the Liberty plugin stop command is issued.
-     * @param baseMsg     The base message to display.
-     */
-    private void handleStopActionError(String projectName, String baseMsg) {
-        String stopPromptMsg = Messages.getMessage("issue_stop_prompt");
-        String msg = baseMsg + "\n\n" + stopPromptMsg;
-        Integer response = ErrorHandler.processWarningMessage(msg, true, new String[] { "Yes", "No" }, 0);
-        if (response != null && response == 0) {
-            issueStopCommand(projectName);
+        // Register the dev mode state handler so that Liberty console messages trigger
+        // the appropriate in-plugin reactions.
+        ConsoleOutputInterceptor interceptor = processController.getInterceptor(projectPath);
+        if (interceptor != null) {
+            interceptor.addHandler(new DevModeStateHandler(projectModel, mode));
         }
     }
 
     /**
      * Issues the Liberty plugin stop command to stop the Liberty server associated with the specified project.
-     * 
+     * If the stop command completes successfully, the optional onSuccess runnable is invoked on the UI thread.
+     *
      * @param projectName The name of the project for which the Liberty plugin stop command is issued.
+     * @param onSuccess A runnable to invoke on the UI thread after a successful stop, or null if no action is needed.
      */
-    private void issueStopCommand(String projectName) {
+    public void issueStopCommand(String projectName, Runnable onSuccess) {
         if (Trace.isEnabled()) {
             Trace.getTracer().traceEntry(Trace.TRACE_TOOLS, projectName);
         }
@@ -796,17 +793,15 @@ public class DevModeOperations {
                 throw new Exception(Messages.getMessage("unexpected_build_type", targetProjectModel.getBuildType().toString(), projectName));
             }
 
-            // Issue the command.
             String[] cmdParts = cmd.split(" ");
             ProcessBuilder pb = new ProcessBuilder(cmdParts);
             pb.directory(new File(targetProjectExecPath));
             pb.redirectErrorStream(true);
             pb.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
 
-            /*
-             * Per: https://stackoverflow.com/questions/29793071/rcp-no-progress-dialog-when-starting-a-job it seems that job.setUser(true)
-             * is no longer enough to result in the creation of a progress dialog.
-             */
+            // Create a job to stop the dev mode process currently running the target project.
+            // Per: https://stackoverflow.com/questions/29793071/rcp-no-progress-dialog-when-starting-a-job it seems that job.setUser(true)
+            // is no longer enough to result in the creation of a progress dialog.
             Job job = new Job(Messages.getMessage("stopping_server_job", targetProjectModel.getBuildType().toString())) {
 
                 @Override
@@ -852,6 +847,7 @@ public class DevModeOperations {
 
             };
 
+            // Add the listener that will restart dev mode for the target project when stop is complete.
             job.addJobChangeListener(new JobChangeAdapter() {
                 @Override
                 public void done(IJobChangeEvent event) {
@@ -862,7 +858,7 @@ public class DevModeOperations {
                     }
 
                     /*
-                     * Check for timeout
+                     * Check for timeout.
                      */
                     Object timeoutOnCompletion = event.getJob().getProperty(STOP_JOB_COMPLETION_TIMEOUT);
                     if (Boolean.TRUE.equals(timeoutOnCompletion)) {
@@ -884,7 +880,7 @@ public class DevModeOperations {
                     }
 
                     /*
-                     * Check for bad exit value
+                     * Check for bad exit value.
                      */
                     Object rc = event.getJob().getProperty(STOP_JOB_COMPLETION_EXIT_CODE);
                     if (rc != Integer.valueOf(0)) {
@@ -897,6 +893,11 @@ public class DevModeOperations {
                             }
                         });
                         return;
+                    }
+
+                    // Invoke the post-stop action if one was provided.
+                    if (onSuccess != null) {
+                        Display.getDefault().asyncExec(onSuccess);
                     }
                 }
             });

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/messages/Messages.properties
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/messages/Messages.properties
@@ -12,7 +12,6 @@
 # NLS_MESSAGEFORMAT_VAR
 
 # DebugModeHandler
-multiple_server_env=More than one server.env file was found for the {0} project. Liberty Tools cannot determine which server.env file to use.
 unexpected_build_type=Unexpected project build type: {0}. Project {1} does not appear to be a Maven or Gradle built project.
 debug_port_read_error=Failed to read debug port from server.env file.
 debugger_attach_error=An error was detected while attaching the debugger to the JVM.
@@ -60,7 +59,6 @@ gradle_test_report_no_project_found=Unable to process the view test report reque
 gradle_test_report_none_found=No test results were found for the {0} project. Select "{1}" before you select "{2}" on the menu.
 gradle_test_report_general_error=An error occurred while processing the view test report request on the {0} project.
 
-issue_stop_prompt=Would you like to run the Liberty Maven or Gradle stop command for this project to stop a Liberty server that may still be running outside of the Liberty Tools session?
 plugin_stop_issue_error=An error occurred while running the plugin stop command.
 plugin_stop_timeout=The Liberty Maven or Gradle stop command issued for the {0} project timed out after {1} seconds.
 plugin_stop_failed=The stop command failed with exit code: {0}.
@@ -73,7 +71,8 @@ restart_server_error=An error was detected during the server restart for the {0}
 # ProcessController
 process_write_error=Unable to write to the process associated with project {0}. Internal process object not found.
 
-# WorkspaceModel
+# DevModeStateHandler
+server_already_running=Dev mode for the {0} project is already running outside of Liberty Tools. Would you like to stop it and restart it with Liberty Tools?\n\nSelecting No will prevent Liberty Tools from managing dev mode for this project.
 
 # DashboardHandler
 dashboard_open_error=Unable to open the Liberty Dashboard view.

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/ConsoleOutputInterceptor.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/ConsoleOutputInterceptor.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+* Copyright (c) 2026 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial implementation
+*******************************************************************************/
+package io.openliberty.tools.eclipse.process;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.debug.core.IStreamListener;
+import org.eclipse.debug.core.model.IStreamMonitor;
+
+import io.openliberty.tools.eclipse.logging.Trace;
+
+/**
+ * Intercepts console output produced by a dev mode process.
+ *
+ * A single instance of this class is registered as an IStreamListener on both the stdout
+ * and stderr monitors of the IProcess returned by DebugPlugin.newProcess(). Eclipse still
+ * delivers the same text to the Console view; this class only observes the text in parallel.
+ */
+public class ConsoleOutputInterceptor implements IStreamListener {
+
+    /** Handlers to be notified for each complete line. */
+    private final List<IConsoleLineHandler> handlers = new CopyOnWriteArrayList<>();
+
+    /** Name of the project whose process output is being intercepted. */
+    private final String projectName;
+
+    /** Buffer for partial lines that did not end with a newline in the last chunk. */
+    private final StringBuilder lineBuffer = new StringBuilder();
+
+    /**
+     * Constructs an interceptor for the specified project.
+     *
+     * @param projectName The name of the project whose process output is intercepted.
+     */
+    public ConsoleOutputInterceptor(String projectName) {
+        this.projectName = projectName;
+    }
+
+    /**
+     * Adds a handler to be notified for each complete line of output.
+     *
+     * @param handler The handler to add.
+     */
+    public void addHandler(IConsoleLineHandler handler) {
+        handlers.add(handler);
+    }
+
+    /**
+     * Removes a previously registered handler.
+     *
+     * @param handler The handler to remove.
+     */
+    public void removeHandler(IConsoleLineHandler handler) {
+        handlers.remove(handler);
+    }
+
+    /**
+     * Receives a set of text from the Eclipse stream monitor. The chunk is appended to
+     * the internal line buffer and then split on newlines. Each complete line is dispatched
+     * to all registered handlers. Any trailing text without a newline remains in the buffer
+     * until the next set arrives or until flush() is called.
+     *
+     * @param text The text chunk appended to the stream.
+     * @param monitor The stream monitor that produced the text.
+     */
+    @Override
+    public void streamAppended(String text, IStreamMonitor monitor) {
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+
+        lineBuffer.append(text);
+        String buffered = lineBuffer.toString();
+        lineBuffer.setLength(0);
+
+        int start = 0;
+        int length = buffered.length();
+        for (int i = 0; i < length; i++) {
+            char c = buffered.charAt(i);
+            if (c == '\n' || c == '\r') {
+                dispatchLine(buffered.substring(start, i));
+                // Treat \r\n as a single line ending.
+                if (c == '\r' && i + 1 < length && buffered.charAt(i + 1) == '\n') {
+                    i++;
+                }
+                start = i + 1;
+            }
+        }
+
+        // Retain any trailing text that did not end with a newline.
+        if (start < length) {
+            lineBuffer.append(buffered.substring(start));
+        }
+    }
+
+    /**
+     * Flushes any text remaining in the partial-line buffer as a final line. Should be
+     * called once when the associated process has terminated to ensure that a final line
+     * not terminated with a newline is still delivered to handlers.
+     */
+    public void flush() {
+        if (lineBuffer.length() > 0) {
+            String line = lineBuffer.toString();
+            lineBuffer.setLength(0);
+            dispatchLine(line);
+        }
+    }
+
+    /**
+     * Dispatches one complete line to all registered handlers. Exceptions thrown by
+     * individual handlers are caught and logged so that other handlers still receive
+     * the line.
+     *
+     * @param line The line to dispatch.
+     */
+    private void dispatchLine(String line) {
+        for (IConsoleLineHandler handler : handlers) {
+            try {
+                handler.handleLine(projectName, line);
+            } catch (Exception e) {
+                if (Trace.isEnabled()) {
+                    Trace.getTracer().trace(Trace.TRACE_UI,
+                        "ConsoleOutputInterceptor: handler " + handler.getClass().getName()
+                        + " threw an exception processing line for project " + projectName, e);
+                }
+            }
+        }
+    }
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/DevModeStateHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/DevModeStateHandler.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+* Copyright (c) 2026 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial implementation
+*******************************************************************************/
+package io.openliberty.tools.eclipse.process;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.swt.widgets.Display;
+
+import io.openliberty.tools.eclipse.DevModeOperations;
+import io.openliberty.tools.eclipse.logging.Trace;
+import io.openliberty.tools.eclipse.messages.Messages;
+import io.openliberty.tools.eclipse.model.ProjectModel;
+import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationDelegateLauncher.RuntimeEnv;
+import io.openliberty.tools.eclipse.ui.launch.LaunchConfigurationHelper;
+import io.openliberty.tools.eclipse.utils.ErrorHandler;
+import io.openliberty.tools.eclipse.utils.Utils;
+
+/**
+ * Scans each line of dev mode console output for patterns that indicate a change
+ * in dev mode state, and triggers the appropriate in-plugin reaction for each match.
+ *
+ * New patterns are added by inserting a PatternAction entry into the list built by
+ * buildPatternActions(). Each entry pairs a PatternMatcher with a Consumer action.
+ */
+public class DevModeStateHandler implements IConsoleLineHandler {
+
+    /**
+     * Encapsulates a single pattern check used in the pattern-action table.
+     */
+    private interface PatternMatcher {
+
+        /**
+         * Returns true if the given line matches this pattern.
+         *
+         * @param line The line of console output to test.
+         * 
+         * @return True if the line matches, false otherwise.
+         */
+        boolean matches(String line);
+    }
+
+    /**
+     * A PatternMatcher that checks whether the line matches a compiled regular expression.
+     */
+    private static class RegexMatcher implements PatternMatcher {
+
+        private final Pattern pattern;
+
+        RegexMatcher(String regex) {
+            this.pattern = Pattern.compile(regex);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean matches(String line) {
+            return pattern.matcher(line).find();
+        }
+    }
+
+    /**
+     * A PatternMatcher that checks whether the line contains a fixed substring.
+     */
+    private static class ContainsMatcher implements PatternMatcher {
+
+        private final String substring;
+
+        ContainsMatcher(String substring) {
+            this.substring = substring;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean matches(String line) {
+            return line.contains(substring);
+        }
+    }
+
+    /**
+     * Associates a PatternMatcher with the action to invoke when the pattern is found.
+     */
+    private static class PatternAction {
+
+        final PatternMatcher matcher;
+        final Consumer<String> action;
+
+        PatternAction(PatternMatcher matcher, Consumer<String> action) {
+            this.matcher = matcher;
+            this.action = action;
+        }
+    }
+
+    /** The project model for the project whose process output this handler is observing. */
+    private final ProjectModel projectModel;
+
+    /** The launch mode (run or debug) originally used to start dev mode for this project. */
+    private final String mode;
+
+    /** Pattern-action table. Each entry is evaluated in order for every console line. */
+    private final List<PatternAction> patternActions;
+
+    /**
+     * Constructs a handler for the specified project.
+     *
+     * @param projectModel The model of the project whose dev mode process is being monitored.
+     * @param mode         The Eclipse launch mode (ILaunchManager.RUN_MODE or ILaunchManager.DEBUG_MODE)
+     *                         originally used to start dev mode.
+     */
+    public DevModeStateHandler(ProjectModel projectModel, String mode) {
+        this.projectModel = projectModel;
+        this.mode = mode;
+        this.patternActions = buildPatternActions();
+    }
+
+    /**
+     * Builds the pattern-action table. Each entry pairs a matcher with the reaction
+     * to invoke when the pattern is found on a console line.
+     *
+     * @return The list of pattern-action pairs.
+     */
+    private List<PatternAction> buildPatternActions() {
+        return Arrays.asList(
+                             // Gradle and Maven both emit a message of the form
+                             // "The server <name> is already running." when dev mode tries to start
+                             // against an already-running server instance.
+                             new PatternAction(new RegexMatcher("The server .+ is already running\\."), line -> handleAlreadyRunning()));
+    }
+
+    /**
+     * Shows a Yes/No warning dialog informing the user that dev mode is already running
+     * outside of Liberty Tools. If the user selects Yes, the running dev mode process is
+     * stopped and dev mode is restarted using the original launch configuration so that
+     * Liberty Tools can fully manage the project.
+     */
+    private void handleAlreadyRunning() {
+        Display.getDefault().asyncExec(() -> {
+            String targetProjectName = projectModel.getName();
+            String msg = Messages.getMessage("server_already_running", targetProjectName);
+            Integer response = ErrorHandler.processWarningMessage(msg, true, new String[] { "Yes", "No" }, 0);
+            if (response != null && response == 0) {
+                DevModeOperations.getInstance().issueStopCommand(projectModel.getName(), () -> {
+                    try {
+                        // Update the active selection to the selected target project if the original selection does not match the target.
+                        if (targetProjectName != null) {
+                            Utils.updateActiveSelection(projectModel);
+                        }
+
+                        // Determine what configuration to use.
+                        LaunchConfigurationHelper launchConfigHelper = LaunchConfigurationHelper.getInstance();
+                        ILaunchConfiguration configuration = launchConfigHelper.getLaunchConfiguration(projectModel, mode, RuntimeEnv.LOCAL);
+                        DebugUITools.launch(configuration, mode);
+                    } catch (Exception e) {
+                        if (Trace.isEnabled()) {
+                            Trace.getTracer().trace(Trace.TRACE_TOOLS,
+                                                    "DevModeStateHandler: failed to restart dev mode for project "
+                                                                       + projectModel.getName(),
+                                                    e);
+                        }
+                        ErrorHandler.processErrorMessage(
+                                                         Messages.getMessage("start_general_error", targetProjectName), e, true);
+                    }
+                });
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void handleLine(String projectName, String line) {
+        //Evaluates each known pattern against the given line and invokes the associated
+        // action for any that match.
+        for (PatternAction pa : patternActions) {
+            if (pa.matcher.matches(line)) {
+                pa.action.accept(line);
+            }
+        }
+    }
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/IConsoleLineHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/IConsoleLineHandler.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2026 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial implementation
+*******************************************************************************/
+package io.openliberty.tools.eclipse.process;
+
+/**
+ * Receives individual lines of console output produced by a running dev mode process.
+ *
+ * Implementations are registered with a ConsoleOutputInterceptor. The interceptor calls
+ * handleLine once for each complete line delivered by Eclipse. Handlers must not block
+ * the calling thread because the call originates from an Eclipse stream monitor callback.
+ */
+public interface IConsoleLineHandler {
+
+    /**
+     * Handles one line of console output from the dev mode process.
+     *
+     * @param projectName The name of the project whose process produced the line.
+     * @param line The line of text, without any trailing newline character.
+     */
+    void handleLine(String projectName, String line);
+}

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/ProcessController.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/ProcessController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022, 2025 IBM Corporation and others.
+* Copyright (c) 2022, 2026 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.debug.core.model.IStreamMonitor;
 
 import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.messages.Messages;
@@ -34,6 +36,9 @@ public class ProcessController {
 
     /** The set of processes associated with different application projects. */
     private static final ConcurrentHashMap<String, Process> projectProcessMap = new ConcurrentHashMap<String, Process>();
+
+    /** The set of console output interceptors keyed by project path. */
+    private static final ConcurrentHashMap<String, ConsoleOutputInterceptor> interceptorMap = new ConcurrentHashMap<String, ConsoleOutputInterceptor>();
 
     /** Instance of this class */
     private static ProcessController instance;
@@ -64,9 +69,10 @@ public class ProcessController {
      * @param projectPath The application project path.
      * @param command     The command to execute.
      * @param envs        The environment properties to be set for the process.
+     * @param printCmd    Whether to echo the command to the console before running it.
      * @param launch      The Eclipse launch object used to register the process in the debug framework.
      *
-     * @throws IOException
+     * @throws IOException If an error occurs while starting the process.
      */
     public void runProcess(String projectName, String projectPath, String command, List<String> envs, boolean printCmd, ILaunch launch) throws IOException {
 
@@ -120,7 +126,27 @@ public class ProcessController {
         // Launch the Java process as part of the Debug plugin framework, which wraps
         // the raw Java process and monitors it.
         // Cleanup for the initiated process is done by the registered listener.
-        DebugPlugin.newProcess(launch, process, projectName);
+        IProcess iProcess = DebugPlugin.newProcess(launch, process, projectName);
+
+        // Create a console output interceptor and register it on both the stdout and
+        // stderr monitors so that handlers can react to messages on either stream.
+        ConsoleOutputInterceptor interceptor = new ConsoleOutputInterceptor(projectName);
+        IStreamMonitor outMonitor = iProcess.getStreamsProxy().getOutputStreamMonitor();
+        IStreamMonitor errMonitor = iProcess.getStreamsProxy().getErrorStreamMonitor();
+        outMonitor.addListener(interceptor);
+        errMonitor.addListener(interceptor);
+        interceptorMap.put(projectPath, interceptor);
+    }
+
+    /**
+     * Returns the ConsoleOutputInterceptor registered for the specified project path, or null
+     * if no process is currently running for that project.
+     *
+     * @param projectPath The file system path of the project.
+     * @return The ConsoleOutputInterceptor for the project, or null if none exists.
+     */
+    public ConsoleOutputInterceptor getInterceptor(String projectPath) {
+        return interceptorMap.get(projectPath);
     }
 
     private void addTerminateListener(String projectName) {
@@ -170,11 +196,18 @@ public class ProcessController {
 
     /**
      * Cleans up any objects associated with this project.
-     * 
-     * @param projectName - The name of the project to clean up.
+     *
+     * @param projectName The name of the project to clean up.
+     * @param projectPath The file system path of the project.
      */
-    public void cleanup(String projectName) {
+    public void cleanup(String projectName, String projectPath) {
         projectProcessMap.remove(projectName);
+        if (projectPath != null) {
+            ConsoleOutputInterceptor interceptor = interceptorMap.remove(projectPath);
+            if (interceptor != null) {
+                interceptor.flush();
+            }
+        }
     }
 
     /**
@@ -185,7 +218,9 @@ public class ProcessController {
         StringBuffer sb = new StringBuffer();
         sb.append("Class: ").append(instance.getClass().getName()).append(": ");
         sb.append("projectProcessMap size: ").append(projectProcessMap.size()).append(", ");
-        sb.append("projectProcessMap: ").append(projectProcessMap);
+        sb.append("projectProcessMap: ").append(projectProcessMap).append(", ");
+        sb.append("interceptorMap size: ").append(interceptorMap.size()).append(", ");
+        sb.append("interceptorMap: ").append(interceptorMap);
         return sb.toString();
     }
 }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/StartTab.java
@@ -245,7 +245,7 @@ public class StartTab extends AbstractLaunchConfigurationTab {
                     Trace.getTracer().trace(Trace.TRACE_TOOLS, "The start request was already issued on project " + configProjectName);
                 }
 
-                super.setErrorMessage(Messages.getMessage("start_already_issued", configProjectName));
+                super.setErrorMessage(Messages.getMessage("start_already_issued", selectedProjectModel.getName()));
                 return false;
             }
         } catch (CoreException ce) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -127,7 +127,7 @@ public class StartAction implements ILaunchShortcut {
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_TOOLS, "The start request was already issued on project " + targetProjectName);
             }
-            throw new Exception(Messages.getMessage("start_already_issued"));
+            throw new Exception(Messages.getMessage("start_already_issued", targetProjectName));
         }
 
         

--- a/ci/jenkins/run-tests
+++ b/ci/jenkins/run-tests
@@ -48,17 +48,13 @@ pipeline {
                                 sh '''
                                    MVNPATH="$(dirname $(which mvn))/.."
                                    GRADLEPATH="$(dirname $(which gradle))/.."
-                                   mvn clean verify -DmvnLogFile -DmvnPath=$MVNPATH -DgradlePath=$GRADLEPATH -Dtycho.disableP2Mirrors=true -Declipse.target=1Q2026 -Dosgi.debug=./tests/resources/ci/debug.opts -DtestAppImportWait=120000 -Dtycho.showEclipseLog -e -X
+                                   mvn clean verify -DmvnPath=$MVNPATH -DgradlePath=$GRADLEPATH -Dtycho.disableP2Mirrors=true -Declipse.target=1Q2026 -Dosgi.debug=./tests/resources/ci/debug.opts -DtestAppImportWait=120000 -Dtycho.showEclipseLog -e -X
                                 '''
                             }
                         } finally {
-                            sh "find tests -type f -name \"lte-dev-mode-output-*.log\""
-                            sh "mkdir lte-dev-mode-output-logs && find tests -type f -name \"lte-dev-mode-output-*.log\" -exec cp {} lte-dev-mode-output-logs \\;"
-                            sh "zip -r lte-dev-mode-output-logs.zip lte-dev-mode-output-logs"
                             sh "cd tests/target/surefire-reports && zip -r 1Q2026-test-reports.zip ."
                             
                             archiveArtifacts artifacts: 'tests/target/surefire-reports/1Q2026-test-reports.zip', fingerprint: true
-                            archiveArtifacts artifacts: 'lte-dev-mode-output-logs.zip', fingerprint: true
                             archiveArtifacts artifacts: 'tests/target/work/data/.metadata/.log', fingerprint: true
                         }
                     }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -38,7 +38,6 @@
                     <forkedProcessTimeoutInSeconds>7200</forkedProcessTimeoutInSeconds>
                     <systemProperties>
                         <org.eclipse.swtbot.search.timeout>20000</org.eclipse.swtbot.search.timeout>
-                        <io.liberty.tools.eclipse.tests.mvn.logfile>${mvnLogFile}</io.liberty.tools.eclipse.tests.mvn.logfile>
                         <io.liberty.tools.eclipse.tests.mvnexecutable.path>${mvnPath}</io.liberty.tools.eclipse.tests.mvnexecutable.path>
                         <io.liberty.tools.eclipse.tests.gradleexecutable.path>${gradlePath}</io.liberty.tools.eclipse.tests.gradleexecutable.path>
                     </systemProperties>

--- a/tests/resources/ci/scripts/exec.sh
+++ b/tests/resources/ci/scripts/exec.sh
@@ -40,7 +40,7 @@ main() {
         metacity --sm-disable --replace 2> metacity.err &
     fi
     
-    mvn clean install -Declipse.target="$TARGET" -Dosgi.debug=./tests/resources/ci/debug.opts -Dtycho.showEclipseLog -DtestAppImportWait=120000 -DmvnPath="${PWD}/test-tools/liberty-dev-tools/apache-maven-3.9.6" -DgradlePath="${PWD}/test-tools/liberty-dev-tools/gradle-8.8" -DmvnLogFile
+    mvn clean install -Declipse.target="$TARGET" -Dosgi.debug=./tests/resources/ci/debug.opts -Dtycho.showEclipseLog -DtestAppImportWait=120000 -DmvnPath="${PWD}/test-tools/liberty-dev-tools/apache-maven-3.9.6" -DgradlePath="${PWD}/test-tools/liberty-dev-tools/gradle-8.8"
 
     # If there were any errors, gather some debug data before exiting.
     rc=$?

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/AbstractLibertyPluginSWTBotTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/AbstractLibertyPluginSWTBotTest.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package io.openliberty.tools.eclipse.test.it;
 
-import static io.openliberty.tools.eclipse.DevModeOperations.MVN_RUN_APP_LOG_FILE;
 import static io.openliberty.tools.eclipse.test.it.utils.LibertyPluginTestUtils.isInternalBrowserSupportAvailable;
 import static io.openliberty.tools.eclipse.test.it.utils.MagicWidgetFinder.go;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.closeWelcomePage;
@@ -83,10 +82,6 @@ public abstract class AbstractLibertyPluginSWTBotTest {
         return mvnCmdPath + File.separator + "bin" + File.separator + getMvnCmdFilename();
     }
 
-    public static boolean isMvnLogFile() {
-        return Boolean.getBoolean("io.liberty.tools.eclipse.tests.mvn.logfile");
-    }
-
     public static String getMvnCmdPath() {
         String pathVal = System.getProperty("io.liberty.tools.eclipse.tests.mvnexecutable.path");
         // Tycho "helpfully" converts empty/absent props to 'null' but we'd rather have an empty so we can use /
@@ -134,11 +129,6 @@ public abstract class AbstractLibertyPluginSWTBotTest {
     public void beforeEach(TestInfo info) {
         System.out.println(
                            "INFO: Test " + this.getClass().getSimpleName() + "#" + info.getDisplayName() + " entry: " + java.time.LocalDateTime.now());
-
-        if (isMvnLogFile()) {
-            // Turn on config to log dev mode output to file
-            System.setProperty(MVN_RUN_APP_LOG_FILE, "lte-dev-mode-output-" + getTimestamp() + ".log");
-        }
     }
 
     @AfterEach
@@ -250,11 +240,5 @@ public abstract class AbstractLibertyPluginSWTBotTest {
         }
 
         Assertions.fail("The debug configuration: " + configName + " was not found.");
-    }
-
-    private String getTimestamp() {
-        long currentTime = System.currentTimeMillis();
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd.HH-mm-ss.SSS");
-        return formatter.format(currentTime);
     }
 }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotGradleTest.java
@@ -29,6 +29,7 @@ import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchCustomDebugFromDashboard;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchCustomRunFromDashboard;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDashboardAction;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.waitForAndClickButton;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDebugConfigurationsDialogFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchRunConfigurationsDialogFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchRunTestsWithRunAsShortcut;
@@ -380,44 +381,87 @@ public class LibertyPluginSWTBotGradleTest extends AbstractLibertyPluginSWTBotTe
     }
 
     /**
-     * Tests stop of a server started outside of the current Liberty Tools Eclipse session
+     * Tests the restart of an externally started dev mode process when
+     * the user selects a start action using Liberty Tools.
      * 
      * @throws CommandNotFoundException
      * @throws IOException
      * @throws InterruptedException
      */
     @Test
-    @Disabled("Until the option to stop an externally start module is added. The stop action is no longer enabled if LT did not start dev mode.")
-    public void testDashboardStopExternalServer() throws CommandNotFoundException, IOException, InterruptedException {
+    public void testRestartOfExternallyStartedDevMode() throws CommandNotFoundException, IOException, InterruptedException {
         IProject iProject = LibertyPluginTestUtils.getProject(GRADLE_WRAPPER_APP_NAME);
         ProjectModel projectModel = new ProjectModel(iProject);
 
         Path wrapperProject = Paths.get("resources", "applications", "gradle", GRADLE_WRAPPER_APP_NAME).toAbsolutePath();
+        String libertyBasePath = wrapperProject.toString() + "/build";
 
-        // Doing a 'clean' first in case server was started previously and terminated abruptly
-        String cmd = CommandBuilder.constructGradleCommand(projectModel, "clean libertyDev", null).getCommand();
+        // Doing a 'clean' first in case server was started previously and terminated abruptly.
+        String startDevModeCmd = CommandBuilder.constructGradleCommand(projectModel, "clean libertyDev", null).getCommand();
 
         if (LibertyPluginTestUtils.onWindows()) {
-            cmd = "cmd.exe /c" + cmd;
+            startDevModeCmd = "cmd.exe /c" + startDevModeCmd;
         }
-        String[] cmdParts = cmd.split(" ");
-        ProcessBuilder pb = new ProcessBuilder(cmdParts).inheritIO().directory(wrapperProject.toFile()).redirectErrorStream(true);
-        pb.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
+        String[] startDMCmdParts = startDevModeCmd.split(" ");
+        ProcessBuilder startDMPB = new ProcessBuilder(startDMCmdParts).inheritIO().directory(wrapperProject.toFile()).redirectErrorStream(true);
+        startDMPB.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
 
-        Process p = pb.start();
-        p.waitFor(3, TimeUnit.SECONDS);
+        Process startDMProcess = startDMPB.start();
+        startDMProcess.waitFor(3, TimeUnit.SECONDS);
 
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(GRADLE_WRAPPER_APP_NAME, true, wrapperProject.toString() + "/target/liberty");
+        // Validate application is up and running outside of Liberty Tools.
+        LibertyPluginTestUtils.validateApplicationOutcome(GRADLE_WRAPPER_APP_NAME, true, libertyBasePath);
 
-        // Stop dev mode.
-        launchDashboardAction(GRADLE_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+        boolean devModeStopped = false;
+        try {
+            // Record the messages.log timestamp before triggering the restart. This is used
+            // after the restart to prove that the server genuinely restarted and was not
+            // simply left running from the original external process.
+            long timestampBeforeRestart = new File(libertyBasePath
+                                                   + "/wlp/usr/servers/defaultServer/logs/messages.log").lastModified();
 
-        bot.button("Yes").click();
+            // Trigger the start action. Liberty Tools detects the externally running server
+            // and opens a Yes/No dialog.
+            launchDashboardAction(GRADLE_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_START);
 
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(wrapperProject.toString() + "/build");
+            // Wait for the dialog and confirm the restart.
+            try {
+                waitForAndClickButton(bot, "Liberty Tools", "Yes", SWTBotTestCondition.SERVER_WAIT_MS);
+            } catch (org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException e) {
+                System.out.println("[testRestartOfExternallyStartedDevMode] Eclipse console output before dialog failure:\n"
+                                   + LibertyPluginTestUtils.getConsoleOutput());
+                throw e;
+            }
 
+            // Validate that the server came back up under Liberty Tools.
+            LibertyPluginTestUtils.validateApplicationOutcome(GRADLE_WRAPPER_APP_NAME, true, libertyBasePath);
+
+            // Validate that messages.log is newer than before the restart was triggered.
+            // A newer timestamp proves the server process was genuinely restarted and is not
+            // the original externally started instance still running.
+            LibertyPluginTestUtils.validateMessagesLogIsNewer(libertyBasePath, timestampBeforeRestart);
+
+            // Stop dev mode via Liberty Tools.
+            launchDashboardAction(GRADLE_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+            LibertyPluginTestUtils.validateLibertyServerStopped(libertyBasePath);
+            devModeStopped = true;
+        } finally {
+            if (!devModeStopped) {
+                String stopDevModeCmd = CommandBuilder.constructGradleCommand(projectModel, "clean libertyStop", null).getCommand();
+
+                if (LibertyPluginTestUtils.onWindows()) {
+                    stopDevModeCmd = "cmd.exe /c" + stopDevModeCmd;
+                }
+                String[] stopDMCmdParts = stopDevModeCmd.split(" ");
+                ProcessBuilder stopDMPB = new ProcessBuilder(stopDMCmdParts).inheritIO().directory(wrapperProject.toFile()).redirectErrorStream(true);
+                stopDMPB.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
+
+                Process stopDMProcess = stopDMPB.start();
+                stopDMProcess.waitFor(3, TimeUnit.SECONDS);
+                
+                LibertyPluginTestUtils.validateLibertyServerStopped(libertyBasePath);
+            }
+        }
     }
 
     /**

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMavenTest.java
@@ -30,6 +30,7 @@ import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchCustomDebugFromDashboard;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchCustomRunFromDashboard;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDashboardAction;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.waitForAndClickButton;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDebugConfigurationsDialogFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchRunConfigurationsDialogFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchRunTestsWithRunAsShortcut;
@@ -412,47 +413,94 @@ public class LibertyPluginSWTBotMavenTest extends AbstractLibertyPluginSWTBotTes
     }
 
     /**
-     * Tests stop of a server started outside of the current Liberty Tools Eclipse session
+     * Tests the restart of an externally started dev mode process when
+     * the user selects a start action using Liberty Tools.
      * 
      * @throws CommandNotFoundException
      * @throws IOException
      * @throws InterruptedException
      */
     @Test
-    @Disabled("Until the option to stop an externally start module is added. The stop action is no longer enabled if LT did not start dev mode.")
-    public void testDashboardStopExternalServer() throws CommandNotFoundException, IOException, InterruptedException {
+    public void testRestartOfExternallyStartedDevMode() throws CommandNotFoundException, IOException, InterruptedException {
 
         Path projAbsolutePath = wrapperProjectPath.toAbsolutePath();
         IProject iProject = LibertyPluginTestUtils.getProject(MVN_WRAPPER_APP_NAME);
         ProjectModel projectModel = new ProjectModel(iProject);
+        String libertyBasePath = projAbsolutePath.toString() + "/target/liberty";
 
         // Doing a 'clean' first in case server was started previously and terminated abruptly. App tests may fail,
         // making it look like an "outer", actual test is failing, so we skip the tests.
-        String cmd = CommandBuilder.constructMavenCommand(projectModel,
-                                                          "clean io.openliberty.tools:liberty-maven-plugin:dev -DskipITs=true", null).getCommand();
+        String startDevModeCmd = CommandBuilder.constructMavenCommand(projectModel,
+                                                                      "clean io.openliberty.tools:liberty-maven-plugin:dev -DskipITs=true", null).getCommand();
 
         if (LibertyPluginTestUtils.onWindows()) {
-            cmd = "cmd.exe /c" + cmd;
+            startDevModeCmd = "cmd.exe /c" + startDevModeCmd;
         }
 
-        String[] cmdParts = cmd.split(" ");
-        ProcessBuilder pb = new ProcessBuilder(cmdParts).inheritIO().directory(projAbsolutePath.toFile()).redirectErrorStream(true);
-        pb.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
+        String[] startDevModeCmdParts = startDevModeCmd.split(" ");
+        ProcessBuilder startDMPB = new ProcessBuilder(startDevModeCmdParts).inheritIO().directory(projAbsolutePath.toFile()).redirectErrorStream(true);
+        startDMPB.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
 
-        Process p = pb.start();
-        p.waitFor(3, TimeUnit.SECONDS);
+        Process startDMProcess = startDMPB.start();
+        startDMProcess.waitFor(3, TimeUnit.SECONDS);
 
-        // Validate application is up and running.
-        LibertyPluginTestUtils.validateApplicationOutcome(MVN_WRAPPER_APP_NAME, true,
-                                                          wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
+        // Validate application is up and running outside of Liberty Tools.
+        LibertyPluginTestUtils.validateApplicationOutcome(MVN_WRAPPER_APP_NAME, true, libertyBasePath);
 
-        // Stop dev mode.
-        launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+        boolean devModeStopped = false;
+        try {
+            // Record the messages.log timestamp before triggering the restart. This is used
+            // after the restart to prove that the server genuinely restarted and was not
+            // simply left running from the original external process.
+            long timestampBeforeRestart = new File(libertyBasePath
+                                                   + "/wlp/usr/servers/defaultServer/logs/messages.log").lastModified();
 
-        bot.button("Yes").click();
+            // Trigger the start action. Liberty Tools detects the externally running server
+            // and opens a Yes/No dialog.
+            launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_START);
 
-        // Validate application stopped.
-        LibertyPluginTestUtils.validateLibertyServerStopped(wrapperProjectPath.toAbsolutePath().toString() + "/target/liberty");
+            // Wait for the dialog and confirm the restart.
+            try {
+                waitForAndClickButton(bot, "Liberty Tools", "Yes", SWTBotTestCondition.SERVER_WAIT_MS);
+            } catch (org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException e) {
+                System.out.println("[testRestartOfExternallyStartedDevMode] Eclipse console output before dialog failure:\n"
+                                   + LibertyPluginTestUtils.getConsoleOutput());
+                throw e;
+            }
+
+            // Validate that the server came back up under Liberty Tools.
+            LibertyPluginTestUtils.validateApplicationOutcome(MVN_WRAPPER_APP_NAME, true, libertyBasePath);
+
+            // Validate that messages.log is newer than before the restart was triggered.
+            // A newer timestamp proves the server process was genuinely restarted and is not
+            // the original externally started instance still running.
+            LibertyPluginTestUtils.validateMessagesLogIsNewer(libertyBasePath, timestampBeforeRestart);
+
+            // Stop dev mode via Liberty Tools.
+            launchDashboardAction(MVN_WRAPPER_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+            LibertyPluginTestUtils.validateLibertyServerStopped(libertyBasePath);
+            devModeStopped = true;
+        } finally {
+            if (!devModeStopped) {
+                // Doing a 'clean' first in case server was started previously and terminated abruptly. App tests may fail,
+                // making it look like an "outer", actual test is failing, so we skip the tests.
+                String stopDevModeCmd = CommandBuilder.constructMavenCommand(projectModel,
+                                                                             "io.openliberty.tools:liberty-maven-plugin:stop", null).getCommand();
+
+                if (LibertyPluginTestUtils.onWindows()) {
+                    stopDevModeCmd = "cmd.exe /c" + stopDevModeCmd;
+                }
+
+                String[] stopDevModeCmdParts = stopDevModeCmd.split(" ");
+                ProcessBuilder stopDMPB = new ProcessBuilder(stopDevModeCmdParts).inheritIO().directory(projAbsolutePath.toFile()).redirectErrorStream(true);
+                stopDMPB.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
+
+                Process stopDMProcess = stopDMPB.start();
+                stopDMProcess.waitFor(3, TimeUnit.SECONDS);
+
+                LibertyPluginTestUtils.validateLibertyServerStopped(libertyBasePath);
+            }
+        }
     }
 
     /**

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiLibertyModMavenTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiLibertyModMavenTest.java
@@ -26,6 +26,7 @@ import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getModuleSelectionDialogItems;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.getRunConfigurationsShell;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDashboardAction;
+import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.waitForAndClickButton;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchDebugConfigurationsDialogFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchRunConfigurationsDialogFromAppRunAs;
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.launchStartWithRunAsShortcut;
@@ -38,13 +39,16 @@ import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.
 import static io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations.waitForModuleSelectionDialog;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
@@ -56,6 +60,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import io.openliberty.tools.eclipse.CommandBuilder.CommandNotFoundException;
 import io.openliberty.tools.eclipse.test.it.utils.LibertyPluginTestUtils;
 import io.openliberty.tools.eclipse.test.it.utils.SWTBotPluginOperations;
 import io.openliberty.tools.eclipse.test.it.utils.SWTBotTestCondition;
@@ -117,16 +122,16 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
      * Expected dashboard menu items for the root aggregator project.
      */
     static final String[] mvnMenuItems = new String[] {
-        DashboardView.APP_MENU_ACTION_START,
-        DashboardView.APP_MENU_ACTION_START_CONFIG,
-        DashboardView.APP_MENU_ACTION_START_IN_CONTAINER,
-        DashboardView.APP_MENU_ACTION_DEBUG,
-        DashboardView.APP_MENU_ACTION_DEBUG_CONFIG,
-        DashboardView.APP_MENU_ACTION_DEBUG_IN_CONTAINER,
-        DashboardView.APP_MENU_ACTION_STOP,
-        DashboardView.APP_MENU_ACTION_RUN_TESTS,
-        DashboardView.APP_MENU_ACTION_VIEW_MVN_IT_REPORT,
-        DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT
+                                                        DashboardView.APP_MENU_ACTION_START,
+                                                        DashboardView.APP_MENU_ACTION_START_CONFIG,
+                                                        DashboardView.APP_MENU_ACTION_START_IN_CONTAINER,
+                                                        DashboardView.APP_MENU_ACTION_DEBUG,
+                                                        DashboardView.APP_MENU_ACTION_DEBUG_CONFIG,
+                                                        DashboardView.APP_MENU_ACTION_DEBUG_IN_CONTAINER,
+                                                        DashboardView.APP_MENU_ACTION_STOP,
+                                                        DashboardView.APP_MENU_ACTION_RUN_TESTS,
+                                                        DashboardView.APP_MENU_ACTION_VIEW_MVN_IT_REPORT,
+                                                        DashboardView.APP_MENU_ACTION_VIEW_MVN_UT_REPORT
     };
 
     /**
@@ -135,11 +140,11 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
      * not listed here.
      */
     static final String[] runAsShortcuts = new String[] {
-        LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START,
-        LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONFIG,
-        LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER,
-        LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT,
-        LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT
+                                                          LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START,
+                                                          LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONFIG,
+                                                          LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER,
+                                                          LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_IT_REPORT,
+                                                          LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_MVN_VIEW_UT_REPORT
     };
 
     static File workspaceRoot = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile();
@@ -215,7 +220,7 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
     public static final void validateBeforeTestRun() {
 
         SWTBotTestCondition.waitFor(
-            () -> getDashboardContent().contains(MVN_APP_NAME), SWTBotTestCondition.LARGE_WAIT_MS);
+                                    () -> getDashboardContent().contains(MVN_APP_NAME), SWTBotTestCondition.LARGE_WAIT_MS);
 
         List<String> projectList = getDashboardContent();
         boolean foundApp = false;
@@ -229,15 +234,15 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
         List<String> menuItems = getDashboardItemMenuActions(MVN_APP_NAME);
         Assertions.assertTrue(menuItems.size() == mvnMenuItems.length,
-            () -> "Maven application " + MVN_APP_NAME + " does not contain the expected number of menu items: " + mvnMenuItems.length);
+                              () -> "Maven application " + MVN_APP_NAME + " does not contain the expected number of menu items: " + mvnMenuItems.length);
         Assertions.assertTrue(menuItems.containsAll(Arrays.asList(mvnMenuItems)),
-            () -> "Maven application " + MVN_APP_NAME + " does not contain the expected menu items: " + Arrays.toString(mvnMenuItems));
+                              () -> "Maven application " + MVN_APP_NAME + " does not contain the expected menu items: " + Arrays.toString(mvnMenuItems));
 
         SWTBotMenu runAsMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, MVN_APP_NAME);
         Assertions.assertNotNull(runAsMenu, "The Run As menu associated with project " + MVN_APP_NAME + " is null.");
         List<String> runAsMenuItems = runAsMenu.menuItems();
         Assertions.assertTrue(runAsMenuItems != null && !runAsMenuItems.isEmpty(),
-            "The Run As menu associated with project " + MVN_APP_NAME + " is null or empty.");
+                              "The Run As menu associated with project " + MVN_APP_NAME + " is null or empty.");
 
         int foundItems = 0;
         for (String expectedItem : runAsShortcuts) {
@@ -249,9 +254,9 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
             }
         }
         Assertions.assertTrue(foundItems == runAsShortcuts.length,
-            "The Run As menu associated with project " + MVN_APP_NAME
-                + " does not contain one or more expected entries. Expected: " + runAsShortcuts.length
-                + ", found: " + foundItems + ". Items: " + runAsMenuItems);
+                              "The Run As menu associated with project " + MVN_APP_NAME
+                                                                   + " does not contain one or more expected entries. Expected: " + runAsShortcuts.length
+                                                                   + ", found: " + foundItems + ". Items: " + runAsMenuItems);
 
         Shell configShell = launchRunConfigurationsDialogFromAppRunAs(MVN_APP_NAME);
         try {
@@ -278,12 +283,12 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
     public void testDashboardActionsOpenModuleSelectionDialogWithCorrectCount() {
 
         String[] actionsWithInactiveModuleFilter = new String[] {
-            DashboardView.APP_MENU_ACTION_START,
-            DashboardView.APP_MENU_ACTION_DEBUG,
-            DashboardView.APP_MENU_ACTION_START_CONFIG,
-            DashboardView.APP_MENU_ACTION_DEBUG_CONFIG,
-            DashboardView.APP_MENU_ACTION_START_IN_CONTAINER,
-            DashboardView.APP_MENU_ACTION_DEBUG_IN_CONTAINER
+                                                                  DashboardView.APP_MENU_ACTION_START,
+                                                                  DashboardView.APP_MENU_ACTION_DEBUG,
+                                                                  DashboardView.APP_MENU_ACTION_START_CONFIG,
+                                                                  DashboardView.APP_MENU_ACTION_DEBUG_CONFIG,
+                                                                  DashboardView.APP_MENU_ACTION_START_IN_CONTAINER,
+                                                                  DashboardView.APP_MENU_ACTION_DEBUG_IN_CONTAINER
         };
 
         for (String action : actionsWithInactiveModuleFilter) {
@@ -291,20 +296,20 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
             Shell dialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
             Assertions.assertNotNull(dialog,
-                "Module selection dialog did not open for dashboard action: " + action);
+                                     "Module selection dialog did not open for dashboard action: " + action);
 
             int count = getModuleSelectionDialogItemCount(dialog);
             List<String> items = getModuleSelectionDialogItems(dialog);
             Assertions.assertEquals(EXPECTED_LIBERTY_MODULE_COUNT, count,
-                "Dashboard action '" + action + "' should list " + EXPECTED_LIBERTY_MODULE_COUNT
-                    + " Liberty modules in the selection dialog, but found " + count + ". Items: " + items);
+                                    "Dashboard action '" + action + "' should list " + EXPECTED_LIBERTY_MODULE_COUNT
+                                                                          + " Liberty modules in the selection dialog, but found " + count + ". Items: " + items);
 
             Assertions.assertTrue(items.contains(MVN_EAR1_MODULE_NAME),
-                "Selection dialog for action '" + action + "' is missing module: " + MVN_EAR1_MODULE_NAME);
+                                  "Selection dialog for action '" + action + "' is missing module: " + MVN_EAR1_MODULE_NAME);
             Assertions.assertTrue(items.contains(MVN_EAR2_MODULE_NAME),
-                "Selection dialog for action '" + action + "' is missing module: " + MVN_EAR2_MODULE_NAME);
+                                  "Selection dialog for action '" + action + "' is missing module: " + MVN_EAR2_MODULE_NAME);
             Assertions.assertTrue(items.contains(MVN_EAR_SKINNY_MODULE_NAME),
-                "Selection dialog for action '" + action + "' is missing module: " + MVN_EAR_SKINNY_MODULE_NAME);
+                                  "Selection dialog for action '" + action + "' is missing module: " + MVN_EAR_SKINNY_MODULE_NAME);
 
             cancelModuleSelectionDialog(dialog);
         }
@@ -322,34 +327,36 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
         launchStartWithRunAsShortcut(MVN_APP_NAME);
         Shell startDialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(startDialog,
-            "Module selection dialog did not open for the Run As Start shortcut.");
+                                 "Module selection dialog did not open for the Run As Start shortcut.");
         int startCount = getModuleSelectionDialogItemCount(startDialog);
         List<String> startItems = getModuleSelectionDialogItems(startDialog);
         Assertions.assertEquals(EXPECTED_LIBERTY_MODULE_COUNT, startCount,
-            "Run As Start shortcut should list " + EXPECTED_LIBERTY_MODULE_COUNT
-                + " Liberty modules, but found " + startCount + ". Items: " + startItems);
+                                "Run As Start shortcut should list " + EXPECTED_LIBERTY_MODULE_COUNT
+                                                                           + " Liberty modules, but found " + startCount + ". Items: " + startItems);
         cancelModuleSelectionDialog(startDialog);
 
         // Verify the Start in Container shortcut.
-        SWTBotMenu containerMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, MVN_APP_NAME)
-            .menu(WidgetMatcherFactory.withRegex(
-                ".*" + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER + ".*"), false, 0);
+        SWTBotMenu containerMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, MVN_APP_NAME).menu(WidgetMatcherFactory.withRegex(
+                                                                                                                                 ".*"
+                                                                                                                                 + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER
+                                                                                                                                 + ".*"),
+                                                                                                  false, 0);
         containerMenu.click();
 
         Shell containerDialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(containerDialog,
-            "Module selection dialog did not open for the Run As Start in Container shortcut.");
+                                 "Module selection dialog did not open for the Run As Start in Container shortcut.");
         int containerCount = getModuleSelectionDialogItemCount(containerDialog);
         List<String> containerItems = getModuleSelectionDialogItems(containerDialog);
         Assertions.assertEquals(EXPECTED_LIBERTY_MODULE_COUNT, containerCount,
-            "Run As Start in Container shortcut should list " + EXPECTED_LIBERTY_MODULE_COUNT
-                + " Liberty modules, but found " + containerCount + ". Items: " + containerItems);
+                                "Run As Start in Container shortcut should list " + EXPECTED_LIBERTY_MODULE_COUNT
+                                                                               + " Liberty modules, but found " + containerCount + ". Items: " + containerItems);
         cancelModuleSelectionDialog(containerDialog);
     }
 
     /**
-     * Tests the Start/Stop dashboard actions. More precisely, it tests that the module 
-     * selection dialog opens when the start action is selected. 
+     * Tests the Start/Stop dashboard actions. More precisely, it tests that the module
+     * selection dialog opens when the start action is selected.
      * After selecting the the module, the Liberty server starts for the selected module.
      * Last, when the stop actions through the dashboard, the server is stopped.
      */
@@ -365,13 +372,13 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
         int count = getModuleSelectionDialogItemCount(startDialog);
         Assertions.assertEquals(EXPECTED_LIBERTY_MODULE_COUNT, count,
-            "Expected " + EXPECTED_LIBERTY_MODULE_COUNT + " Liberty modules in the selection dialog, but found " + count + ".");
+                                "Expected " + EXPECTED_LIBERTY_MODULE_COUNT + " Liberty modules in the selection dialog, but found " + count + ".");
 
         selectModuleInDialog(startDialog, MVN_EAR1_MODULE_NAME);
 
         LibertyPluginTestUtils.validateApplicationOutcomeCustom(
-            "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
-            "Height in feet and inches", ear1ServerPath.toString());
+                                                                "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
+                                                                "Height in feet and inches", ear1ServerPath.toString());
 
         pressWorkspaceErrorDialogProceedButton(bot);
 
@@ -397,13 +404,13 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
         int count = getModuleSelectionDialogItemCount(debugDialog);
         Assertions.assertEquals(EXPECTED_LIBERTY_MODULE_COUNT, count,
-            "Expected " + EXPECTED_LIBERTY_MODULE_COUNT + " Liberty modules in the selection dialog, but found " + count + ".");
+                                "Expected " + EXPECTED_LIBERTY_MODULE_COUNT + " Liberty modules in the selection dialog, but found " + count + ".");
 
         selectModuleInDialog(debugDialog, MVN_EAR1_MODULE_NAME);
 
         LibertyPluginTestUtils.validateApplicationOutcomeCustom(
-            "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
-            "Height in feet and inches", ear1ServerPath.toString());
+                                                                "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
+                                                                "Height in feet and inches", ear1ServerPath.toString());
 
         pressWorkspaceErrorDialogProceedButton(bot);
 
@@ -414,8 +421,8 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
     /**
      * Tests the Start with configuration dashboard action. More precisely, test that
-     * the Run Configurations dialog opens, the user presses Run, the module selection 
-     * dialog appears with the expected modules, a module is selected, the server starts, 
+     * the Run Configurations dialog opens, the user presses Run, the module selection
+     * dialog appears with the expected modules, a module is selected, the server starts,
      * and when the stop action is issued from the dashboard, the server is stopped.
      */
     @Test
@@ -427,22 +434,22 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
         Shell dialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(dialog,
-            "Module selection dialog did not open after pressing Run in the Run Configurations dialog.");
+                                 "Module selection dialog did not open after pressing Run in the Run Configurations dialog.");
 
         int count = getModuleSelectionDialogItemCount(dialog);
         Assertions.assertEquals(EXPECTED_LIBERTY_MODULE_COUNT, count,
-            "Expected " + EXPECTED_LIBERTY_MODULE_COUNT + " Liberty modules in the selection dialog, but found " + count + ".");
+                                "Expected " + EXPECTED_LIBERTY_MODULE_COUNT + " Liberty modules in the selection dialog, but found " + count + ".");
 
         selectModuleInDialog(dialog, MVN_EAR1_MODULE_NAME);
-        
+
         Shell configShell = getRunConfigurationsShell();
         Assertions.assertNotNull(configShell, "Run Configurations dialog did not open.");
 
         go("Run", configShell);
 
         LibertyPluginTestUtils.validateApplicationOutcomeCustom(
-            "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
-            "Height in feet and inches", ear1ServerPath.toString());
+                                                                "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
+                                                                "Height in feet and inches", ear1ServerPath.toString());
 
         pressWorkspaceErrorDialogProceedButton(bot);
 
@@ -453,7 +460,7 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
     /**
      * Tests the Run As Start shortcut end-to-end. More precisely, test that the module
-     * selection dialog opens, a module is selected, the Liberty server starts, and 
+     * selection dialog opens, a module is selected, the Liberty server starts, and
      * when the stop action is issued from the the Run As context menu, the server
      * is stopped.
      */
@@ -466,17 +473,17 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
         Shell dialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(dialog,
-            "Module selection dialog did not open for the Run As Start shortcut.");
+                                 "Module selection dialog did not open for the Run As Start shortcut.");
 
         int count = getModuleSelectionDialogItemCount(dialog);
         Assertions.assertEquals(EXPECTED_LIBERTY_MODULE_COUNT, count,
-            "Expected " + EXPECTED_LIBERTY_MODULE_COUNT + " Liberty modules in the selection dialog, but found " + count + ".");
+                                "Expected " + EXPECTED_LIBERTY_MODULE_COUNT + " Liberty modules in the selection dialog, but found " + count + ".");
 
         selectModuleInDialog(dialog, MVN_EAR1_MODULE_NAME);
 
         LibertyPluginTestUtils.validateApplicationOutcomeCustom(
-            "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
-            "Height in feet and inches", ear1ServerPath.toString());
+                                                                "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
+                                                                "Height in feet and inches", ear1ServerPath.toString());
 
         pressWorkspaceErrorDialogProceedButton(bot);
 
@@ -499,7 +506,7 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
         Shell dialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(dialog,
-            "Module selection dialog did not open for the Run As Start shortcut.");
+                                 "Module selection dialog did not open for the Run As Start shortcut.");
 
         // Type "ear1" into the filter field. The dialog should reduce the visible list
         // to only items whose name contains "ear1".
@@ -513,9 +520,9 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
 
         List<String> filteredItems = getModuleSelectionDialogItems(dialog);
         Assertions.assertEquals(1, filteredItems.size(),
-            "After typing 'ear1', the selection dialog should show exactly 1 item, but found: " + filteredItems);
+                                "After typing 'ear1', the selection dialog should show exactly 1 item, but found: " + filteredItems);
         Assertions.assertTrue(filteredItems.get(0).contains("ear1"),
-            "The remaining item after filtering by 'ear1' should contain 'ear1' in its name, but was: " + filteredItems.get(0));
+                              "The remaining item after filtering by 'ear1' should contain 'ear1' in its name, but was: " + filteredItems.get(0));
 
         cancelModuleSelectionDialog(dialog);
     }
@@ -525,11 +532,11 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
      * decrease. The scenario is:
      * 1. Start ear1 from the parent. The selection dialog shows 3 inactive modules. Select ear1.
      * 2. Start ear2 from the parent. The selection dialog now shows 2 inactive modules (ear2 and
-     *    ear-skinny-modules). Select ear2.
+     * ear-skinny-modules). Select ear2.
      * 3. Stop from the parent. The selection dialog shows 2 active modules (ear1 and ear2).
-     *    Select ear2. Verify ear2 stops.
+     * Select ear2. Verify ear2 stops.
      * 4. Stop from the parent again. Because only one active module (ear1) remains, no
-     *    selection dialog is shown and ear1 stops directly.
+     * selection dialog is shown and ear1 stops directly.
      */
     @Test
     public void testStopDialogCountReducesAsModulesStop() {
@@ -542,13 +549,13 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
         Assertions.assertNotNull(startDialog1, "Module selection dialog did not open when starting ear1.");
         int countBeforeFirstStart = getModuleSelectionDialogItemCount(startDialog1);
         Assertions.assertEquals(EXPECTED_LIBERTY_MODULE_COUNT, countBeforeFirstStart,
-            "Before any module is started, the dialog should show " + EXPECTED_LIBERTY_MODULE_COUNT
-                + " inactive modules, but found " + countBeforeFirstStart + ".");
+                                "Before any module is started, the dialog should show " + EXPECTED_LIBERTY_MODULE_COUNT
+                                                                                      + " inactive modules, but found " + countBeforeFirstStart + ".");
         selectModuleInDialog(startDialog1, MVN_EAR1_MODULE_NAME);
 
         LibertyPluginTestUtils.validateApplicationOutcomeCustom(
-            "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
-            "Height in feet and inches", ear1ServerPath.toString());
+                                                                "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
+                                                                "Height in feet and inches", ear1ServerPath.toString());
         pressWorkspaceErrorDialogProceedButton(bot);
 
         // Step 2: Start ear2. Only 2 inactive modules should remain (ear2 and ear-skinny-modules).
@@ -557,12 +564,12 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
         Assertions.assertNotNull(startDialog2, "Module selection dialog did not open when starting ear2.");
         int countAfterFirstStart = getModuleSelectionDialogItemCount(startDialog2);
         Assertions.assertEquals(2, countAfterFirstStart,
-            "After ear1 is running, the dialog should show 2 inactive modules, but found " + countAfterFirstStart + ".");
+                                "After ear1 is running, the dialog should show 2 inactive modules, but found " + countAfterFirstStart + ".");
         selectModuleInDialog(startDialog2, MVN_EAR2_MODULE_NAME);
 
         LibertyPluginTestUtils.validateApplicationOutcomeCustom(
-            "http://localhost:9081/converter/heights.jsp?heightCm=20", true,
-            "Height in feet and inches", ear2ServerPath.toString());
+                                                                "http://localhost:9081/converter/heights.jsp?heightCm=20", true,
+                                                                "Height in feet and inches", ear2ServerPath.toString());
         pressWorkspaceErrorDialogProceedButton(bot);
 
         // Step 3: Stop from the parent. Both ear1 and ear2 are active so the dialog should
@@ -570,16 +577,16 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
         launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
         Shell stopDialog1 = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(stopDialog1,
-            "Module selection dialog did not open for Stop when both ear1 and ear2 are active.");
+                                 "Module selection dialog did not open for Stop when both ear1 and ear2 are active.");
         int activeCount = getModuleSelectionDialogItemCount(stopDialog1);
         List<String> activeItems = getModuleSelectionDialogItems(stopDialog1);
         Assertions.assertEquals(2, activeCount,
-            "With ear1 and ear2 running, the Stop dialog should show 2 active modules, but found "
-                + activeCount + ". Items: " + activeItems);
+                                "With ear1 and ear2 running, the Stop dialog should show 2 active modules, but found "
+                                                + activeCount + ". Items: " + activeItems);
         Assertions.assertTrue(activeItems.contains(MVN_EAR1_MODULE_NAME),
-            "Stop dialog should list " + MVN_EAR1_MODULE_NAME + " as active.");
+                              "Stop dialog should list " + MVN_EAR1_MODULE_NAME + " as active.");
         Assertions.assertTrue(activeItems.contains(MVN_EAR2_MODULE_NAME),
-            "Stop dialog should list " + MVN_EAR2_MODULE_NAME + " as active.");
+                              "Stop dialog should list " + MVN_EAR2_MODULE_NAME + " as active.");
         selectModuleInDialog(stopDialog1, MVN_EAR2_MODULE_NAME);
 
         LibertyPluginTestUtils.validateLibertyServerStopped(ear2ServerPath.toString());
@@ -589,7 +596,7 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
         launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
         Shell stopDialog2 = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNull(stopDialog2,
-            "With only ear1 active, the Stop action should not show a selection dialog, but one appeared.");
+                              "With only ear1 active, the Stop action should not show a selection dialog, but one appeared.");
 
         LibertyPluginTestUtils.validateLibertyServerStopped(ear1ServerPath.toString());
     }
@@ -616,15 +623,15 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
         List<String> filteredContent = getDashboardContent();
 
         Assertions.assertTrue(filteredContent.contains(MVN_APP_NAME),
-            "The parent aggregator project " + MVN_APP_NAME + " should be visible after filtering by 'ear2'.");
+                              "The parent aggregator project " + MVN_APP_NAME + " should be visible after filtering by 'ear2'.");
         Assertions.assertTrue(filteredContent.contains(MVN_EAR2_MODULE_NAME),
-            "Module " + MVN_EAR2_MODULE_NAME + " should be visible after filtering by 'ear2'.");
+                              "Module " + MVN_EAR2_MODULE_NAME + " should be visible after filtering by 'ear2'.");
         Assertions.assertFalse(filteredContent.contains(MVN_EAR1_MODULE_NAME),
-            "Module " + MVN_EAR1_MODULE_NAME + " should not be visible after filtering by 'ear2'.");
+                               "Module " + MVN_EAR1_MODULE_NAME + " should not be visible after filtering by 'ear2'.");
         Assertions.assertFalse(filteredContent.contains(MVN_EAR_SKINNY_MODULE_NAME),
-            "Module " + MVN_EAR_SKINNY_MODULE_NAME + " should not be visible after filtering by 'ear2'.");
+                               "Module " + MVN_EAR_SKINNY_MODULE_NAME + " should not be visible after filtering by 'ear2'.");
         Assertions.assertEquals(2, filteredContent.size(),
-            "Dashboard should show exactly 2 items (parent + ear2) after filtering, but found: " + filteredContent);
+                                "Dashboard should show exactly 2 items (parent + ear2) after filtering, but found: " + filteredContent);
 
         // Clear the filter so the full dashboard is restored for subsequent tests.
         clearDashboardFilter(bot);
@@ -634,7 +641,7 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
             return content.contains(MVN_EAR1_MODULE_NAME) && content.contains(MVN_EAR_SKINNY_MODULE_NAME);
         }, SWTBotTestCondition.MIN_WAIT_MS);
     }
-    
+
     /**
      * Tests the Collapse All toolbar button in the Liberty dashboard. After collapsing,
      * none of the root-level tree items should have expanded children visible in the tree.
@@ -665,7 +672,7 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
         // Verify that no root-level item is expanded.
         for (org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem item : SWTBotPluginOperations.getDashboardTree().getAllItems()) {
             Assertions.assertFalse(item.isExpanded(),
-                "Dashboard tree item '" + item.getText() + "' should be collapsed after Collapse All, but it is expanded.");
+                                   "Dashboard tree item '" + item.getText() + "' should be collapsed after Collapse All, but it is expanded.");
         }
     }
 
@@ -715,12 +722,126 @@ public class LibertyPluginSWTBotMultiLibertyModMavenTest extends AbstractLiberty
         }
 
         Assertions.assertTrue(parentExpanded,
-            "The parent project " + MVN_APP_NAME + " should be expanded after Expand All.");
+                              "The parent project " + MVN_APP_NAME + " should be expanded after Expand All.");
         Assertions.assertTrue(visibleChildren.contains(MVN_EAR1_MODULE_NAME),
-            "After Expand All, " + MVN_EAR1_MODULE_NAME + " should be visible as a child of " + MVN_APP_NAME + ".");
+                              "After Expand All, " + MVN_EAR1_MODULE_NAME + " should be visible as a child of " + MVN_APP_NAME + ".");
         Assertions.assertTrue(visibleChildren.contains(MVN_EAR2_MODULE_NAME),
-            "After Expand All, " + MVN_EAR2_MODULE_NAME + " should be visible as a child of " + MVN_APP_NAME + ".");
+                              "After Expand All, " + MVN_EAR2_MODULE_NAME + " should be visible as a child of " + MVN_APP_NAME + ".");
         Assertions.assertTrue(visibleChildren.contains(MVN_EAR_SKINNY_MODULE_NAME),
                               "After Expand All, " + MVN_EAR_SKINNY_MODULE_NAME + " should be visible as a child of " + MVN_APP_NAME + ".");
+    }
+
+    /**
+     * Tests the restart of an externally started dev mode process for a single Liberty
+     * module in a multi-module Maven project. The scenario is:
+     *
+     * 1. Start ear1 externally using the Maven -pl and -am flags so that Liberty Tools
+     * has no knowledge of the running process.
+     * 2. Trigger the dashboard Start action from the parent aggregator project. The module
+     * selection dialog appears because all modules are in scope. Select ear1.
+     * 3. Liberty Tools detects that ear1 is already running and opens a Yes/No dialog.
+     * Click Yes to confirm the stop and restart.
+     * 4. Validate that the server was genuinely restarted by checking that messages.log
+     * is newer than the timestamp recorded before the restart was triggered.
+     * 5. Stop ear1 from the parent using the dashboard Stop action. Since only one module
+     * is active, no module selection dialog is expected. Validate that dev mode stopped.
+     *
+     * @throws CommandNotFoundException If the Maven command cannot be constructed.
+     * @throws IOException              If the external process cannot be started.
+     * @throws InterruptedException     If the process wait is interrupted.
+     */
+    @Test
+    public void testRestartOfExternallyStartedDevMode() throws IOException, InterruptedException {
+
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(MVN_APP_NAME);
+
+        Path rootPath = rootProjectPath.toAbsolutePath();
+
+        // Start ear1 externally using -pl ear1 -am so that Liberty Tools has no
+        // knowledge of the running process.
+        String startDevModeCmd = "io.openliberty.tools:liberty-maven-plugin:dev -pl ear1 -am -DskipITs=true";
+        if (LibertyPluginTestUtils.onWindows()) {
+            startDevModeCmd = "cmd.exe /c mvn " + startDevModeCmd;
+        } else {
+            startDevModeCmd = "mvn " + startDevModeCmd;
+        }
+
+        String[] startDMCmdParts = startDevModeCmd.split(" ");
+        ProcessBuilder starDMPB = new ProcessBuilder(startDMCmdParts).inheritIO().directory(rootPath.toFile()).redirectErrorStream(true);
+        starDMPB.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
+
+        Process startDMProcess = starDMPB.start();
+        startDMProcess.waitFor(3, TimeUnit.SECONDS);
+
+        // Validate that ear1 is up and running outside of Liberty Tools.
+        LibertyPluginTestUtils.validateApplicationOutcomeCustom(
+                                                                "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
+                                                                "Height in feet and inches", ear1ServerPath.toString());
+
+        boolean devModeStopped = false;
+        try {
+            // Record the messages.log timestamp before triggering the restart. This is used
+            // after the restart to prove that the server genuinely restarted and was not
+            // simply left running from the original external process.
+            long timestampBeforeRestart = new File(ear1ServerPath.toString()
+                                                   + "/wlp/usr/servers/defaultServer/logs/messages.log").lastModified();
+
+            // Trigger the Start action from the parent dashboard. A module selection dialog
+            // appears showing all inactive modules. Select ear1.
+            launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_START);
+
+            Shell moduleDialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
+            Assertions.assertNotNull(moduleDialog,
+                                     "Module selection dialog did not open when triggering Start with ear1 running externally.");
+            selectModuleInDialog(moduleDialog, MVN_EAR1_MODULE_NAME);
+
+            // Liberty Tools detects that ear1 is already running. Wait for the Yes/No dialog
+            // and confirm the restart.
+            try {
+                waitForAndClickButton(bot, "Liberty Tools", "Yes", SWTBotTestCondition.SERVER_WAIT_MS);
+            } catch (org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException e) {
+                System.out.println("[testRestartOfExternallyStartedDevMode] Eclipse console output before dialog failure:\n"
+                                   + LibertyPluginTestUtils.getConsoleOutput());
+                throw e;
+            }
+
+            // Validate that the server came back up under Liberty Tools.
+            LibertyPluginTestUtils.validateApplicationOutcomeCustom(
+                                                                    "http://localhost:9080/converter/heights.jsp?heightCm=10", true,
+                                                                    "Height in feet and inches", ear1ServerPath.toString());
+
+            // Validate that messages.log is newer than before the restart was triggered.
+            // A newer timestamp proves the server process was genuinely restarted and is not
+            // the original externally started instance still running.
+            LibertyPluginTestUtils.validateMessagesLogIsNewer(ear1ServerPath.toString(), timestampBeforeRestart);
+
+            pressWorkspaceErrorDialogProceedButton(bot);
+
+            // Stop ear1 from the parent dashboard Stop action. Only one module is active so
+            // no module selection dialog is expected and ear1 stops directly.
+            launchDashboardAction(MVN_APP_NAME, DashboardView.APP_MENU_ACTION_STOP);
+
+            LibertyPluginTestUtils.validateLibertyServerStopped(ear1ServerPath.toString());
+            devModeStopped = true;
+        } finally {
+            if (!devModeStopped) {
+                String stopDevModeCmd = "io.openliberty.tools:liberty-maven-plugin:stop -pl ear1 -am";
+                if (LibertyPluginTestUtils.onWindows()) {
+                    stopDevModeCmd = "cmd.exe /c mvn " + stopDevModeCmd;
+                } else {
+                    stopDevModeCmd = "mvn " + stopDevModeCmd;
+                }
+
+                String[] stopDMCmdParts = stopDevModeCmd.split(" ");
+                ProcessBuilder stopDMPB = new ProcessBuilder(stopDMCmdParts).inheritIO().directory(rootPath.toFile()).redirectErrorStream(true);
+                stopDMPB.environment().put("JAVA_HOME", JavaRuntime.getDefaultVMInstall().getInstallLocation().getAbsolutePath());
+
+                Process stopDMProcess = stopDMPB.start();
+                stopDMProcess.waitFor(3, TimeUnit.SECONDS);
+
+                LibertyPluginTestUtils.validateLibertyServerStopped(ear1ServerPath.toString());
+            }
+
+        }
     }
 }

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/LibertyPluginTestUtils.java
@@ -96,8 +96,33 @@ public class LibertyPluginTestUtils {
     }
 
     /**
+     * Validates that the Liberty server was restarted by asserting that the messages.log file
+     * has a last-modified timestamp strictly newer than the one recorded before the restart was
+     * triggered. Liberty startup takes several seconds, so the timestamps will always differ on
+     * a genuine restart.
+     *
+     * @param testAppPath The base path to the Liberty installation.
+     * @param timestampBeforeRestart The last-modified time of messages.log recorded before the
+     *                               restart was triggered, in milliseconds since the epoch.
+     */
+    public static void validateMessagesLogIsNewer(String testAppPath, long timestampBeforeRestart) {
+        String wlpMsgLogPath = testAppPath + "/wlp/usr/servers/defaultServer/logs/messages.log";
+        File msgLog = new File(wlpMsgLogPath);
+
+        boolean renewed = SWTBotTestCondition.waitFor(() -> msgLog.lastModified() > timestampBeforeRestart,
+                                                      SWTBotTestCondition.MID_WAIT_MS);
+
+        if (!renewed) {
+            printLibertyMessagesLogFile(wlpMsgLogPath);
+            Assertions.fail("messages.log was not renewed after restart. Expected a last-modified timestamp"
+                            + " newer than " + timestampBeforeRestart + " but got " + msgLog.lastModified()
+                            + " at path: " + wlpMsgLogPath);
+        }
+    }
+
+    /**
      * Validates the state of the application (active/inactive) based on the expectation of success (true/false).
-     * 
+     *
      * @param appUrl           The application URL.
      * @param expectSuccess    True to check for success. False to check for failure.
      * @param expectedResponse The expected application response payload.

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/utils/SWTBotPluginOperations.java
@@ -606,19 +606,97 @@ public class SWTBotPluginOperations {
 
     /**
      * Launches a dashboard action for the specified application name.
-     * 
+     * Retries the action if the dashboard loses focus or the action fails.
+     *
      * @param appName The application name to select.
      * @param action  The action to select
      */
     public static void launchDashboardAction(String appName, String action) {
-        SWTBotTree dashboardTree = getDashboardTree();
-        SWTBotTreeItem treeItem = findTreeItem(dashboardTree, appName);
-        if (treeItem == null) {
-            throw new org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException("Tree item not found: " + appName);
+        boolean success = SWTBotTestCondition.waitFor(() -> {
+            try {
+                SWTBotTree dashboardTree = getDashboardTree();
+                SWTBotTreeItem treeItem = findTreeItem(dashboardTree, appName);
+                if (treeItem == null) {
+                    System.out.println("[launchDashboardAction] Retrying: tree item not found");
+                    return false;
+                }
+                treeItem.select();
+                SWTBotRootMenu appCtxMenu = treeItem.contextMenu();
+                appCtxMenu.menu(action).click();
+                return true;
+            } catch (Exception e) {
+                System.out.println("[launchDashboardAction] Retrying: " + e.getClass().getSimpleName());
+                return false;
+            }
+        }, SWTBotTestCondition.SHORT_WAIT_MS);
+
+        if (!success) {
+            throw new org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException("Failed to execute dashboard action '" + action + "' for " + appName);
         }
-        treeItem.select();
-        SWTBotRootMenu appCtxMenu = treeItem.contextMenu();
-        appCtxMenu.menu(action).click();
+    }
+
+    /**
+     * Waits for and clicks a button with retry logic.
+     * Finds a dialog with the specified title, brings it into focus, and clicks the button.
+     * Useful for dialogs that may take time to appear and may lose focus.
+     *
+     * @param bot The SWTWorkbenchBot instance.
+     * @param dialogTitle The title of the dialog to find (substring match).
+     * @param buttonText The text of the button to find and click.
+     * @param timeoutMs The maximum time to wait in milliseconds.
+     */
+    public static void waitForAndClickButton(SWTBot bot, String dialogTitle, String buttonText, int timeoutMs) {
+        boolean success = SWTBotTestCondition.waitFor(() -> {
+            try {
+                // Find the shell with the specified title that has the button
+                // Condition 1: Shell title should contain dialogTitle
+                // Condition 2: Shell must have the button
+                SWTBotShell dialogShell = null;
+                for (SWTBotShell shell : bot.shells()) {
+                    try {
+                        String shellTitle = shell.getText();
+                        if (shellTitle != null && shellTitle.contains(dialogTitle)) {
+                            // Check if this shell has the button
+                            shell.bot().button(buttonText);
+                            dialogShell = shell;
+                            break;
+                        }
+                    } catch (Exception e) {
+                        // Continue searching
+                    }
+                }
+                
+                if (dialogShell == null) {
+                    System.out.println("[waitForAndClickButton] Retrying: dialog with title '" + dialogTitle + "' and button '" + buttonText + "' not found");
+                    return false;
+                }
+                
+                // Bring the dialog into focus before clicking
+                final SWTBotShell shellToFocus = dialogShell;
+                Display.getDefault().syncExec(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            shellToFocus.setFocus();
+                        } catch (Exception e) {
+                            System.out.println("[waitForAndClickButton] Failed to set shell focus: " + e.getClass().getSimpleName());
+                        }
+                    }
+                });
+                
+                // Click the button
+                dialogShell.bot().button(buttonText).click();
+                return true;
+            } catch (Exception e) {
+                System.out.println("[waitForAndClickButton] Retrying: " + e.getClass().getSimpleName());
+                return false;
+            }
+        }, timeoutMs);
+        
+        if (!success) {
+            throw new org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException(
+                "Failed to find and click button '" + buttonText + "' in dialog with title '" + dialogTitle + "'");
+        }
     }
 
     /**
@@ -1513,7 +1591,7 @@ public class SWTBotPluginOperations {
      */
     public static void clearDashboardFilter(SWTWorkbenchBot bot) {
         openDashboardUsingToolbar();
-        
+
         try {
             bot.textWithMessage("Filter projects...").setText("");
         } catch (Exception ignored) {


### PR DESCRIPTION
Problem:
If Dev mode for a particular application is started outside of Liberty Tools, and there is a subsequent attempt to manage dev mode through using the Liberty Tools support in the IDE, those attempts may fail because Liberty Tools is not aware of such a process.
With this PR: If the Liberty Tools' start action is used, Liberty Tools will detect that there is an active process, and will query the user to either accept or decline restarting the active process. Accepting the restart enables full Liberty Tools action capabilities.