### PR TITLE
Dashboard selection consistency and other fixes

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/DevModeOperations.java
@@ -175,6 +175,15 @@ public class DevModeOperations {
     private final Map<String, ServerSocket> libertyDebugPortReservations = new ConcurrentHashMap<String, ServerSocket>();
 
     /**
+     * Tracks the last known app state for every project by project name. Updated at every
+     * state transition so that the state can be seeded into the newly created ProjectModel
+     * instances after the workspace model is rebuilt on a dashboard refresh. Entries whose
+     * state is STOPPED are removed because STOPPED is the default initial state of every
+     * new ProjectModel.
+     */
+    private final Map<String, ProjectModel.AppState> projectStateTable = new ConcurrentHashMap<String, ProjectModel.AppState>();
+
+    /**
      * Process controller instance.
      */
     private ProcessController processController;
@@ -504,6 +513,7 @@ public class DevModeOperations {
 
             // Transition to STOPPING so the dashboard shows the stopping icon.
             targetProjectModel.setAppState(ProjectModel.AppState.STOPPING);
+            cacheAppState(targetProjectName, ProjectModel.AppState.STOPPING);
             refreshDashboardLabel(targetProjectModel);
 
             // Issue the command to the process.
@@ -531,6 +541,7 @@ public class DevModeOperations {
         String projectPath = (projectModel != null) ? projectModel.getPath() : null;
         processController.cleanup(projectName, projectPath);
         projectModel.setAppState(ProjectModel.AppState.STOPPED);
+        cacheAppState(projectName, ProjectModel.AppState.STOPPED);
         refreshDashboardLabel(projectModel);
     }
 
@@ -791,8 +802,10 @@ public class DevModeOperations {
         envs.add("JAVA_HOME=" + javaInstallPath);
 
         // Transition to STARTING state immediately so the dashboard shows the spinner
-        // before any console output arrives.
+        // before any console output arrives. Expand the parent first so the child row
+        // is already visible when the label is repainted with the spinner icon.
         projectModel.setAppState(ProjectModel.AppState.STARTING);
+        cacheAppState(projectName, ProjectModel.AppState.STARTING);
         refreshDashboardLabel(projectModel);
 
         processController.runProcess(projectName, projectPath, cmd, envs, true, launch);
@@ -1232,10 +1245,46 @@ public class DevModeOperations {
 
     /**
      * Refreshes the dashboard view.
+     *
+     * @param reportError Whether to surface errors to the user in a dialog.
      */
     public void refreshDashboardView(boolean reportError) {
         if (dashboardView != null) {
             dashboardView.refreshDashboardView(workspaceModel, reportError);
+            populateProjectStatesFromCache();
+        }
+    }
+
+    /**
+     * Records the project state in the state cache map.
+     * When the state is STOPPED the entry is removed because STOPPED is the
+     * default initial state of every newly constructed ProjectModel.
+     *
+     * @param projectName The name of the project whose state changed.
+     * @param state       The new app state.
+     */
+    public void cacheAppState(String projectName, ProjectModel.AppState state) {
+        if (state == ProjectModel.AppState.STOPPED) {
+            projectStateTable.remove(projectName);
+        } else {
+            projectStateTable.put(projectName, state);
+        }
+    }
+
+    /**
+     * Populates the state of every project in the workspace model from the state cache map.
+     * Called after the workspace model is rebuilt so that freshly created ProjectModel
+     * instances start with the correct state rather than the default STOPPED. For each
+     * project whose state is known and not STOPPED, the label is also refreshed so that
+     * the dashboard icon repaints immediately.
+     */
+    private void populateProjectStatesFromCache() {
+        for (Map.Entry<String, ProjectModel.AppState> entry : projectStateTable.entrySet()) {
+            ProjectModel projectModel = workspaceModel.getProjectByName(entry.getKey());
+            if (projectModel != null) {
+                projectModel.setAppState(entry.getValue());
+                refreshDashboardLabel(projectModel);
+            }
         }
     }
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyResourceChangeListener.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/LibertyResourceChangeListener.java
@@ -19,7 +19,6 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.swt.widgets.Display;
 
-import io.openliberty.tools.eclipse.logging.Trace;
 import io.openliberty.tools.eclipse.model.ProjectModel;
 import io.openliberty.tools.eclipse.model.WorkspaceModel;
 
@@ -68,7 +67,7 @@ public class LibertyResourceChangeListener implements IResourceChangeListener {
                         case IResourceDelta.CHANGED:
                             String projectLocation = iProject.getLocation().toOSString();
                             ProjectModel projectModel = workspaceModel.getProjectByLocation(projectLocation);
-                            
+
                             if (projectModel != null && (updateFlag == IResourceDelta.OPEN || updateFlag == 147456)) {
                                 refreshNeeded = true;
                             }

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/messages/Messages.properties
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/messages/Messages.properties
@@ -108,7 +108,7 @@ dashboard_tooltip_running=Running
 dashboard_tooltip_starting=Starting...
 dashboard_tooltip_stopping=Stopping...
 dashboard_tooltip_stopped=Stopped
-dashboard_tooltip_incomplete={0}/{1} running
+dashboard_tooltip_modules_running={0}/{1} running
 
 # JRETab
 java_default_set_error=Unable to set the default Java installation that was obtained from the build path of the {0} project in the {1} configuration.

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/DevModeStateHandler.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/process/DevModeStateHandler.java
@@ -48,7 +48,7 @@ public class DevModeStateHandler implements IConsoleLineHandler {
          * Returns true if the given line matches this pattern.
          *
          * @param line The line of console output to test.
-         * 
+         *
          * @return True if the line matches, false otherwise.
          */
         boolean matches(String line);
@@ -59,6 +59,7 @@ public class DevModeStateHandler implements IConsoleLineHandler {
      */
     private static class RegexMatcher implements PatternMatcher {
 
+        /** The compiled regular expression used to test console lines. */
         private final Pattern pattern;
 
         RegexMatcher(String regex) {
@@ -79,6 +80,7 @@ public class DevModeStateHandler implements IConsoleLineHandler {
      */
     private static class ContainsMatcher implements PatternMatcher {
 
+        /** The fixed substring to search for in each console line. */
         private final String substring;
 
         ContainsMatcher(String substring) {
@@ -99,7 +101,10 @@ public class DevModeStateHandler implements IConsoleLineHandler {
      */
     private static class PatternAction {
 
+        /** The matcher that tests whether a console line triggers this action. */
         final PatternMatcher matcher;
+
+        /** The action to invoke when the matcher returns true. */
         final Consumer<String> action;
 
         PatternAction(PatternMatcher matcher, Consumer<String> action) {
@@ -193,22 +198,25 @@ public class DevModeStateHandler implements IConsoleLineHandler {
     }
 
     /**
-     * Called when {@code CWWKZ0001I:} is detected — the Liberty application has started.
-     * Transitions the module to {@code RUNNING} and refreshes the dashboard label.
+     * Called when CWWKZ0001I is detected. This means that the Liberty application has started.
+     * Transitions the module to RUNNING and refreshes the dashboard label.
      */
     private void handleAppStarted() {
         projectModel.setAppState(ProjectModel.AppState.RUNNING);
-        DevModeOperations.getInstance().refreshDashboardLabel(projectModel);
+        DevModeOperations devModeOps = DevModeOperations.getInstance();
+        devModeOps.cacheAppState(projectModel.getName(), ProjectModel.AppState.RUNNING);
+        devModeOps.refreshDashboardLabel(projectModel);
     }
 
     /**
-     * Called when {@code CWWKE0036I:} is detected — the Liberty server has stopped.
-     * Transitions the module to {@code STOPPED}, refreshes the dashboard label, and
+     * Called when CWWKE0036I is detected. This means that the Liberty server has stopped.
+     * Transitions the module to STOPPED, refreshes the dashboard label, and
      * tears down the console interceptor and process map entry for this project.
      */
     private void handleServerStopped() {
         projectModel.setAppState(ProjectModel.AppState.STOPPED);
         DevModeOperations devModeOps = DevModeOperations.getInstance();
+        devModeOps.cacheAppState(projectModel.getName(), ProjectModel.AppState.STOPPED);
         devModeOps.cleanupProcess(projectModel.getName());
     }
 

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
@@ -259,7 +259,7 @@ public class DashboardEntryLabelProvider {
             }
         }
         if (running == children.size()) {
-            return Messages.getMessage("dashboard_tooltip_running");
+            return Messages.getMessage("dashboard_tooltip_modules_running", running, children.size());
         }
         if (starting > 0) {
             return Messages.getMessage("dashboard_tooltip_starting");
@@ -271,7 +271,7 @@ public class DashboardEntryLabelProvider {
             return Messages.getMessage("dashboard_tooltip_stopped");
         }
 
-        return Messages.getMessage("dashboard_tooltip_incomplete", running, children.size());
+        return Messages.getMessage("dashboard_tooltip_modules_running", running, children.size());
     }
 
     /**

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenGradleTestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenGradleTestReportAction.java
@@ -113,17 +113,15 @@ public class OpenGradleTestReportAction implements ILaunchShortcut {
 
         // Resolve the target module. This action accepts on a single project executions.
         List<ProjectModel> targetProjects = devModeOps.resolveCommandTargets(
-                selectedProjectModel, DashboardAction.OPEN_GRADLE_TEST_REPORT, DevModeOperations.ModuleStateFilter.ALL, false);
+                                                                             selectedProjectModel, DashboardAction.OPEN_GRADLE_TEST_REPORT, DevModeOperations.ModuleStateFilter.ALL,
+                                                                             false);
         if (targetProjects.isEmpty()) {
             return;
         }
         ProjectModel targetProjectModel = targetProjects.get(0);
 
-        // Update the active selection to the target project if it differs from the original.
-        String targetProjectName = targetProjectModel.getName();
-        if (!selectedProjectName.equals(targetProjectName)) {
-            Utils.updateActiveSelection(targetProjectModel);
-        }
+        // Update the active selection to the target project.
+        Utils.updateActiveSelection(targetProjectModel);
 
         // Resolve the test report to view.
         targetProjectModel = devModeOps.resolveTestReportTarget(targetProjectModel, DashboardAction.OPEN_GRADLE_TEST_REPORT);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenITestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenITestReportAction.java
@@ -113,17 +113,15 @@ public class OpenMavenITestReportAction implements ILaunchShortcut {
 
         // Resolve the target module. This action accepts on a single project executions.
         List<ProjectModel> targetProjects = devModeOps.resolveCommandTargets(
-                selectedProjectModel, DashboardAction.OPEN_MVN_IT_TEST_REPORT, DevModeOperations.ModuleStateFilter.ALL, false);
+                                                                             selectedProjectModel, DashboardAction.OPEN_MVN_IT_TEST_REPORT, DevModeOperations.ModuleStateFilter.ALL,
+                                                                             false);
         if (targetProjects.isEmpty()) {
             return;
         }
         ProjectModel targetProjectModel = targetProjects.get(0);
 
-        // Update the active project selection on the dashboard.
-        String targetProjectName = targetProjectModel.getName();
-        if (!selectedProjectName.equals(targetProjectName)) {
-            Utils.updateActiveSelection(targetProjectModel);
-        }
+        // Update the active selection to the target project.
+        Utils.updateActiveSelection(targetProjectModel);
 
         // Resolve the test report to view.
         targetProjectModel = devModeOps.resolveTestReportTarget(targetProjectModel, DashboardAction.OPEN_MVN_IT_TEST_REPORT);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenUTestReportAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/OpenMavenUTestReportAction.java
@@ -120,11 +120,8 @@ public class OpenMavenUTestReportAction implements ILaunchShortcut {
         }
         ProjectModel targetProjectModel = targetProjects.get(0);
 
-        // Update the active selection to the target project if it differs from the original.
-        String targetProjectName = targetProjectModel.getName();
-        if (!selectedProjectName.equals(targetProjectName)) {
-            Utils.updateActiveSelection(targetProjectModel);
-        }
+        // Update the active selection to the target project.
+        Utils.updateActiveSelection(targetProjectModel);
 
         // Resolve the test report to view.
         targetProjectModel = devModeOps.resolveTestReportTarget(targetProjectModel, DashboardAction.OPEN_MVN_UT_TEST_REPORT);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/RunTestsAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/RunTestsAction.java
@@ -118,14 +118,10 @@ public class RunTestsAction implements ILaunchShortcut {
             return;
         }
 
-        // Run tests found in  all target projects/modules. 
+        // Run tests found in all target projects/modules.
         for (ProjectModel targetProjectModel : targetProjects) {
-            String targetProjectName = targetProjectModel.getName();
-
-            // Update the active selection to the target project if it differs from the original.
-            if (!selectedProjectName.equals(targetProjectName)) {
-                Utils.updateActiveSelection(targetProjectModel);
-            }
+            // Update the active selection to the target project.
+            Utils.updateActiveSelection(targetProjectModel);
 
             // Trigger tests for this module.
             devModeOps.runTests(targetProjectModel);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartAction.java
@@ -158,15 +158,11 @@ public class StartAction implements ILaunchShortcut {
             }
         }
 
-        // Launch all target projects/modules. 
+        // Launch all target projects/modules.
         LaunchConfigurationHelper launchConfigHelper = LaunchConfigurationHelper.getInstance();
         for (ProjectModel targetProjectModel : targetProjects) {
-            String targetProjectName = targetProjectModel.getName();
-
-            // Update the active selection to the selected target project if the original selection does not match the target.
-            if (!selectedProjectName.equals(targetProjectName)) {
-                Utils.updateActiveSelection(targetProjectModel);
-            }
+            // Update the active selection to the target project.
+            Utils.updateActiveSelection(targetProjectModel);
 
             ILaunchConfiguration configuration = launchConfigHelper.getLaunchConfiguration(targetProjectModel, mode, RuntimeEnv.LOCAL);
             DebugUITools.launch(configuration, mode);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartConfigurationDialogAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartConfigurationDialogAction.java
@@ -139,11 +139,9 @@ public class StartConfigurationDialogAction implements ILaunchShortcut {
             }
             targetProjectModel = targetProjects.get(0);
 
-            // Update the active selection to the target project if it differs from the original.
+            // Update the active selection to the target project.
             targetProjectName = targetProjectModel.getName();
-            if (!selectedProjectName.equals(targetProjectName)) {
-                Utils.updateActiveSelection(targetProjectModel);
-            }
+            Utils.updateActiveSelection(targetProjectModel);
 
             // Check if the target project is already started.
             if (devModeOps.isProjectStarted(targetProjectModel)) {

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StartInContainerAction.java
@@ -159,15 +159,11 @@ public class StartInContainerAction implements ILaunchShortcut {
             }
         }
 
-        // Launch all target projects/modules. 
+        // Launch all target projects/modules.
         LaunchConfigurationHelper launchConfigHelper = LaunchConfigurationHelper.getInstance();
         for (ProjectModel targetProjectModel : targetProjects) {
-            String targetProjectName = targetProjectModel.getName();
-
-            // Update the active selection to the selected target project if the original selection does not match the target.
-            if (!selectedProjectName.equals(targetProjectName)) {
-                Utils.updateActiveSelection(targetProjectModel);
-            }
+            // Update the active selection to the target project.
+            Utils.updateActiveSelection(targetProjectModel);
 
             ILaunchConfiguration configuration = launchConfigHelper.getLaunchConfiguration(targetProjectModel, mode, RuntimeEnv.CONTAINER);
             DebugUITools.launch(configuration, mode);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StopAction.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/launch/shortcuts/StopAction.java
@@ -119,15 +119,11 @@ public class StopAction implements ILaunchShortcut {
 
         // Stop all targeted projects.
         for (ProjectModel targetProjectModel : targetProjects) {
-            String targetProjectName = targetProjectModel.getName();
-
             // Reset batch started indicator.
             targetProjectModel.setBatchStarted(false);
 
-            // Update the active selection to the target project if it differs from the original.
-            if (!selectedProjectName.equals(targetProjectName)) {
-                Utils.updateActiveSelection(targetProjectModel);
-            }
+            // Update the active selection to the target project.
+            Utils.updateActiveSelection(targetProjectModel);
 
             // Process the stop action.
             devModeOps.stop(targetProjectModel);

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/Utils.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/utils/Utils.java
@@ -263,8 +263,10 @@ public class Utils {
      * to ensure that when the launch configuration dialog opens and validates the configuration,
      * the active project context matches the project associated with the configuration.
      * This handles selections from Dashboard, Project Explorer, Package Explorer, and other views.
+     * If the active part is not the dashboard but the dashboard is open, its selection is also updated
+     * so that the dashboard tree reflects the module being operated on regardless of which view is active.
      *
-     * @param targetProjectModel The target project model to select
+     * @param targetProjectModel The target project model to select.
      */
     public static void updateActiveSelection(ProjectModel targetProjectModel) {
         try {
@@ -280,15 +282,27 @@ public class Utils {
                     if (activePart != null) {
                         ISelectionProvider selectionProvider = activePart.getSite().getSelectionProvider();
                         if (selectionProvider != null) {
-                            // For Dashboard, select the ProjectModel; for other views, select the IProject
+                            // For Dashboard, select the ProjectModel; for other views, select the IProject.
                             Object selectionObject = (activePart instanceof DashboardView) ? targetProjectModel : targetProjectModel.getIProject();
                             selectionProvider.setSelection(new StructuredSelection(selectionObject));
+                        }
+
+                        // If the active part is not the dashboard, also update the dashboard selection
+                        // so that the dashboard tree always tracks the module being operated on.
+                        if (!(activePart instanceof DashboardView)) {
+                            DashboardView dashboardView = DevModeOperations.getInstance().getDashboardView();
+                            if (dashboardView != null) {
+                                ISelectionProvider dashboardSelectionProvider = dashboardView.getSite().getSelectionProvider();
+                                if (dashboardSelectionProvider != null) {
+                                    dashboardSelectionProvider.setSelection(new StructuredSelection(targetProjectModel));
+                                }
+                            }
                         }
                     }
                 }
             }
         } catch (Exception e) {
-            // Log the error but don't fail the operation - the configuration dialog will still open
+            // Log the error but do not fail the operation.
             if (Trace.isEnabled()) {
                 Trace.getTracer().trace(Trace.TRACE_UI, "Failed to update active selection", e);
             }


### PR DESCRIPTION
This PR:
- Makes dashboard content behavior consistent when actions are run from other views (editor, etc).
- Caches dashboard state for cases in which the dashboard is closed and re-opened. Newer dashbords now reflect the prior state.
- Updates the state tool tip for multi-module parents. 