### PR TITLE
Upgrade test gradle and java version

### DIFF
--- a/.github/workflows/run-regression-tests.yml
+++ b/.github/workflows/run-regression-tests.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: test-tools/liberty-dev-tools
-          key: ${{ runner.os }}-tools-jdk21.0.3-maven3.9.6-gradle8.8
+          key: ${{ runner.os }}-tools-jdk21.0.3-maven3.9.6-gradle9.7.1
           restore-keys: |
             ${{ runner.os }}-tools-
 
@@ -109,4 +109,4 @@ jobs:
         if: always()
         with:
           path: test-tools/liberty-dev-tools
-          key: ${{ runner.os }}-tools-jdk21.0.3-maven3.9.6-gradle8.8
+          key: ${{ runner.os }}-tools-jdk21.0.3-maven3.9.6-gradle9.7.1

--- a/tests/resources/applications/apps with spaces/liberty-gradle-test-app-with-spaces/build.gradle
+++ b/tests/resources/applications/apps with spaces/liberty-gradle-test-app-with-spaces/build.gradle
@@ -4,19 +4,24 @@ apply plugin: 'war'
 version '0.0.1-SNAPSHOT'
 group 'liberty.gradle.test.app.with.spaces'
 
-sourceCompatibility = 21
-targetCompatibility = 21
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
 buildscript {
     repositories {
-        mavenCentral()
         mavenLocal()
+        mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.8.3'
+        classpath "io.openliberty.tools:liberty-gradle-plugin:4.0.2"
     }
 }
 
@@ -27,8 +32,8 @@ repositories {
 
 dependencies {
      // provided dependencies
-     providedCompile 'javax.servlet:javax.servlet-api:3.1.0' 
-     providedCompile 'org.eclipse.microprofile:microprofile:5.0'
+     compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
+     compileOnly 'org.eclipse.microprofile:microprofile:5.0'
      
      // test dependencies
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1' 
@@ -45,4 +50,4 @@ liberty {
     }
 }
 
-clean.dependsOn 'libertyStop'
+tasks.named('clean').configure { dependsOn 'libertyStop' }

--- a/tests/resources/applications/apps with spaces/liberty-gradle-test-app-with-spaces/src/main/liberty/config/server.xml
+++ b/tests/resources/applications/apps with spaces/liberty-gradle-test-app-with-spaces/src/main/liberty/config/server.xml
@@ -17,5 +17,5 @@
     
     <httpEndpoint  host="*" httpPort="9080" httpsPort="9443" id="defaultHttpEndpoint" />
     
-    <webApplication id="liberty.gradle.test.app" location="liberty.gradle.test.app.war" name="liberty.gradle.test.app"/>
+    <webApplication id="liberty-gradle-test-app-with-spaces" location="liberty-gradle-test-app-with-spaces-0.0.1-SNAPSHOT.war" name="liberty-gradle-test-app-with-spaces"/>
 </server>

--- a/tests/resources/applications/apps with spaces/liberty-gradle-test-wrapper-app-with-spaces/build.gradle
+++ b/tests/resources/applications/apps with spaces/liberty-gradle-test-wrapper-app-with-spaces/build.gradle
@@ -4,18 +4,24 @@ apply plugin: 'war'
 version '0.0.1-SNAPSHOT'
 group 'liberty.gradle.test.wrapper.app.with.spaces'
 
-sourceCompatibility = 21
-targetCompatibility = 21
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
 buildscript {
     repositories {
+        mavenLocal()
         mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
     }
-        dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.8.3'
+    dependencies {
+        classpath "io.openliberty.tools:liberty-gradle-plugin:4.0.2"
     }
 }
 
@@ -25,8 +31,8 @@ repositories {
 
 dependencies {
      // provided dependencies
-     providedCompile 'javax.servlet:javax.servlet-api:3.1.0' 
-     providedCompile 'org.eclipse.microprofile:microprofile:5.0'
+     compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
+     compileOnly 'org.eclipse.microprofile:microprofile:5.0'
      
      // test dependencies
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1' 
@@ -40,4 +46,4 @@ liberty {
     }
 }
 
-clean.dependsOn 'libertyStop'
+tasks.named('clean').configure { dependsOn 'libertyStop' }

--- a/tests/resources/applications/apps with spaces/liberty-gradle-test-wrapper-app-with-spaces/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/resources/applications/apps with spaces/liberty-gradle-test-wrapper-app-with-spaces/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tests/resources/applications/apps with spaces/liberty-gradle-test-wrapper-app-with-spaces/src/main/liberty/config/server.xml
+++ b/tests/resources/applications/apps with spaces/liberty-gradle-test-wrapper-app-with-spaces/src/main/liberty/config/server.xml
@@ -17,5 +17,5 @@
     
     <httpEndpoint  host="*" httpPort="9080" httpsPort="9443" id="defaultHttpEndpoint" />
     
-    <webApplication id="liberty.gradle.test.app" location="liberty.gradle.test.app.war" name="liberty.gradle.test.app"/>
+    <webApplication id="liberty-gradle-test-wrapper-app-with-spaces" location="liberty-gradle-test-wrapper-app-with-spaces-0.0.1-SNAPSHOT.war" name="liberty-gradle-test-wrapper-app-with-spaces"/>
 </server>

--- a/tests/resources/applications/gradle/liberty-gradle-test-app/build.gradle
+++ b/tests/resources/applications/gradle/liberty-gradle-test-app/build.gradle
@@ -4,21 +4,27 @@ apply plugin: 'war'
 version '0.0.1-SNAPSHOT'
 group 'liberty.gradle.test.app'
 
-sourceCompatibility = 21
-targetCompatibility = 21
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
 buildscript {
     repositories {
-        mavenCentral()
         mavenLocal()
+        mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.8.3'
+        classpath "io.openliberty.tools:liberty-gradle-plugin:4.0.2"
     }
 }
+
 
 repositories {
     mavenCentral()
@@ -27,8 +33,8 @@ repositories {
 
 dependencies {
      // provided dependencies
-     providedCompile 'javax.servlet:javax.servlet-api:3.1.0' 
-     providedCompile 'org.eclipse.microprofile:microprofile:5.0'
+     compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
+     compileOnly 'org.eclipse.microprofile:microprofile:5.0'
      
      // test dependencies
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1' 
@@ -45,4 +51,4 @@ liberty {
     }
 }
 
-clean.dependsOn 'libertyStop'
+tasks.named('clean').configure { dependsOn 'libertyStop' }

--- a/tests/resources/applications/gradle/liberty-gradle-test-app/src/main/liberty/config/server.xml
+++ b/tests/resources/applications/gradle/liberty-gradle-test-app/src/main/liberty/config/server.xml
@@ -17,5 +17,5 @@
     
     <httpEndpoint  host="*" httpPort="9080" httpsPort="9443" id="defaultHttpEndpoint" />
     
-    <webApplication id="liberty.gradle.test.app" location="liberty.gradle.test.app.war" name="liberty.gradle.test.app"/>
+    <webApplication id="liberty-gradle-test-app" location="liberty-gradle-test-app-0.0.1-SNAPSHOT.war" name="liberty-gradle-test-app"/>
 </server>

--- a/tests/resources/applications/gradle/liberty-gradle-test-wrapper-app/build.gradle
+++ b/tests/resources/applications/gradle/liberty-gradle-test-wrapper-app/build.gradle
@@ -4,20 +4,27 @@ apply plugin: 'war'
 version '0.0.1-SNAPSHOT'
 group 'liberty.gradle.test.app'
 
-sourceCompatibility = 21
-targetCompatibility = 21
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
 buildscript {
     repositories {
+        mavenLocal()
         mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
     }
-        dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.8.3'
+    dependencies {
+        classpath "io.openliberty.tools:liberty-gradle-plugin:4.0.2"
     }
 }
+
 
 repositories {
     mavenCentral()
@@ -25,8 +32,8 @@ repositories {
 
 dependencies {
      // provided dependencies
-     providedCompile 'javax.servlet:javax.servlet-api:3.1.0' 
-     providedCompile 'org.eclipse.microprofile:microprofile:5.0'
+     compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
+     compileOnly 'org.eclipse.microprofile:microprofile:5.0'
      
      // test dependencies
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1' 
@@ -40,4 +47,4 @@ liberty {
     }
 }
 
-clean.dependsOn 'libertyStop'
+tasks.named('clean').configure { dependsOn 'libertyStop' }

--- a/tests/resources/applications/gradle/liberty-gradle-test-wrapper-app/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/resources/applications/gradle/liberty-gradle-test-wrapper-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tests/resources/applications/gradle/liberty-gradle-test-wrapper-app/src/main/liberty/config/server.xml
+++ b/tests/resources/applications/gradle/liberty-gradle-test-wrapper-app/src/main/liberty/config/server.xml
@@ -17,5 +17,5 @@
     
     <httpEndpoint  host="*" httpPort="9080" httpsPort="9443" id="defaultHttpEndpoint" />
     
-    <webApplication id="liberty.gradle.test.app" location="liberty.gradle.test.app.war" name="liberty.gradle.test.app"/>
+    <webApplication id="liberty-gradle-test-wrapper-app" location="liberty-gradle-test-wrapper-app-0.0.1-SNAPSHOT.war" name="liberty-gradle-test-wrapper-app"/>
 </server>

--- a/tests/resources/applications/gradle/multi-liberty-module-gradle-app/build.gradle
+++ b/tests/resources/applications/gradle/multi-liberty-module-gradle-app/build.gradle
@@ -7,8 +7,8 @@ subprojects {
     apply plugin: 'java'
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     tasks.withType(JavaCompile).configureEach {
@@ -21,6 +21,7 @@ subprojects {
 
     dependencies {
         testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.6.2'
     }
 
     repositories {

--- a/tests/resources/applications/gradle/multi-liberty-module-gradle-app/ear-skinny-modules/build.gradle
+++ b/tests/resources/applications/gradle/multi-liberty-module-gradle-app/ear-skinny-modules/build.gradle
@@ -4,21 +4,24 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.9.5'
+        classpath "io.openliberty.tools:liberty-gradle-plugin:4.0.2"
     }
 }
+
 
 apply plugin: 'liberty'
 
 description = 'EAR Skinny Modules'
 
 dependencies {
-    deploy project(':jar')
-    deploy project(path: ':ejb',  configuration: 'archives')
-    deploy project(path: ':war',  configuration: 'archives')
-    deploy project(path: ':war2', configuration: 'archives')
+    deploy project(path: ':ejb',  configuration: 'default')
+    deploy project(path: ':war',  configuration: 'warOnly')
+    deploy project(path: ':war2', configuration: 'warOnly')
     deploy project(path: ':rar',  configuration: 'rarArchive')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
 }
@@ -58,4 +61,4 @@ test {
 }
 
 deploy.dependsOn 'ear'
-ear.dependsOn ':jar:jar', ':ejb:jar', ':war:war', ':war2:war', ':rar:rar'
+ear.dependsOn ':ejb:jar', ':war:war', ':war2:war', ':rar:rar'

--- a/tests/resources/applications/gradle/multi-liberty-module-gradle-app/ear1/build.gradle
+++ b/tests/resources/applications/gradle/multi-liberty-module-gradle-app/ear1/build.gradle
@@ -4,9 +4,12 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.9.5'
+        classpath "io.openliberty.tools:liberty-gradle-plugin:4.0.2"
     }
 }
 
@@ -15,8 +18,8 @@ apply plugin: 'liberty'
 description = 'EAR1 Module'
 
 dependencies {
-    deploy project(':jar')
-    deploy project(path: ':war', configuration: 'archives')
+    deploy project(path: ':ejb', configuration: 'default')
+    deploy project(path: ':war', configuration: 'warOnly')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
 }
 
@@ -48,4 +51,4 @@ test {
 }
 
 deploy.dependsOn 'ear'
-ear.dependsOn ':jar:jar', ':war:war'
+ear.dependsOn ':ejb:jar', ':war:war'

--- a/tests/resources/applications/gradle/multi-liberty-module-gradle-app/ear2/build.gradle
+++ b/tests/resources/applications/gradle/multi-liberty-module-gradle-app/ear2/build.gradle
@@ -4,9 +4,12 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven {
+            url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        }
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.9.5'
+        classpath "io.openliberty.tools:liberty-gradle-plugin:4.0.2"
     }
 }
 
@@ -15,8 +18,8 @@ apply plugin: 'liberty'
 description = 'EAR2 Module'
 
 dependencies {
-    deploy project(':jar')
-    deploy project(path: ':war', configuration: 'archives')
+    deploy project(path: ':ejb', configuration: 'default')
+    deploy project(path: ':war', configuration: 'warOnly')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
 }
 
@@ -48,4 +51,4 @@ test {
 }
 
 deploy.dependsOn 'ear'
-ear.dependsOn ':jar:jar', ':war:war'
+ear.dependsOn ':ejb:jar', ':war:war'

--- a/tests/resources/applications/gradle/multi-liberty-module-gradle-app/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/resources/applications/gradle/multi-liberty-module-gradle-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tests/resources/applications/gradle/multi-liberty-module-gradle-app/war/build.gradle
+++ b/tests/resources/applications/gradle/multi-liberty-module-gradle-app/war/build.gradle
@@ -2,8 +2,16 @@ apply plugin: 'war'
 
 description = 'WAR Module'
 
+configurations {
+    warOnly
+}
+
 war {
     archiveBaseName = 'guide-gradle-multimodules-custmm-war'
+}
+
+artifacts {
+    warOnly war
 }
 
 dependencies {

--- a/tests/resources/applications/gradle/multi-liberty-module-gradle-app/war2/build.gradle
+++ b/tests/resources/applications/gradle/multi-liberty-module-gradle-app/war2/build.gradle
@@ -2,8 +2,16 @@ apply plugin: 'war'
 
 description = 'WAR2 Module'
 
+configurations {
+    warOnly
+}
+
 war {
     archiveBaseName = 'guide-gradle-multimodules-custmm-war2'
+}
+
+artifacts {
+    warOnly war
 }
 
 dependencies {

--- a/tests/resources/applications/maven/multi-liberty-module-maven-app/ear-skinny-modules/pom.xml
+++ b/tests/resources/applications/maven/multi-liberty-module-maven-app/ear-skinny-modules/pom.xml
@@ -4,6 +4,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.openliberty.guides</groupId>
+        <artifactId>guide-maven-multimodules-custmm</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <groupId>io.openliberty.guides</groupId>
     <artifactId>guide-maven-multimodules-custmm-ear-skinny-modules</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -12,8 +19,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9083</liberty.var.default.http.port>
         <liberty.var.default.https.port>9446</liberty.var.default.https.port>
@@ -59,7 +66,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -106,7 +113,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.12.0</version>
+                <version>3.12.3</version>
             </plugin>
 
             <!-- Since the package type is ear,
@@ -114,7 +121,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.13.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/tests/resources/applications/maven/multi-liberty-module-maven-app/ear1/pom.xml
+++ b/tests/resources/applications/maven/multi-liberty-module-maven-app/ear1/pom.xml
@@ -4,6 +4,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.openliberty.guides</groupId>
+        <artifactId>guide-maven-multimodules-custmm</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <groupId>io.openliberty.guides</groupId>
     <artifactId>guide-maven-multimodules-custmm-ear1</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -12,8 +19,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
@@ -41,7 +48,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -75,7 +82,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.12.0</version>
+                <version>3.12.3</version>
             </plugin>
 
             <!-- Since the package type is ear,
@@ -83,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.13.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/tests/resources/applications/maven/multi-liberty-module-maven-app/ear2/pom.xml
+++ b/tests/resources/applications/maven/multi-liberty-module-maven-app/ear2/pom.xml
@@ -4,6 +4,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.openliberty.guides</groupId>
+        <artifactId>guide-maven-multimodules-custmm</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <groupId>io.openliberty.guides</groupId>
     <artifactId>guide-maven-multimodules-custmm-ear2</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -12,8 +19,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9081</liberty.var.default.http.port>
         <liberty.var.default.https.port>9444</liberty.var.default.https.port>
@@ -41,7 +48,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -75,7 +82,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.12.0</version>
+                <version>3.12.3</version>
             </plugin>
 
             <!-- Since the package type is ear,
@@ -83,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.13.0</version>
                 <executions>
                     <execution>
                         <phase>test-compile</phase>

--- a/tests/resources/applications/maven/multi-liberty-module-maven-app/ejb/pom.xml
+++ b/tests/resources/applications/maven/multi-liberty-module-maven-app/ejb/pom.xml
@@ -14,8 +14,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/tests/resources/applications/maven/multi-liberty-module-maven-app/jar/pom.xml
+++ b/tests/resources/applications/maven/multi-liberty-module-maven-app/jar/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/resources/applications/maven/multi-liberty-module-maven-app/pom.xml
+++ b/tests/resources/applications/maven/multi-liberty-module-maven-app/pom.xml
@@ -10,9 +10,20 @@
     <artifactId>guide-maven-multimodules-custmm</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <properties>
-        <lmp.version>3.12.0</lmp.version>
-    </properties>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
     <modules>
         <module>jar</module>
         <module>ejb</module>

--- a/tests/resources/applications/maven/multi-liberty-module-maven-app/rar/pom.xml
+++ b/tests/resources/applications/maven/multi-liberty-module-maven-app/rar/pom.xml
@@ -8,8 +8,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -24,7 +24,8 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-rar-plugin</artifactId>
+                    <artifactId>maven-rar-plugin</artifactId>
+                    <version>3.0.0</version>
                 <configuration>
                     <raXmlFile>src/main/rar-source/META-INF/ra.xml</raXmlFile>
                     <rarSourceDirectory>src/main/resources</rarSourceDirectory>

--- a/tests/resources/applications/maven/multi-liberty-module-maven-app/war/pom.xml
+++ b/tests/resources/applications/maven/multi-liberty-module-maven-app/war/pom.xml
@@ -16,8 +16,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <!-- Test Configuration -->
         <!-- <skipTests>true</skipTests> -->
         <!-- <skipITs>true</skipITs> -->
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/resources/applications/maven/multi-liberty-module-maven-app/war2/pom.xml
+++ b/tests/resources/applications/maven/multi-liberty-module-maven-app/war2/pom.xml
@@ -9,6 +9,13 @@
     <name>guide-maven-multimodules-custmm-war2</name>
     <url>http://maven.apache.org</url>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
     <dependencies>
 
         <!-- Provided dependencies -->
@@ -34,7 +41,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/resources/ci/scripts/exec.sh
+++ b/tests/resources/ci/scripts/exec.sh
@@ -40,7 +40,7 @@ main() {
         metacity --sm-disable --replace 2> metacity.err &
     fi
     
-    mvn clean install -Declipse.target="$TARGET" -Dosgi.debug=./tests/resources/ci/debug.opts -Dtycho.showEclipseLog -DtestAppImportWait=120000 -DmvnPath="${PWD}/test-tools/liberty-dev-tools/apache-maven-3.9.6" -DgradlePath="${PWD}/test-tools/liberty-dev-tools/gradle-8.8"
+    mvn clean install -Declipse.target="$TARGET" -Dosgi.debug=./tests/resources/ci/debug.opts -Dtycho.showEclipseLog -DtestAppImportWait=120000 -DmvnPath="${PWD}/test-tools/liberty-dev-tools/apache-maven-3.9.6" -DgradlePath="${PWD}/test-tools/liberty-dev-tools/gradle-9.7.1"
 
     # If there were any errors, gather some debug data before exiting.
     rc=$?

--- a/tests/resources/ci/scripts/setup.sh
+++ b/tests/resources/ci/scripts/setup.sh
@@ -41,8 +41,8 @@ MAVEN_ARCHIVE_SHA512=0eb0432004a91ebf399314ad33e5aaffec3d3b29279f2f143b2f43ade26
 
 # Gradle version control constants.
 # NOTE: If this version is changed, the "mvn clean install" command in tests/resources/ci/scripts/exec.sh.
-GRADLE_VERSION=8.8
-GRADLE_ARCHIVE_SHA256=a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612
+GRADLE_VERSION=9.7.1
+GRADLE_ARCHIVE_SHA256=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
 
 SOFTWARE_INSTALL_DIR="${PWD}/test-tools/liberty-dev-tools"
 

--- a/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiLibertyModGradleTest.java
+++ b/tests/src/main/java/io/openliberty/tools/eclipse/test/it/LibertyPluginSWTBotMultiLibertyModGradleTest.java
@@ -91,6 +91,11 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     static final String GRADLE_APP_NAME = "guide-gradle-multimodules-custmm";
 
     /**
+     * Eclipse project name of the root aggregator project.
+     */
+    static final String PACKAGE_EXPLORER_PROJECT_NAME = "multi-liberty-module-gradle-app";
+
+    /**
      * Name of the first Liberty ear module.
      */
     static final String GRADLE_EAR1_MODULE_NAME = "ear1";
@@ -241,7 +246,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
         Assertions.assertTrue(menuItems.containsAll(Arrays.asList(gradleMenuItems)),
                               () -> "Gradle application " + GRADLE_APP_NAME + " does not contain the expected menu items: " + Arrays.toString(gradleMenuItems));
 
-        SWTBotMenu runAsMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, GRADLE_APP_NAME);
+        SWTBotMenu runAsMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, PACKAGE_EXPLORER_PROJECT_NAME);
         Assertions.assertNotNull(runAsMenu, "The Run As menu associated with project " + GRADLE_APP_NAME + " is null.");
         List<String> runAsMenuItems = runAsMenu.menuItems();
         Assertions.assertTrue(runAsMenuItems != null && !runAsMenuItems.isEmpty(),
@@ -261,7 +266,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
                                                                    + " does not contain one or more expected entries. Expected: " + runAsShortcuts.length
                                                                    + ", found: " + foundItems + ". Items: " + runAsMenuItems);
 
-        Shell configShell = launchRunConfigurationsDialogFromAppRunAs(GRADLE_APP_NAME);
+        Shell configShell = launchRunConfigurationsDialogFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
         try {
             SWTBotTreeItem runAsLibertyEntry = getLibertyTreeItem(configShell);
             Assertions.assertNotNull(runAsLibertyEntry, "Liberty entry in Run Configurations view was not found.");
@@ -269,7 +274,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
             go("Close", configShell);
         }
 
-        Shell debugShell = launchDebugConfigurationsDialogFromAppRunAs(GRADLE_APP_NAME);
+        Shell debugShell = launchDebugConfigurationsDialogFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
         try {
             SWTBotTreeItem debugAsLibertyEntry = getLibertyTreeItem(debugShell);
             Assertions.assertNotNull(debugAsLibertyEntry, "Liberty entry in Debug Configurations view was not found.");
@@ -327,7 +332,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     public void testRunAsShortcutActionsOpenModuleSelectionDialogWithCorrectCount() {
 
         // Verify the Start shortcut.
-        launchStartWithRunAsShortcut(GRADLE_APP_NAME);
+        launchStartWithRunAsShortcut(PACKAGE_EXPLORER_PROJECT_NAME);
         Shell startDialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(startDialog,
                                  "Module selection dialog did not open for the Run As Start shortcut.");
@@ -339,7 +344,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
         cancelModuleSelectionDialog(startDialog);
 
         // Verify the Start in Container shortcut.
-        SWTBotMenu containerMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, GRADLE_APP_NAME).menu(WidgetMatcherFactory.withRegex(
+        SWTBotMenu containerMenu = SWTBotPluginOperations.getAppRunAsMenu(bot, PACKAGE_EXPLORER_PROJECT_NAME).menu(WidgetMatcherFactory.withRegex(
                                                                                                                                     ".*"
                                                                                                                                     + LaunchConfigurationDelegateLauncher.LAUNCH_SHORTCUT_START_CONTAINER
                                                                                                                                     + ".*"),
@@ -366,7 +371,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     @Test
     public void testDashboardStartActionSelectsModuleAndStops() {
 
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(GRADLE_APP_NAME);
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
 
         launchDashboardAction(GRADLE_APP_NAME, DashboardView.APP_MENU_ACTION_START);
 
@@ -404,7 +409,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     @Test
     public void testDashboardDebugActionSelectsModuleAndStops() {
 
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(GRADLE_APP_NAME);
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
 
         launchDashboardAction(GRADLE_APP_NAME, DashboardView.APP_MENU_ACTION_DEBUG);
 
@@ -437,7 +442,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     @Test
     public void testDashboardStartWithConfigActionSelectsModuleAndStops() {
 
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(GRADLE_APP_NAME);
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
 
         launchDashboardAction(GRADLE_APP_NAME, DashboardView.APP_MENU_ACTION_START_CONFIG);
 
@@ -476,9 +481,9 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     @Test
     public void testRunAsStartShortcutSelectsModuleAndStops() {
 
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(GRADLE_APP_NAME);
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
 
-        launchStartWithRunAsShortcut(GRADLE_APP_NAME);
+        launchStartWithRunAsShortcut(PACKAGE_EXPLORER_PROJECT_NAME);
 
         Shell startDialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(startDialog,
@@ -502,7 +507,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
 
         pressWorkspaceErrorDialogProceedButton(bot);
 
-        launchStopWithRunAsShortcut(GRADLE_APP_NAME);
+        launchStopWithRunAsShortcut(PACKAGE_EXPLORER_PROJECT_NAME);
 
         LibertyPluginTestUtils.validateLibertyServerStopped(ear1ServerPath.toString());
     }
@@ -517,7 +522,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     @Test
     public void testModuleSelectionDialogSearchFilter() {
 
-        launchStartWithRunAsShortcut(GRADLE_APP_NAME);
+        launchStartWithRunAsShortcut(PACKAGE_EXPLORER_PROJECT_NAME);
 
         Shell dialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(dialog,
@@ -556,7 +561,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     @Test
     public void testStopDialogCountReducesAsModulesStop() {
 
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(GRADLE_APP_NAME);
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
 
         // Step 1: Start ear1. All 3 modules should be inactive.
         launchDashboardAction(GRADLE_APP_NAME, DashboardView.APP_MENU_ACTION_START);
@@ -760,7 +765,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     @Test
     public void testRestartOfExternallyStartedDevMode() throws IOException, InterruptedException {
 
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(GRADLE_APP_NAME);
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
 
         Path rootPath = rootProjectPath.toAbsolutePath();
 
@@ -856,7 +861,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     @Test
     public void testModuleSelectionDialogSelectAllAndDeselectAllButtons() {
 
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(GRADLE_APP_NAME);
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
 
         // Start action.
         launchDashboardAction(GRADLE_APP_NAME, DashboardView.APP_MENU_ACTION_START);
@@ -922,7 +927,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
     @Test
     public void testStartAllModulesWithSelectAllAndStopAll() {
 
-        deleteLibertyToolsRunConfigEntriesFromAppRunAs(GRADLE_APP_NAME);
+        deleteLibertyToolsRunConfigEntriesFromAppRunAs(PACKAGE_EXPLORER_PROJECT_NAME);
 
         // Trigger the Start action from the parent project.
         launchDashboardAction(GRADLE_APP_NAME, DashboardView.APP_MENU_ACTION_START);
@@ -953,7 +958,7 @@ public class LibertyPluginSWTBotMultiLibertyModGradleTest extends AbstractLibert
         pressWorkspaceErrorDialogProceedButton(bot);
 
         // Run Tests action should show the Select All and Deselect All buttons.
-        launchRunTestsWithRunAsShortcut(GRADLE_APP_NAME);
+        launchRunTestsWithRunAsShortcut(PACKAGE_EXPLORER_PROJECT_NAME);
 
         Shell runTestsDialog = waitForModuleSelectionDialog(SWTBotTestCondition.SHORT_WAIT_MS);
         Assertions.assertNotNull(runTestsDialog,


### PR DESCRIPTION
This PR:
- Migrates gradle test apps to use Gradle 9 and Liberty Gradle plugin 4.
- Updates Multi-liberty module Maven app to use java 21.
- Updates CI artifacts to reflect the change.