### PR TITLE
Fix SWTException: Graphic is disposed on Windows

### DIFF
--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/DashboardEntryLabelProvider.java
@@ -144,7 +144,7 @@ public class DashboardEntryLabelProvider {
             stoppingImg = paddedStateIcon(themeFolder + "stopping");
             incompleteImg = paddedStateIcon(themeFolder + "incomplete");
             String progressFolder = themeFolder + "inProgress/";
-            progressAnimator = new ProgressIndicatorAnimator(dashboardView, progressFolder, raw -> paddedStateIconFromImage(raw, PROGRESS_ICON_SIZE));
+            progressAnimator = new ProgressIndicatorAnimator(dashboardView, progressFolder, desc -> paddedIconDescriptor(desc, PROGRESS_ICON_SIZE));
         }
 
         /**
@@ -332,22 +332,6 @@ public class DashboardEntryLabelProvider {
     private static Image paddedStateIcon(String baseName) {
         ImageDescriptor desc = LibertyDevPlugin.loadIconDescriptor(baseName);
         return (desc != null) ? paddedIconDescriptor(desc, STATE_ICON_SIZE).createImage() : null;
-    }
-
-    /**
-     * Creates a padded image from an already-loaded raw Image, centering it in a
-     * BADGE_W × BADGE_H transparent canvas so SWT never stretches it.
-     *
-     * @param raw      The raw icon image.
-     * @param iconSize The true logical pixel size of the (square) icon.
-     *
-     * @return The padded image, or null if raw is null.
-     */
-    private static Image paddedStateIconFromImage(Image raw, int iconSize) {
-        if (raw == null) {
-            return null;
-        }
-        return paddedIconDescriptor(ImageDescriptor.createFromImage(raw), iconSize).createImage();
     }
 
     /**

--- a/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/ProgressIndicatorAnimator.java
+++ b/bundles/io.openliberty.tools.eclipse.ui/src/io/openliberty/tools/eclipse/ui/dashboard/ProgressIndicatorAnimator.java
@@ -55,10 +55,10 @@ class ProgressIndicatorAnimator {
      * @param dashboardView The dashboard view to refresh on each animation tick.
      * @param progressFolder The icon folder path for the progress frames, relative to icons/.
      *                       For example: "state/light/progress/" or "state/dark/progress/".
-     * @param frameTransform Transform applied to each raw frame before storage.
-     *                       Pass null to store the raw frame as-is.
+     * @param frameTransform Transform applied to each frame descriptor to create the image.
+     *                       Pass null to create the image directly from the descriptor.
      */
-    ProgressIndicatorAnimator(DashboardView dashboardView, String progressFolder, UnaryOperator<Image> frameTransform) {
+    ProgressIndicatorAnimator(DashboardView dashboardView, String progressFolder, UnaryOperator<ImageDescriptor> frameTransform) {
         this.dashboardView = dashboardView;
         this.frames = new Image[FRAME_COUNT];
         for (int i = 0; i < FRAME_COUNT; i++) {
@@ -66,18 +66,9 @@ class ProgressIndicatorAnimator {
             if (desc == null) {
                 continue;
             }
-            Image raw = desc.createImage();
-            if (raw == null) {
-                continue;
-            }
-            if (frameTransform != null) {
-                frames[i] = frameTransform.apply(raw);
-                // Dispose the raw frame only when the transform produced a new image.
-                if (frames[i] != raw && !raw.isDisposed()) {
-                    raw.dispose();
-                }
-            } else {
-                frames[i] = raw;
+            ImageDescriptor targetDesc = (frameTransform != null) ? frameTransform.apply(desc) : desc;
+            if (targetDesc != null) {
+                frames[i] = targetDesc.createImage();
             }
         }
     }


### PR DESCRIPTION
Exception on Windows:
```
2026-09-04T02:00:12.5232363Z org.eclipse.swt.SWTException: Graphic is disposed
2026-09-04T02:00:12.5233118Z 	at org.eclipse.swt.SWT.error(SWT.java:4950)
2026-09-04T02:00:12.5233402Z 	at org.eclipse.swt.SWT.error(SWT.java:4865)
2026-09-04T02:00:12.5233570Z 	at org.eclipse.swt.SWT.error(SWT.java:4836)
2026-09-04T02:00:12.5233872Z 	at org.eclipse.swt.graphics.Image.getImageData(Image.java:1382)
2026-09-04T02:00:12.5234210Z 	at org.eclipse.jface.resource.ImageDataImageDescriptor.getImageData(ImageDataImageDescriptor.java:85)
2026-09-04T02:00:12.5234678Z 	at io.openliberty.tools.eclipse.ui.dashboard.DashboardEntryLabelProvider$1.lambda$0(DashboardEntryLabelProvider.java:369)
2026-09-04T02:00:12.5235172Z 	at org.eclipse.jface.resource.CompositeImageDescriptor.getZoomedImageData(CompositeImageDescriptor.java:460)
2026-09-04T02:00:12.5235616Z 	at org.eclipse.jface.resource.CompositeImageDescriptor.drawImage(CompositeImageDescriptor.java:267)
2026-09-04T02:00:12.5236107Z 	at io.openliberty.tools.eclipse.ui.dashboard.DashboardEntryLabelProvider$1.drawCompositeImage(DashboardEntryLabelProvider.java:370)
...
2026-09-04T02:00:12.5252937Z 	at org.eclipse.jface.viewers.ColumnViewer.update(ColumnViewer.java:542)
2026-09-04T02:00:12.5253264Z 	at io.openliberty.tools.eclipse.ui.dashboard.DashboardView.updateLabel(DashboardView.java:1100)
2026-09-04T02:00:12.5253690Z 	at io.openliberty.tools.eclipse.ui.dashboard.ProgressIndicatorAnimator.tick(ProgressIndicatorAnimator.java:127)
```